### PR TITLE
Release v0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ secrets.*
 # Internal planning docs & agent instructions — kept local, never published
 docs/
 CLAUDE.md
+
+# AI / agent process artifacts — audit catalogs, findings write-ups, scratch
+# tracking docs, and skill-manager state. Local working notes, never published.
+*_AUDIT.md
+*_AUDIT.csv
+*_FINDINGS.md
+.agents/
+skills-lock.json

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A native macOS file browser built for the multi-agent era.
 
 When you have several AI coding agents (Claude Code, Codex/CMAX, etc.) working in
 parallel across git worktrees, **teebe** is the calm control room that shows
-you — across all your repos and worktrees — what files exist, what's changing, and
-what's about to ship. It does not replace your editor: it's the navigator that
-launches files into whatever native app you already use.
+you — across all your repos and worktrees — what files exist and what's changing.
+It does not replace your editor: it's the navigator that launches files into
+whatever native app you already use.
 
 > Status: in development. `TreebranchCore` (git layer, parsers, services, file
 > watcher, file ops, write queue) and the app's view models are implemented and
@@ -37,7 +37,7 @@ integration tests shell out to the system `git` against throwaway temp repos.
 
 ## Why
 
-There's no open-source, Finder-like, **worktree- and branch-aware** file browser.
+There's no open-source, Finder-like, **worktree-aware** file browser.
 Existing tools are either git clients centered on a single repo (Fork, Sublime
 Merge), terminal TUIs (lazygit), or agent-session managers (Crystal, Conductor).
 None give you a live, cross-worktree "mission control" of what your agents are
@@ -48,11 +48,11 @@ touching right now.
 - A **tree navigator**, not an editor. Click a file → it opens in its native app.
 - **Worktree-aware**: pick any worktree of any repo and see its files.
 - **Git-aware**: changed files are badged; a Changes view shows working changes
-  and what's "about to ship" (diff vs base branch), with inline read-only diffs.
+  with inline read-only diffs.
 - **Live**: the tree and badges update in real time (FSEvents) as agents write.
 - **Multi-repo**: add several repos; an Overview shows all worktrees at once.
 - **Read-write** at the file-management level (rename/move/trash/new) and the git
-  level (stage/discard/commit/checkout). Content editing is delegated to native apps.
+  level (stage/discard/commit). Content editing is delegated to native apps.
 
 ## What it is not (v1)
 

--- a/Sources/Treebranch/ViewModels/AppModel.swift
+++ b/Sources/Treebranch/ViewModels/AppModel.swift
@@ -18,18 +18,25 @@ final class AppModel {
         self.environment = environment
         self.selector = SelectorModel(environment: environment)
         self.floatOnTop = false
+        // Persist whenever the selection changes so the app reopens where it was left.
+        self.selector.onSelectionChange = { [weak self] in self?.persist() }
     }
 
     /// Load persisted state and hydrate repositories + selection.
     func bootstrap() async {
         let state = environment.store.load()
         floatOnTop = state.floatOnTop
-        repositories = state.repositories.map { Repository(path: $0.path, baseBranch: $0.baseBranch) }
+        repositories = state.repositories.map { Repository(path: $0.path) }
         selector.setRepositories(repositories)
-        if let last = state.lastSelectedRepoPath, let repo = repositories.first(where: { $0.path == last }) {
-            await selector.selectRepo(repo)
-        } else if let first = repositories.first {
-            await selector.selectRepo(first)
+        let target = state.lastSelectedRepoPath.flatMap { last in repositories.first { $0.path == last } }
+            ?? repositories.first
+        guard let target else { return }
+        await selector.selectRepo(target)   // focuses the primary worktree
+        // Restore the last selected worktree if it still exists (else keep primary).
+        if let wtPath = state.lastSelectedWorktreePath,
+           selector.selectedWorktree?.path != wtPath,
+           let saved = selector.worktrees.first(where: { $0.path == wtPath }) {
+            await selector.selectWorktree(saved)
         }
     }
 
@@ -61,13 +68,6 @@ final class AppModel {
         if selector.selectedRepo?.path == repo.path {
             selector.clearSelection()
         }
-        persist()
-    }
-
-    func setBaseBranch(_ base: String?, for repo: Repository) {
-        guard let index = repositories.firstIndex(where: { $0.path == repo.path }) else { return }
-        repositories[index].baseBranch = base
-        selector.setRepositories(repositories)
         persist()
     }
 
@@ -134,9 +134,12 @@ final class AppModel {
     private func runFileOp(_ operation: @escaping () throws -> Void) {
         do {
             try operation()
+            // This was teebe's own write — don't let the resulting file-watch event
+            // read as external agent activity.
+            selector.worktree.noteSelfWrite()
             Task { await selector.worktree.refresh() }
         } catch {
-            errorMessage = "File operation failed: \(error)"
+            errorMessage = "File operation failed: \(WorktreeModel.describe(error))"
         }
     }
 
@@ -189,7 +192,7 @@ final class AppModel {
                 try await environment.worktreeService.removeWorktree(in: repo, worktree: worktree, force: false)
                 await selector.selectRepo(repo)
             } catch {
-                errorMessage = "Couldn't remove worktree: \(error)"
+                errorMessage = "Couldn't remove worktree: \(WorktreeModel.describe(error))"
             }
         }
     }
@@ -208,7 +211,7 @@ final class AppModel {
 
     func persist() {
         var state = environment.store.load()
-        state.repositories = repositories.map { PersistedRepository(path: $0.path, baseBranch: $0.baseBranch) }
+        state.repositories = repositories.map { PersistedRepository(path: $0.path) }
         state.floatOnTop = floatOnTop
         state.lastSelectedRepoPath = selector.selectedRepo?.path
         state.lastSelectedWorktreePath = selector.selectedWorktree?.path

--- a/Sources/Treebranch/ViewModels/PreviewModel.swift
+++ b/Sources/Treebranch/ViewModels/PreviewModel.swift
@@ -24,34 +24,22 @@ final class PreviewModel {
         self.environment = environment
     }
 
-    /// Spacebar: toggle the panel. Opening resolves content for `node`. When
-    /// `snapshot` is provided (read-only branch browse), text/Quick Look content is
-    /// read from the committed ref via `git show`, never the working directory (D2).
-    func toggle(for node: FileNode?, worktreePath: String, snapshot: WorktreeModel? = nil) async {
+    /// Spacebar: toggle the panel. Opening resolves content for `node`.
+    func toggle(for node: FileNode?, worktreePath: String) async {
         if isVisible {
             close()
             return
         }
         guard let node, !node.isDirectory else { return }
-        await update(for: node, worktreePath: worktreePath, snapshot: snapshot)
+        await update(for: node, worktreePath: worktreePath)
         isVisible = true
     }
 
     /// Arrow keys while open: live-update the preview to a new selection.
-    func update(for node: FileNode, worktreePath: String, snapshot: WorktreeModel? = nil) async {
+    func update(for node: FileNode, worktreePath: String) async {
         guard !node.isDirectory else { return }
         currentPath = node.path
         let url = URL(fileURLWithPath: node.path)
-
-        // Branch-snapshot browse: committed content via git show, not disk (D2).
-        if let snapshot, snapshot.isBrowsingSnapshot {
-            if let text = await snapshot.snapshotContent(forNodePath: node.path) {
-                content = .text(text)
-            } else {
-                content = .quickLook(url)
-            }
-            return
-        }
 
         switch PreviewResolver.kind(forFileName: node.name, change: node.change) {
         case .diff:

--- a/Sources/Treebranch/ViewModels/SelectorModel.swift
+++ b/Sources/Treebranch/ViewModels/SelectorModel.swift
@@ -2,9 +2,8 @@ import Foundation
 import Observation
 import TreebranchCore
 
-/// Drives the `Repo ▾ · Worktree ▾ · Branch ▾` selectors. Switching a selector
-/// repopulates downstream state and the worktree view. Branch selection defaults
-/// to read-only snapshot browse (D2).
+/// Drives the `Repo ▾ · Worktree ▾` selectors. Switching a selector repopulates
+/// downstream state and the worktree view.
 @MainActor
 @Observable
 final class SelectorModel {
@@ -21,19 +20,34 @@ final class SelectorModel {
     private(set) var worktrees: [Worktree] = []
     private(set) var selectedWorktree: Worktree?
     private(set) var branches: [Branch] = []
-    /// Branch chosen for read-only browse (nil = viewing the worktree's own branch).
-    private(set) var browseBranch: Branch?
     /// Sync/activity info keyed by worktree path.
     private(set) var worktreeInfo: [String: WorktreeInfo] = [:]
     var errorMessage: String?
 
     let worktree: WorktreeModel
 
+    /// Invoked whenever the selected repo/worktree changes, so the owner can persist
+    /// the new selection (drives "reopen where I left off").
+    var onSelectionChange: (() -> Void)?
+
     private let environment: AppEnvironment
 
     init(environment: AppEnvironment) {
         self.environment = environment
         self.worktree = WorktreeModel(environment: environment)
+        // An external write to the active worktree should re-light its live dot
+        // immediately, without waiting for a manual refresh.
+        self.worktree.onActivity = { [weak self] _ in self?.refreshLiveState() }
+    }
+
+    /// Recompute only the cheap `isLive` flags from the activity monitor (no git),
+    /// e.g. after a file-watch event reports external activity.
+    func refreshLiveState(now: Date = Date()) {
+        for wt in worktrees {
+            var info = worktreeInfo[wt.path] ?? WorktreeInfo()
+            info.isLive = environment.activityMonitor.isBusy(worktreePath: wt.path, within: 5, now: now)
+            worktreeInfo[wt.path] = info
+        }
     }
 
     func setRepositories(_ repos: [Repository]) {
@@ -45,15 +59,14 @@ final class SelectorModel {
         worktrees = []
         selectedWorktree = nil
         branches = []
-        browseBranch = nil
         worktree.clear()
+        onSelectionChange?()
     }
 
     /// Select a repo: discover its worktrees + branches, then focus the primary
     /// worktree.
     func selectRepo(_ repo: Repository) async {
         selectedRepo = repo
-        browseBranch = nil
         do {
             worktrees = try await environment.worktreeService.worktrees(for: repo)
             branches = try await environment.branchService.branches(for: repo)
@@ -67,6 +80,7 @@ final class SelectorModel {
         if let primary = worktrees.first(where: { $0.isPrimary }) ?? worktrees.first {
             await selectWorktree(primary)
         }
+        onSelectionChange?()
     }
 
     /// Load per-worktree ahead/behind + change count + live state for the
@@ -92,22 +106,7 @@ final class SelectorModel {
 
     func selectWorktree(_ wt: Worktree) async {
         selectedWorktree = wt
-        browseBranch = nil
         await worktree.load(worktreePath: wt.path, repo: selectedRepo)
-    }
-
-    /// Browse another branch read-only (snapshot), without checkout (D2).
-    func browse(branch: Branch) async {
-        browseBranch = branch
-        guard let repo = selectedRepo else { return }
-        await worktree.loadSnapshot(repo: repo, ref: branch.name)
-    }
-
-    /// Return to viewing the worktree's own working tree.
-    func stopBrowsing() async {
-        browseBranch = nil
-        if let wt = selectedWorktree {
-            await worktree.load(worktreePath: wt.path, repo: selectedRepo)
-        }
+        onSelectionChange?()
     }
 }

--- a/Sources/Treebranch/ViewModels/WorktreeModel.swift
+++ b/Sources/Treebranch/ViewModels/WorktreeModel.swift
@@ -8,7 +8,6 @@ struct PendingMutation: Equatable {
     enum Kind: Equatable {
         case discard
         case discardUntracked
-        case checkout(branch: String)
         case trash
     }
     var kind: Kind
@@ -37,14 +36,20 @@ final class WorktreeModel {
     /// Expanded directory paths in the FILES tree.
     var expandedPaths: Set<String> = []
     private(set) var worktreePath: String?
-    private(set) var isBrowsingSnapshot = false
-    /// The branch ref currently being browsed read-only (snapshot mode).
-    private(set) var browseRef: String?
     private(set) var errorMessage: String?
     private(set) var pendingMutation: PendingMutation?
 
     /// Window (seconds) used to flag a worktree as "busy" before a guarded op.
     var busyWindow: TimeInterval = 5
+    /// Window (seconds) after one of teebe's OWN writes during which file-watch
+    /// events are attributed to us and NOT recorded as worktree activity — so the
+    /// user's own stage/commit/discard/trash/new/rename never reads as "an agent is
+    /// active" (the live dot / busy warning are for *external* writers).
+    var selfWriteIgnoreWindow: TimeInterval = 1.5
+    private(set) var lastSelfWriteAt: Date?
+    /// Called (with the worktree path) when an *external* write is observed, so the
+    /// owner can refresh the live/activity indicators.
+    var onActivity: ((String) -> Void)?
 
     private let environment: AppEnvironment
     private var repo: Repository?
@@ -57,9 +62,6 @@ final class WorktreeModel {
     init(environment: AppEnvironment) {
         self.environment = environment
     }
-
-    /// Repo path when browsing a read-only snapshot (else nil).
-    var snapshotRepoPath: String? { isBrowsingSnapshot ? worktreePath : nil }
 
     var changeCount: Int { changes.count }
 
@@ -86,13 +88,15 @@ final class WorktreeModel {
     func commitPending() async {
         let message = commitMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
-        // Stage everything not yet staged so the commit captures the change set.
-        let unstaged = changes.filter { !$0.isStaged && !$0.isUntracked }.map(\.path)
-        let untracked = changes.filter { $0.isUntracked }.map(\.path)
+        // Stage every path with working-tree changes so the commit captures the full
+        // change set — including the unstaged half of a partially-staged file and
+        // untracked files. Purely-staged paths (worktreeStatus == .unmodified) need
+        // no `add`.
+        let toStage = changes.filter { $0.worktreeStatus != .unmodified }.map(\.path)
         if let worktreePath {
             await perform {
-                if !(unstaged + untracked).isEmpty {
-                    try await self.queue?.stage(worktreePath: worktreePath, paths: unstaged + untracked)
+                if !toStage.isEmpty {
+                    try await self.queue?.stage(worktreePath: worktreePath, paths: toStage)
                 }
             }
         }
@@ -107,8 +111,6 @@ final class WorktreeModel {
         status = nil
         changes = []
         worktreePath = nil
-        isBrowsingSnapshot = false
-        browseRef = nil
         errorMessage = nil
         pendingMutation = nil
         expandedPaths.removeAll()
@@ -120,8 +122,6 @@ final class WorktreeModel {
     func load(worktreePath: String, repo: Repository?) async {
         self.worktreePath = worktreePath
         self.repo = repo
-        self.isBrowsingSnapshot = false
-        self.browseRef = nil
         self.queue = repo.map { environment.makeQueue(repoPath: $0.path) }
         self.expandedPaths.removeAll()
         self.childrenCache.removeAll()
@@ -136,18 +136,36 @@ final class WorktreeModel {
         watcher?.stop()
         let watcher = environment.makeWatcher()
         watcher.start(paths: [path], debounce: 0.25) { [weak self] _ in
-            Task { @MainActor in
-                guard let self, self.worktreePath == path, !self.isBrowsingSnapshot else { return }
-                self.environment.activityMonitor.recordActivity(worktreePath: path, at: Date())
-                await self.refresh()
-            }
+            Task { @MainActor in await self?.handleFileSystemEvent() }
         }
         self.watcher = watcher
     }
 
+    /// Handle a file-watch event for the active worktree: record *external* activity
+    /// (skipping our own recent writes), notify the owner, then refresh. Synchronous
+    /// and parameterized so it is unit-testable without real FSEvents.
+    func handleFileSystemEvent(now: Date = Date()) async {
+        guard let worktreePath else { return }
+        if !recentSelfWrite(now: now) {
+            environment.activityMonitor.recordActivity(worktreePath: worktreePath, at: now)
+            onActivity?(worktreePath)
+        }
+        await refresh()
+    }
+
+    /// Mark that teebe just wrote into the worktree, so the imminent file-watch
+    /// event is not misattributed to an external agent.
+    func noteSelfWrite(at date: Date = Date()) { lastSelfWriteAt = date }
+
+    /// Whether teebe wrote into the worktree within `selfWriteIgnoreWindow` of `now`.
+    func recentSelfWrite(now: Date = Date()) -> Bool {
+        guard let lastSelfWriteAt else { return false }
+        return now.timeIntervalSince(lastSelfWriteAt) < selfWriteIgnoreWindow
+    }
+
     /// Re-query status and rebuild the tree (called on watcher events).
     func refresh() async {
-        guard let worktreePath, !isBrowsingSnapshot else { return }
+        guard let worktreePath else { return }
         do {
             let result = try await environment.statusService.status(worktreePath: worktreePath)
             status = result
@@ -160,28 +178,8 @@ final class WorktreeModel {
         reloadExpandedChildren()
     }
 
-    /// Browse another branch's committed tree read-only (D2): files come from git,
-    /// the working directory is untouched.
-    func loadSnapshot(repo: Repository, ref: String) async {
-        watcher?.stop()
-        watcher = nil
-        isBrowsingSnapshot = true
-        browseRef = ref
-        worktreePath = repo.path
-        self.repo = repo
-        do {
-            let files = try await environment.branchService.snapshotFiles(for: repo, ref: ref)
-            changes = []
-            status = nil
-            root = FileTreeBuilder.tree(fromRelativePaths: files, rootPath: repo.path)
-            errorMessage = nil
-        } catch {
-            errorMessage = Self.describe(error)
-        }
-    }
-
     private func rebuildTree() {
-        guard let worktreePath, !isBrowsingSnapshot else { return }
+        guard let worktreePath else { return }
         let builder = makeBuilder(rootPath: worktreePath)
         guard let built = try? builder.buildRoot() else { root = nil; return }
         root = StatusOverlay.apply(changes, to: built, rootPath: worktreePath)
@@ -216,7 +214,7 @@ final class WorktreeModel {
     }
 
     private func loadChildrenIntoCache(_ path: String) {
-        guard let worktreePath, !isBrowsingSnapshot else { return }
+        guard let worktreePath else { return }
         let kids = (try? makeBuilder(rootPath: worktreePath).loadChildren(of: path)) ?? []
         childrenCache[path] = kids.map { StatusOverlay.apply(changes, to: $0, rootPath: worktreePath) }
     }
@@ -318,17 +316,6 @@ final class WorktreeModel {
         )
     }
 
-    /// Read-only content of a file at the browsed ref via `git show` (D2). Used by
-    /// the preview while browsing a branch snapshot, instead of reading disk.
-    func snapshotContent(forNodePath nodePath: String) async -> String? {
-        guard let repo, let ref = browseRef else { return nil }
-        let relative = PathUtil.relativePath(of: nodePath, under: PathUtil.standardized(repo.path))
-        guard let data = try? await environment.branchService.snapshotFileContents(for: repo, ref: ref, path: relative) else {
-            return nil
-        }
-        return String(decoding: data, as: UTF8.self)
-    }
-
     /// The tree to display given the current filter. `Changed` derives the tree
     /// directly from the change list so changed files always appear.
     var displayRoot: FileNode? {
@@ -336,7 +323,7 @@ final class WorktreeModel {
         case .all:
             return root
         case .changed:
-            guard let worktreePath, !isBrowsingSnapshot else { return root }
+            guard let worktreePath else { return root }
             let tree = FileTreeBuilder.tree(fromRelativePaths: changes.map(\.path), rootPath: worktreePath)
             return StatusOverlay.apply(changes, to: tree, rootPath: worktreePath)
         }
@@ -363,10 +350,6 @@ final class WorktreeModel {
         pendingMutation = PendingMutation(kind: kind, paths: [change.path], worktreeBusy: isBusy(now))
     }
 
-    func requestCheckout(branch: String, now: Date = Date()) {
-        pendingMutation = PendingMutation(kind: .checkout(branch: branch), paths: [], worktreeBusy: isBusy(now))
-    }
-
     func requestTrash(path: String, now: Date = Date()) {
         pendingMutation = PendingMutation(kind: .trash, paths: [path], worktreeBusy: isBusy(now))
     }
@@ -384,8 +367,6 @@ final class WorktreeModel {
                 try await self.queue?.discardWorking(worktreePath: worktreePath, paths: mutation.paths)
             case .discardUntracked:
                 try await self.queue?.discardUntracked(worktreePath: worktreePath, paths: mutation.paths)
-            case .checkout(let branch):
-                try await self.queue?.checkout(worktreePath: worktreePath, branch: branch)
             case .trash:
                 for path in mutation.paths {
                     _ = try self.environment.ops.moveToTrash(URL(fileURLWithPath: path))
@@ -407,6 +388,7 @@ final class WorktreeModel {
     }
 
     private func perform(_ operation: @escaping () async throws -> Void) async {
+        noteSelfWrite()
         do {
             try await operation()
             errorMessage = nil
@@ -421,7 +403,6 @@ final class WorktreeModel {
             case .commandFailed(_, _, let stderr): return stderr.isEmpty ? "git command failed" : stderr
             case .notAGitRepository(let path): return "Not a git repository: \(path)"
             case .lockedIndex: return "The git index is locked; try again."
-            case .missingBaseBranch: return "No base branch found."
             case .worktreeBusy(let path): return "Worktree busy: \(path)"
             case .executableNotFound: return "git executable not found."
             case .decodingFailed(let message): return message

--- a/Sources/Treebranch/Views/ChangesSection.swift
+++ b/Sources/Treebranch/Views/ChangesSection.swift
@@ -15,7 +15,9 @@ struct ChangesSection: View {
                     countBadge(worktree.changeCount)
                     if let active = app.selector.selectedWorktree {
                         let info = app.selector.info(for: active)
-                        Text(info.syncText).font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
+                        Text(info.syncText)
+                            .font(.system(size: 11)).monospacedDigit()
+                            .foregroundStyle(Palette.secondaryText)
                     }
                 }
             }
@@ -47,7 +49,7 @@ struct ChangesSection: View {
             .font(.system(size: 12))
             .lineLimit(1...3)
             .padding(.horizontal, 9).padding(.vertical, 7)
-            .background(.black.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
+            .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
             .onSubmit { Task { await worktree.commitPending() } }
 
             Button {
@@ -55,14 +57,20 @@ struct ChangesSection: View {
             } label: {
                 Text(commitLabel)
                     .font(.system(size: 12.5, weight: .semibold))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
                     .frame(maxWidth: .infinity)
                     .frame(height: 30)
+                    .foregroundStyle(commitEnabled ? .white : Palette.secondaryText)
+                    .background(commitEnabled ? Palette.accent : Color.primary.opacity(0.05),
+                                in: RoundedRectangle(cornerRadius: 6))
+                    .contentShape(RoundedRectangle(cornerRadius: 6))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(commitEnabled ? .white : Palette.secondaryText)
-            .background(commitEnabled ? Palette.accent : Color.black.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
+            .buttonStyle(PressableButtonStyle())
             .disabled(!commitEnabled)
             .keyboardShortcut(.return, modifiers: .command)   // ⌘↩ (matches the field's placeholder)
+            .animation(.easeOut(duration: 0.2), value: commitEnabled)
+            .animation(.snappy(duration: 0.22), value: worktree.changeCount)
         }
         .padding(.horizontal, 11).padding(.top, 8).padding(.bottom, 6)
     }
@@ -153,8 +161,11 @@ struct ChangesSection: View {
     private func countBadge(_ count: Int) -> some View {
         Text("\(count)")
             .font(.system(size: 10, weight: .semibold))
+            .monospacedDigit()
+            .contentTransition(.numericText())
             .foregroundStyle(Palette.headerLabel)
             .padding(.horizontal, 5).frame(minWidth: 18, minHeight: 16)
-            .background(.black.opacity(0.07), in: Capsule())
+            .background(Color.primary.opacity(0.07), in: Capsule())
+            .animation(.snappy(duration: 0.22), value: count)
     }
 }

--- a/Sources/Treebranch/Views/ChangesSection.swift
+++ b/Sources/Treebranch/Views/ChangesSection.swift
@@ -62,6 +62,7 @@ struct ChangesSection: View {
             .foregroundStyle(commitEnabled ? .white : Palette.secondaryText)
             .background(commitEnabled ? Palette.accent : Color.black.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
             .disabled(!commitEnabled)
+            .keyboardShortcut(.return, modifiers: .command)   // ⌘↩ (matches the field's placeholder)
         }
         .padding(.horizontal, 11).padding(.top, 8).padding(.bottom, 6)
     }

--- a/Sources/Treebranch/Views/Components.swift
+++ b/Sources/Treebranch/Views/Components.swift
@@ -61,10 +61,19 @@ struct LiveDot: View {
                     .scaleEffect(animate ? 2.4 : 1)
                     .opacity(active ? (animate ? 0 : 0.5) : 0)
             )
-            .onAppear {
-                guard active else { return }
-                withAnimation(.easeOut(duration: 1.6).repeatForever(autoreverses: false)) { animate = true }
-            }
+            .onAppear { syncPulse() }
+            // Restart/stop the pulse when liveness flips after first appearance —
+            // `.onAppear` fires once, so a worktree that goes live later would
+            // otherwise show a static (unpulsing) dot.
+            .onChange(of: active) { syncPulse() }
+    }
+
+    private func syncPulse() {
+        if active {
+            withAnimation(.easeOut(duration: 1.6).repeatForever(autoreverses: false)) { animate = true }
+        } else {
+            withAnimation(.linear(duration: 0)) { animate = false }
+        }
     }
 }
 

--- a/Sources/Treebranch/Views/Components.swift
+++ b/Sources/Treebranch/Views/Components.swift
@@ -47,6 +47,10 @@ struct StatusLetter: View {
 }
 
 /// A green dot that pulses while a worktree is being written to (live agent).
+///
+/// The pulse is driven off `active` via `onChange`, not a one-shot `onAppear`, so
+/// a worktree that goes live *after* the row appears starts pulsing, and one that
+/// goes idle stops — the previous version latched whatever state it saw at appear.
 struct LiveDot: View {
     var active: Bool
     @State private var animate = false
@@ -55,25 +59,96 @@ struct LiveDot: View {
         Circle()
             .fill(active ? Palette.live : Color(white: 0.79))
             .frame(width: 7, height: 7)
-            .overlay(
-                Circle()
-                    .stroke(Palette.live, lineWidth: 2)
-                    .scaleEffect(animate ? 2.4 : 1)
-                    .opacity(active ? (animate ? 0 : 0.5) : 0)
-            )
+            .overlay(ring)
+            .animation(.easeInOut(duration: 0.25), value: active)   // fade the fill on state change
             .onAppear { syncPulse() }
-            // Restart/stop the pulse when liveness flips after first appearance —
-            // `.onAppear` fires once, so a worktree that goes live later would
-            // otherwise show a static (unpulsing) dot.
-            .onChange(of: active) { syncPulse() }
+            .onChange(of: active) { _, _ in syncPulse() }
+    }
+
+    /// The expanding halo. Hidden entirely while idle so a stopped pulse can't
+    /// leave a faint ring frozen mid-cycle.
+    private var ring: some View {
+        Circle()
+            .stroke(Palette.live, lineWidth: 2)
+            .scaleEffect(animate ? 2.4 : 1)
+            .opacity(animate ? 0 : 0.5)
+            .opacity(active ? 1 : 0)
     }
 
     private func syncPulse() {
         if active {
             withAnimation(.easeOut(duration: 1.6).repeatForever(autoreverses: false)) { animate = true }
         } else {
-            withAnimation(.linear(duration: 0)) { animate = false }
+            withAnimation(.easeOut(duration: 0.2)) { animate = false }
         }
+    }
+}
+
+// MARK: - Press / hover chrome for compact controls
+
+/// Tactile press feedback for prominent action buttons (e.g. Commit): the whole
+/// labelled surface scales to `0.96` while pressed and eases back when released.
+/// The skill's floor is `0.95` — anything smaller reads as exaggerated. Keep the
+/// button's background *inside* its label so the scale covers the entire control,
+/// not just the text.
+struct PressableButtonStyle: ButtonStyle {
+    var pressedScale: CGFloat = 0.96
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? pressedScale : 1)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+/// Shared hover-chip + press chrome for compact glyph controls. A bare 11–13pt
+/// SF Symbol gives an ~11×11 hit target; this wraps it in a comfortable hit area
+/// with a subtle hover background and (for buttons) a `0.96` press scale.
+private struct ChipBody<Label: View>: View {
+    let size: CGSize
+    var pressed = false
+    @ViewBuilder var label: () -> Label
+    @State private var hovering = false
+
+    var body: some View {
+        label()
+            .frame(minWidth: size.width, minHeight: size.height)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.primary.opacity(hovering ? 0.08 : 0))
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .scaleEffect(pressed ? 0.96 : 1)
+            .animation(.easeOut(duration: 0.12), value: hovering)
+            .animation(.easeOut(duration: 0.12), value: pressed)
+            .onHover { hovering = $0 }
+    }
+}
+
+/// Compact glyph **button** style: comfortable hit area, hover chip, press scale.
+/// Replaces bare `.buttonStyle(.plain)` on toolbar-style icon buttons. Default
+/// size is sized to stay within a 32pt header without colliding with neighbours.
+struct IconButtonStyle: ButtonStyle {
+    var size = CGSize(width: 22, height: 28)
+    func makeBody(configuration: Configuration) -> some View {
+        ChipBody(size: size, pressed: configuration.isPressed) { configuration.label }
+    }
+}
+
+/// The same hit area + hover chip for controls that can't take a `ButtonStyle`
+/// (notably `Menu`). No press scale — menus open on press, so a scale would fight
+/// the popover.
+private struct HoverChipModifier: ViewModifier {
+    var size: CGSize
+    func body(content: Content) -> some View {
+        ChipBody(size: size) { content }
+    }
+}
+
+extension View {
+    /// Wrap a compact control (e.g. a `Menu` label) in a hit area + hover chip
+    /// matching `IconButtonStyle`.
+    func hoverChip(_ size: CGSize = CGSize(width: 22, height: 28)) -> some View {
+        modifier(HoverChipModifier(size: size))
     }
 }
 

--- a/Sources/Treebranch/Views/FilesSection.swift
+++ b/Sources/Treebranch/Views/FilesSection.swift
@@ -23,9 +23,10 @@ struct FilesSection: View {
                         }
                         Toggle("Show ignored", isOn: $worktree.showIgnored)
                     } label: {
-                        Text("···").font(.system(size: 13)).foregroundStyle(Palette.secondaryText)
+                        Text("···").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).hoverChip()
                     }
                     .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+                    .help("Sort & filter")
                 } else if let active = app.selector.selectedWorktree {
                     Text("\(active.branch ?? active.name)")
                         .font(.system(size: 11, design: .monospaced))
@@ -86,13 +87,15 @@ struct FileRow: View {
     private var worktree: WorktreeModel { app.selector.worktree }
     private var node: FileNode { row.node }
     private var isSelected: Bool { worktree.selectedPath == node.path }
+    private var isExpanded: Bool { worktree.isExpanded(node) }
 
     var body: some View {
         HStack(spacing: 6) {
             if node.isDirectory {
                 Text("▸")
                     .font(.system(size: 13)).frame(width: 13)
-                    .rotationEffect(.degrees(worktree.isExpanded(node) ? 90 : 0))
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(.snappy(duration: 0.2), value: isExpanded)   // was an instant snap
                     .foregroundStyle(isSelected ? .white : Palette.secondaryText)
             } else {
                 Spacer().frame(width: 13)

--- a/Sources/Treebranch/Views/FilesSection.swift
+++ b/Sources/Treebranch/Views/FilesSection.swift
@@ -13,6 +13,10 @@ struct FilesSection: View {
             SectionHeader(title: "FILES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
                 if isOpen {
                     Menu {
+                        Picker("Show", selection: $worktree.filter) {
+                            Text("All files").tag(ChangeFilter.all)
+                            Text("Changed only").tag(ChangeFilter.changed)
+                        }
                         Picker("Sort", selection: $worktree.sortOrder) {
                             Text("Name").tag(FileSortOrder.name)
                             Text("Recently changed").tag(FileSortOrder.recent)
@@ -134,7 +138,7 @@ struct FileRow: View {
         worktree.selectionSource = .files
         if node.isDirectory { worktree.toggleExpand(node) }
         if preview.isVisible, !node.isDirectory, let wt = worktree.worktreePath {
-            Task { await preview.update(for: node, worktreePath: wt, snapshot: worktree) }
+            Task { await preview.update(for: node, worktreePath: wt) }
         }
     }
 
@@ -148,6 +152,7 @@ struct FileContextMenu: View {
     let node: FileNode
     @Bindable var app: AppModel
     @Bindable var preview: PreviewModel
+    @Environment(\.openWindow) private var openWindow
 
     private var worktree: WorktreeModel { app.selector.worktree }
 
@@ -158,7 +163,16 @@ struct FileContextMenu: View {
         if !node.isDirectory {
             Button("Quick Look") {
                 guard let wt = worktree.worktreePath else { return }
-                Task { await preview.toggle(for: node, worktreePath: wt, snapshot: worktree) }
+                // Resolve content AND surface the floating preview window — the
+                // "preview" scene only appears via openWindow.
+                Task {
+                    if preview.isVisible {
+                        await preview.update(for: node, worktreePath: wt)
+                    } else {
+                        await preview.toggle(for: node, worktreePath: wt)
+                    }
+                    openWindow(id: "preview")
+                }
             }
         }
         Divider()

--- a/Sources/Treebranch/Views/RootView.swift
+++ b/Sources/Treebranch/Views/RootView.swift
@@ -290,7 +290,7 @@ struct RootView: View {
         delta < 0 ? worktree.selectPrevious() : worktree.selectNext()
         if preview.isVisible, let node = worktree.selectedNode, !node.isDirectory,
            let wt = worktree.worktreePath {
-            Task { await preview.update(for: node, worktreePath: wt, snapshot: worktree) }
+            Task { await preview.update(for: node, worktreePath: wt) }
         }
     }
 
@@ -319,7 +319,7 @@ struct RootView: View {
         guard let wt = worktree.worktreePath, let change = selectedChange else { return }
         let node = FileNode(path: wt + "/" + change.path, isDirectory: false, change: change)
         Task {
-            await preview.toggle(for: node, worktreePath: wt, snapshot: worktree)
+            await preview.toggle(for: node, worktreePath: wt)
             openWindow(id: "preview")
         }
     }
@@ -352,7 +352,6 @@ struct RootView: View {
     private var confirmTitle: String {
         switch worktree.pendingMutation?.kind {
         case .discard, .discardUntracked: return "Discard changes?"
-        case .checkout(let branch): return "Check out \(branch)?"
         case .trash: return "Move to Trash?"
         case .none: return ""
         }

--- a/Sources/Treebranch/Views/RootView.swift
+++ b/Sources/Treebranch/Views/RootView.swift
@@ -104,34 +104,7 @@ struct RootView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 14) {
-            if let logo = Brand.logo {
-                Image(nsImage: logo)
-                    .resizable()
-                    .interpolation(.high)
-                    .scaledToFit()
-                    .frame(width: 84, height: 84)
-            } else {
-                Image(systemName: "point.3.connected.trianglepath.dotted")
-                    .font(.system(size: 38))
-                    .foregroundStyle(Palette.secondaryText)
-            }
-            Text("No repositories yet")
-                .font(.headline)
-            Text("Add a git repository to browse its worktrees,\nchanges, and files.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-            Button {
-                app.presentAddRepositoryPanel()
-            } label: {
-                Label("Add Repository…", systemImage: "plus")
-            }
-            .controlSize(.large)
-            .buttonStyle(.borderedProminent)
-        }
-        .frame(maxWidth: .infinity, minHeight: 300)
-        .padding(40)
+        EmptyStateView(app: app)
     }
 
     private var titleBar: some View {
@@ -145,9 +118,11 @@ struct RootView: View {
                     Image(systemName: app.floatOnTop ? "pin.fill" : "pin")
                         .font(.system(size: 13))
                         .foregroundStyle(app.floatOnTop ? Palette.accent : Palette.secondaryText)
+                        .contentTransition(.symbolEffect(.replace))   // animated pin ↔ pin.fill swap
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(IconButtonStyle(size: CGSize(width: 26, height: 22)))
                 .help("Float on top")
+                .animation(.snappy(duration: 0.25), value: app.floatOnTop)
             }
             .padding(.horizontal, 11)
         }
@@ -363,5 +338,69 @@ struct RootView: View {
         if lines.isEmpty { lines = "the worktree" }
         let busy = mutation.worktreeBusy ? "\n⚠︎ This worktree was written to recently (an agent may be active)." : ""
         return "Affects: \(lines)\(busy)"
+    }
+}
+
+/// The "no repositories" hero. Its four chunks fade/rise/de-blur in sequence on
+/// appear (split-and-stagger enter) instead of popping in as one block.
+private struct EmptyStateView: View {
+    @Bindable var app: AppModel
+    @State private var revealed = false
+
+    var body: some View {
+        VStack(spacing: 14) {
+            logo
+                .modifier(StaggeredReveal(revealed: revealed, step: 0))
+            Text("No repositories yet")
+                .font(.headline)
+                .modifier(StaggeredReveal(revealed: revealed, step: 1))
+            Text("Add a git repository to browse its worktrees,\nchanges, and files.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .modifier(StaggeredReveal(revealed: revealed, step: 2))
+            Button {
+                app.presentAddRepositoryPanel()
+            } label: {
+                Label("Add Repository…", systemImage: "plus")
+            }
+            .controlSize(.large)
+            .buttonStyle(.borderedProminent)
+            .modifier(StaggeredReveal(revealed: revealed, step: 3))
+        }
+        .frame(maxWidth: .infinity, minHeight: 300)
+        .padding(40)
+        .onAppear { revealed = true }
+    }
+
+    @ViewBuilder
+    private var logo: some View {
+        if let logo = Brand.logo {
+            Image(nsImage: logo)
+                .resizable()
+                .interpolation(.high)
+                .scaledToFit()
+                .frame(width: 84, height: 84)
+        } else {
+            Image(systemName: "point.3.connected.trianglepath.dotted")
+                .font(.system(size: 38))
+                .foregroundStyle(Palette.secondaryText)
+        }
+    }
+}
+
+/// One chunk of a staggered enter: opacity + a small rise + a 4pt deblur, each
+/// chunk delayed `step × 90ms`. Matches the skill's split-and-stagger pattern
+/// (translateY/opacity/blur) without a motion dependency.
+private struct StaggeredReveal: ViewModifier {
+    let revealed: Bool
+    let step: Int
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(revealed ? 1 : 0)
+            .offset(y: revealed ? 0 : 10)
+            .blur(radius: revealed ? 0 : 4)
+            .animation(.smooth(duration: 0.5).delay(Double(step) * 0.09), value: revealed)
     }
 }

--- a/Sources/Treebranch/Views/WorktreesSection.swift
+++ b/Sources/Treebranch/Views/WorktreesSection.swift
@@ -13,11 +13,11 @@ struct WorktreesSection: View {
         VStack(spacing: 0) {
             SectionHeader(title: "WORKTREES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
                 if isOpen {
-                    HStack(spacing: 10) {
+                    HStack(spacing: 2) {
                         Button { app.presentAddRepositoryPanel() } label: {
                             Image(systemName: "plus").font(.system(size: 11, weight: .semibold))
                         }
-                        .buttonStyle(.plain).foregroundStyle(Palette.secondaryText)
+                        .buttonStyle(IconButtonStyle()).foregroundStyle(Palette.secondaryText)
                         .help("Add Repository")
                         Menu {
                             ForEach(app.repositories) { repo in
@@ -30,13 +30,15 @@ struct WorktreesSection: View {
                                 Button("Remove \(selected.name)", role: .destructive) { app.removeRepository(selected) }
                             }
                         } label: {
-                            Text("···").font(.system(size: 13)).foregroundStyle(Palette.secondaryText)
+                            Text("···").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).hoverChip()
                         }
                         .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+                        .help("Repository actions")
                         Button { Task { await selector.refreshWorktreeInfo() } } label: {
                             Image(systemName: "arrow.clockwise").font(.system(size: 11))
                         }
-                        .buttonStyle(.plain).foregroundStyle(Palette.secondaryText)
+                        .buttonStyle(IconButtonStyle()).foregroundStyle(Palette.secondaryText)
+                        .help("Refresh")
                     }
                 } else if let active = selector.selectedWorktree {
                     HStack(spacing: 5) {
@@ -99,7 +101,7 @@ struct WorktreesSection: View {
             Spacer(minLength: 6)
             if let active = selector.selectedWorktree {
                 Text(selector.info(for: active).syncText)
-                    .font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
+                    .font(.system(size: 11)).monospacedDigit().foregroundStyle(Palette.secondaryText)
                     .fixedSize()
             }
         }
@@ -120,6 +122,7 @@ struct WorktreesSection: View {
             Spacer(minLength: 4)
             Text(info.syncText)
                 .font(.system(size: 11))
+                .monospacedDigit()
                 .foregroundStyle(isActive ? .white.opacity(0.85) : Palette.secondaryText)
         }
         .padding(.leading, 25).padding(.trailing, 11).frame(height: 26)

--- a/Sources/Treebranch/Views/WorktreesSection.swift
+++ b/Sources/Treebranch/Views/WorktreesSection.swift
@@ -27,11 +27,6 @@ struct WorktreesSection: View {
                             Button("Add Repository…") { app.presentAddRepositoryPanel() }
                             if let selected = selector.selectedRepo {
                                 Button("New Worktree…") { app.presentNewWorktreePanel() }
-                                Menu("Set Base Branch") {
-                                    ForEach(selector.branches.filter { !$0.isRemote }) { branch in
-                                        Button(branch.name) { app.setBaseBranch(branch.name, for: selected) }
-                                    }
-                                }
                                 Button("Remove \(selected.name)", role: .destructive) { app.removeRepository(selected) }
                             }
                         } label: {

--- a/Sources/TreebranchCore/AppStateStore.swift
+++ b/Sources/TreebranchCore/AppStateStore.swift
@@ -1,13 +1,11 @@
 import Foundation
 
-/// A persisted repository entry (path + configured base branch). No secrets.
+/// A persisted repository entry (just its path). No secrets.
 public struct PersistedRepository: Codable, Equatable, Sendable {
     public var path: String
-    public var baseBranch: String?
 
-    public init(path: String, baseBranch: String? = nil) {
+    public init(path: String) {
         self.path = path
-        self.baseBranch = baseBranch
     }
 }
 

--- a/Sources/TreebranchCore/CoreInfo.swift
+++ b/Sources/TreebranchCore/CoreInfo.swift
@@ -7,22 +7,4 @@ import Foundation
 public enum TreebranchCore {
     /// Library version (kept in sync with releases).
     public static let version = "0.1.0"
-
-    /// Default base-branch candidates, in priority order, used when a repo has no
-    /// explicitly configured base branch (TECH_SPEC §3: "default detect `main`
-    /// then `master`").
-    public static let defaultBaseBranchCandidates = ["main", "master"]
-
-    /// Resolve the base branch for a repo: the configured value if present,
-    /// otherwise the first default candidate that exists in `availableBranches`.
-    /// Returns `nil` if nothing matches (caller surfaces a "missing base" state).
-    public static func resolveBaseBranch(
-        configured: String?,
-        availableBranches: [String]
-    ) -> String? {
-        if let configured, availableBranches.contains(configured) {
-            return configured
-        }
-        return defaultBaseBranchCandidates.first { availableBranches.contains($0) }
-    }
 }

--- a/Sources/TreebranchCore/GitClient.swift
+++ b/Sources/TreebranchCore/GitClient.swift
@@ -30,8 +30,6 @@ public enum GitError: Error, Sendable, Equatable {
     case notAGitRepository(path: String)
     /// `index.lock` is held and did not clear within the retry budget.
     case lockedIndex(path: String)
-    /// No base branch could be resolved for the repo.
-    case missingBaseBranch(repo: String)
     /// The worktree was recently written by an agent; a guarded op refused.
     case worktreeBusy(path: String)
     /// `git` executable could not be located.
@@ -72,26 +70,13 @@ public struct StatusResult: Equatable, Sendable {
     }
 }
 
-/// A `git diff --name-status` entry (status letter + path, plus source for R/C).
-public struct NameStatusEntry: Equatable, Hashable, Sendable {
-    public var status: ChangeStatus
-    public var path: String
-    public var originalPath: String?
-
-    public init(status: ChangeStatus, path: String, originalPath: String? = nil) {
-        self.status = status
-        self.path = path
-        self.originalPath = originalPath
-    }
-}
-
 // MARK: - GitClient protocol
 
 /// Typed, async access to git. `ProcessGitClient` implements it by shelling out to
 /// the system `git`; `FakeGitClient` provides scripted results for tests.
 ///
-/// Write methods (`stage`/`unstage`/`discard*`/`commit`/`checkout`/worktree
-/// management) MUST be serialized per repo by the caller (see `RepoGitQueue`).
+/// Write methods (`stage`/`unstage`/`discard*`/`commit`/worktree management) MUST
+/// be serialized per repo by the caller (see `RepoGitQueue`).
 public protocol GitClient: Sendable {
     // Discovery
     func worktrees(repoPath: String) async throws -> [Worktree]
@@ -99,15 +84,9 @@ public protocol GitClient: Sendable {
 
     // Status & changes
     func status(worktreePath: String) async throws -> StatusResult
-    func changedFilesVsBase(worktreePath: String, base: String) async throws -> [NameStatusEntry]
 
     // Diffs
-    func committedDiff(worktreePath: String, base: String, path: String) async throws -> DiffFile?
     func workingDiff(worktreePath: String, path: String, staged: Bool) async throws -> DiffFile?
-
-    // Branch snapshot browse (read-only, no checkout)
-    func listTree(repoPath: String, ref: String) async throws -> [String]
-    func showFile(repoPath: String, ref: String, path: String) async throws -> Data
 
     // Writes (serialize per repo)
     func stage(worktreePath: String, paths: [String]) async throws
@@ -115,7 +94,6 @@ public protocol GitClient: Sendable {
     func discardWorking(worktreePath: String, paths: [String]) async throws
     func discardUntracked(worktreePath: String, paths: [String]) async throws
     func commit(worktreePath: String, message: String) async throws
-    func checkout(worktreePath: String, branch: String) async throws
 
     // Worktree management
     func addWorktree(repoPath: String, path: String, branch: String?, createBranch: Bool) async throws

--- a/Sources/TreebranchCore/Models.swift
+++ b/Sources/TreebranchCore/Models.swift
@@ -8,15 +8,12 @@ public struct Repository: Identifiable, Hashable, Sendable {
     public var path: String
     /// Display name (defaults to the last path component).
     public var name: String
-    /// Configured base branch (`nil` = auto-detect `main` then `master`).
-    public var baseBranch: String?
 
     public var id: String { path }
 
-    public init(path: String, name: String? = nil, baseBranch: String? = nil) {
+    public init(path: String, name: String? = nil) {
         self.path = path
         self.name = name ?? (path as NSString).lastPathComponent
-        self.baseBranch = baseBranch
     }
 }
 

--- a/Sources/TreebranchCore/ProcessGitClient.swift
+++ b/Sources/TreebranchCore/ProcessGitClient.swift
@@ -32,17 +32,7 @@ public struct ProcessGitClient: GitClient {
         return StatusParser.parse(result.stdoutString)
     }
 
-    public func changedFilesVsBase(worktreePath: String, base: String) async throws -> [NameStatusEntry] {
-        let result = try await runChecked(["diff", "--name-status", "-z", "\(base)...HEAD"], in: worktreePath)
-        return Self.parseNameStatus(result.stdoutString)
-    }
-
     // MARK: - Diffs
-
-    public func committedDiff(worktreePath: String, base: String, path: String) async throws -> DiffFile? {
-        let result = try await runChecked(["diff", "\(base)...HEAD", "--", path], in: worktreePath)
-        return DiffParser.parse(result.stdoutString).first
-    }
 
     public func workingDiff(worktreePath: String, path: String, staged: Bool) async throws -> DiffFile? {
         var args = ["diff"]
@@ -50,20 +40,6 @@ public struct ProcessGitClient: GitClient {
         args.append(contentsOf: ["--", path])
         let result = try await runChecked(args, in: worktreePath)
         return DiffParser.parse(result.stdoutString).first
-    }
-
-    // MARK: - Branch snapshot browse
-
-    public func listTree(repoPath: String, ref: String) async throws -> [String] {
-        let result = try await runChecked(["ls-tree", "-r", "--name-only", "-z", ref], in: repoPath)
-        return result.stdoutString
-            .split(separator: "\u{0}", omittingEmptySubsequences: true)
-            .map(String.init)
-    }
-
-    public func showFile(repoPath: String, ref: String, path: String) async throws -> Data {
-        let result = try await runChecked(["show", "\(ref):\(path)"], in: repoPath)
-        return result.standardOutput
     }
 
     // MARK: - Writes
@@ -90,10 +66,6 @@ public struct ProcessGitClient: GitClient {
 
     public func commit(worktreePath: String, message: String) async throws {
         _ = try await runChecked(["commit", "-m", message], in: worktreePath)
-    }
-
-    public func checkout(worktreePath: String, branch: String) async throws {
-        _ = try await runChecked(["checkout", branch], in: worktreePath)
     }
 
     // MARK: - Worktree management
@@ -195,34 +167,5 @@ public struct ProcessGitClient: GitClient {
             return .lockedIndex(path: directory)
         }
         return .commandFailed(command: ["git"] + arguments, exitCode: result.exitCode, stderr: result.standardError)
-    }
-
-    // MARK: - name-status (-z) parsing
-
-    /// Parse `git diff --name-status -z` output. Records are NUL-separated; R/C
-    /// statuses carry a score and are followed by old- and new-path tokens.
-    static func parseNameStatus(_ output: String) -> [NameStatusEntry] {
-        let tokens = output.split(separator: "\u{0}", omittingEmptySubsequences: true).map(String.init)
-        var entries: [NameStatusEntry] = []
-        var index = 0
-        while index < tokens.count {
-            let statusToken = tokens[index]
-            index += 1
-            guard let first = statusToken.first else { continue }
-            let status = ChangeStatus(porcelainCode: first) ?? .modified
-            if first == "R" || first == "C" {
-                guard index + 1 < tokens.count else { break }
-                let original = tokens[index]
-                let newPath = tokens[index + 1]
-                index += 2
-                entries.append(NameStatusEntry(status: status, path: newPath, originalPath: original))
-            } else {
-                guard index < tokens.count else { break }
-                let path = tokens[index]
-                index += 1
-                entries.append(NameStatusEntry(status: status, path: path))
-            }
-        }
-        return entries
     }
 }

--- a/Sources/TreebranchCore/RepoGitQueue.swift
+++ b/Sources/TreebranchCore/RepoGitQueue.swift
@@ -40,10 +40,6 @@ public actor RepoGitQueue {
         try await run { try await self.git.commit(worktreePath: worktreePath, message: message) }
     }
 
-    public func checkout(worktreePath: String, branch: String) async throws {
-        try await run { try await self.git.checkout(worktreePath: worktreePath, branch: branch) }
-    }
-
     public func addWorktree(path: String, branch: String?, createBranch: Bool) async throws {
         try await run {
             try await self.git.addWorktree(repoPath: self.repoPath, path: path, branch: branch, createBranch: createBranch)

--- a/Sources/TreebranchCore/Services.swift
+++ b/Sources/TreebranchCore/Services.swift
@@ -56,19 +56,10 @@ public struct StatusService: Sendable {
 
 // MARK: - DiffService
 
-/// name-status + per-file hunks vs base, and working diffs (TECH_SPEC §2).
+/// Working-tree diffs for the change peek (TECH_SPEC §2).
 public struct DiffService: Sendable {
     private let git: GitClient
     public init(git: GitClient) { self.git = git }
-
-    /// Files committed ahead of `base` on the worktree's HEAD.
-    public func changedFilesVsBase(worktreePath: String, base: String) async throws -> [NameStatusEntry] {
-        try await git.changedFilesVsBase(worktreePath: worktreePath, base: base)
-    }
-
-    public func committedDiff(worktreePath: String, base: String, path: String) async throws -> DiffFile? {
-        try await git.committedDiff(worktreePath: worktreePath, base: base, path: path)
-    }
 
     public func workingDiff(worktreePath: String, path: String, staged: Bool = false) async throws -> DiffFile? {
         try await git.workingDiff(worktreePath: worktreePath, path: path, staged: staged)
@@ -84,36 +75,12 @@ public struct DiffService: Sendable {
 
 // MARK: - BranchService
 
-/// Lists branches and resolves a repository's base branch.
+/// Lists a repository's branches.
 public struct BranchService: Sendable {
     private let git: GitClient
     public init(git: GitClient) { self.git = git }
 
     public func branches(for repo: Repository) async throws -> [Branch] {
         try await git.branches(repoPath: repo.path)
-    }
-
-    public func localBranchNames(for repo: Repository) async throws -> [String] {
-        try await git.branches(repoPath: repo.path).filter { !$0.isRemote }.map(\.name)
-    }
-
-    /// Resolve the effective base branch for `repo`: the configured value if it
-    /// exists, otherwise `main` then `master`. Throws `.missingBaseBranch` if none.
-    public func resolveBaseBranch(for repo: Repository) async throws -> String {
-        let names = try await localBranchNames(for: repo)
-        guard let base = TreebranchCore.resolveBaseBranch(configured: repo.baseBranch, availableBranches: names) else {
-            throw GitError.missingBaseBranch(repo: repo.path)
-        }
-        return base
-    }
-
-    // MARK: Read-only snapshot browse (D2)
-
-    public func snapshotFiles(for repo: Repository, ref: String) async throws -> [String] {
-        try await git.listTree(repoPath: repo.path, ref: ref)
-    }
-
-    public func snapshotFileContents(for repo: Repository, ref: String, path: String) async throws -> Data {
-        try await git.showFile(repoPath: repo.path, ref: ref, path: path)
     }
 }

--- a/Tests/TreebranchCoreTests/AppStateStoreTests.swift
+++ b/Tests/TreebranchCoreTests/AppStateStoreTests.swift
@@ -15,7 +15,7 @@ struct AppStateStoreTests {
         let (url, cleanup) = tempURL(); defer { cleanup() }
         let store = AppStateStore(url: url)
         let state = AppState(
-            repositories: [PersistedRepository(path: "/a", baseBranch: "main"),
+            repositories: [PersistedRepository(path: "/a"),
                            PersistedRepository(path: "/b")],
             showChangedOnly: true,
             floatOnTop: true,

--- a/Tests/TreebranchCoreTests/CoreInfoTests.swift
+++ b/Tests/TreebranchCoreTests/CoreInfoTests.swift
@@ -7,37 +7,4 @@ struct CoreInfoTests {
     func versionIsSet() {
         #expect(!TreebranchCore.version.isEmpty)
     }
-
-    @Test("base-branch candidates are main then master")
-    func baseBranchCandidates() {
-        #expect(TreebranchCore.defaultBaseBranchCandidates == ["main", "master"])
-    }
-
-    @Test("configured base branch wins when it exists")
-    func resolvesConfigured() {
-        let resolved = TreebranchCore.resolveBaseBranch(
-            configured: "develop",
-            availableBranches: ["main", "develop"]
-        )
-        #expect(resolved == "develop")
-    }
-
-    @Test("falls back to main, then master")
-    func resolvesDefaults() {
-        #expect(
-            TreebranchCore.resolveBaseBranch(configured: nil, availableBranches: ["master", "main"])
-                == "main"
-        )
-        #expect(
-            TreebranchCore.resolveBaseBranch(configured: nil, availableBranches: ["master", "topic"])
-                == "master"
-        )
-    }
-
-    @Test("returns nil when neither configured nor defaults exist")
-    func resolvesNil() {
-        #expect(
-            TreebranchCore.resolveBaseBranch(configured: "gone", availableBranches: ["topic"]) == nil
-        )
-    }
 }

--- a/Tests/TreebranchCoreTests/GitIntegrationExtraTests.swift
+++ b/Tests/TreebranchCoreTests/GitIntegrationExtraTests.swift
@@ -52,20 +52,6 @@ struct GitIntegrationExtraTests {
         }
     }
 
-    @Test("renamed file appears as a rename vs base with original path")
-    func renamedDiff() async throws {
-        let fixture = try GitFixture(); defer { fixture.cleanup() }
-        fixture.commitFile("old.txt", "stable content here\nmore lines\n")
-        fixture.git(["checkout", "-q", "-b", "feature"])
-        fixture.git(["mv", "old.txt", "new.txt"])
-        fixture.commit("rename")
-
-        let entries = try await git.changedFilesVsBase(worktreePath: fixture.repoPath, base: "main")
-        let rename = entries.first { $0.status == .renamed }
-        #expect(rename?.path == "new.txt")
-        #expect(rename?.originalPath == "old.txt")
-    }
-
     @Test("binary file diff is flagged binary")
     func binaryDiff() async throws {
         let fixture = try GitFixture(); defer { fixture.cleanup() }
@@ -78,18 +64,6 @@ struct GitIntegrationExtraTests {
 
         let diff = try await git.workingDiff(worktreePath: fixture.repoPath, path: "blob.bin", staged: false)
         #expect(diff?.isBinary == true)
-    }
-
-    @Test("missing base branch throws missingBaseBranch")
-    func missingBase() async throws {
-        let fixture = try GitFixture(); defer { fixture.cleanup() }
-        fixture.commitFile("seed.txt", "seed\n")
-        fixture.git(["branch", "-m", "trunk"]) // no main/master
-
-        let service = BranchService(git: git)
-        await #expect(throws: GitError.self) {
-            _ = try await service.resolveBaseBranch(for: Repository(path: fixture.repoPath))
-        }
     }
 
     @Test("detached HEAD reported by status")

--- a/Tests/TreebranchCoreTests/GitWritesTests.swift
+++ b/Tests/TreebranchCoreTests/GitWritesTests.swift
@@ -53,17 +53,6 @@ struct GitWritesTests {
         #expect(log.contains("add feature"))
     }
 
-    @Test("checkout switches the worktree branch")
-    func checkout() async throws {
-        let fixture = try GitFixture(); defer { fixture.cleanup() }
-        fixture.commitFile("a.txt", "a\n")
-        fixture.createBranch("feature")
-
-        try await queue(fixture).checkout(worktreePath: fixture.repoPath, branch: "feature")
-        let status = try await git.status(worktreePath: fixture.repoPath)
-        #expect(status.branch == "feature")
-    }
-
     @Test("serialized concurrent stages all apply")
     func serializedConcurrency() async throws {
         let fixture = try GitFixture(); defer { fixture.cleanup() }

--- a/Tests/TreebranchCoreTests/Helpers/FakeGitClient.swift
+++ b/Tests/TreebranchCoreTests/Helpers/FakeGitClient.swift
@@ -8,11 +8,7 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     var worktreesResult: [Worktree] = []
     var branchesResult: [Branch] = []
     var statusResult = StatusResult()
-    var nameStatusResult: [NameStatusEntry] = []
-    var committedDiffResult: DiffFile?
     var workingDiffResult: DiffFile?
-    var listTreeResult: [String] = []
-    var showFileResult = Data()
     /// If set, the next call throws this error.
     var errorToThrow: GitError?
     /// Number of times the next write should throw `.lockedIndex` before succeeding
@@ -25,7 +21,6 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     private(set) var discardedWorking: [[String]] = []
     private(set) var discardedUntracked: [[String]] = []
     private(set) var commitMessages: [String] = []
-    private(set) var checkouts: [String] = []
     private(set) var addedWorktrees: [(path: String, branch: String?, createBranch: Bool)] = []
     private(set) var removedWorktrees: [(path: String, force: Bool)] = []
     private(set) var runInvocations: [[String]] = []
@@ -46,27 +41,15 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     func branches(repoPath: String) async throws -> [Branch] { try throwIfNeeded(); return branchesResult }
     func status(worktreePath: String) async throws -> StatusResult { try throwIfNeeded(); return statusResult }
 
-    func changedFilesVsBase(worktreePath: String, base: String) async throws -> [NameStatusEntry] {
-        try throwIfNeeded(); return nameStatusResult
-    }
-
-    func committedDiff(worktreePath: String, base: String, path: String) async throws -> DiffFile? {
-        try throwIfNeeded(); return committedDiffResult
-    }
-
     func workingDiff(worktreePath: String, path: String, staged: Bool) async throws -> DiffFile? {
         try throwIfNeeded(); workingDiffStagedFlags.append(staged); return workingDiffResult
     }
-
-    func listTree(repoPath: String, ref: String) async throws -> [String] { try throwIfNeeded(); return listTreeResult }
-    func showFile(repoPath: String, ref: String, path: String) async throws -> Data { try throwIfNeeded(); return showFileResult }
 
     func stage(worktreePath: String, paths: [String]) async throws { try throwLockIfNeeded(); try throwIfNeeded(); stagedPaths.append(paths) }
     func unstage(worktreePath: String, paths: [String]) async throws { try throwLockIfNeeded(); try throwIfNeeded(); unstagedPaths.append(paths) }
     func discardWorking(worktreePath: String, paths: [String]) async throws { try throwLockIfNeeded(); try throwIfNeeded(); discardedWorking.append(paths) }
     func discardUntracked(worktreePath: String, paths: [String]) async throws { try throwLockIfNeeded(); try throwIfNeeded(); discardedUntracked.append(paths) }
     func commit(worktreePath: String, message: String) async throws { try throwLockIfNeeded(); try throwIfNeeded(); commitMessages.append(message) }
-    func checkout(worktreePath: String, branch: String) async throws { try throwLockIfNeeded(); try throwIfNeeded(); checkouts.append(branch) }
 
     func addWorktree(repoPath: String, path: String, branch: String?, createBranch: Bool) async throws {
         try throwIfNeeded(); addedWorktrees.append((path, branch, createBranch))

--- a/Tests/TreebranchCoreTests/ProcessGitClientTests.swift
+++ b/Tests/TreebranchCoreTests/ProcessGitClientTests.swift
@@ -47,19 +47,6 @@ struct ProcessGitClientTests {
         #expect(byPath["todelete.txt"]?.worktreeStatus == .deleted)
     }
 
-    @Test("ahead-of-base name-status vs base branch")
-    func aheadOfBase() async throws {
-        let fixture = try GitFixture()
-        defer { fixture.cleanup() }
-        fixture.commitFile("base.txt", "base\n")
-        // Branch off and add a commit ahead of main.
-        fixture.git(["checkout", "-q", "-b", "feature"])
-        fixture.commitFile("feature.txt", "feature\n")
-
-        let entries = try await git.changedFilesVsBase(worktreePath: fixture.repoPath, base: "main")
-        #expect(entries.contains { $0.path == "feature.txt" && $0.status == .added })
-    }
-
     // MARK: M4 — Diffs
 
     @Test("working diff produces hunks with line numbers")
@@ -75,50 +62,6 @@ struct ProcessGitClientTests {
         #expect(file.addedCount == 1)
         #expect(file.removedCount == 1)
         #expect(file.hunks.first?.lines.contains { $0.content == "line2 CHANGED" && $0.kind == .addition } == true)
-    }
-
-    @Test("committed diff vs base for a path")
-    func committedDiff() async throws {
-        let fixture = try GitFixture()
-        defer { fixture.cleanup() }
-        fixture.commitFile("a.txt", "one\n")
-        fixture.git(["checkout", "-q", "-b", "feature"])
-        fixture.writeFile("a.txt", "one\ntwo\n")
-        fixture.stage(["a.txt"])
-        fixture.commit("add two")
-
-        let diff = try await git.committedDiff(worktreePath: fixture.repoPath, base: "main", path: "a.txt")
-        let file = try #require(diff)
-        #expect(file.addedCount == 1)
-    }
-
-    // MARK: M8 — Branch snapshot browse
-
-    @Test("ls-tree lists committed files of a branch without checkout")
-    func branchSnapshot() async throws {
-        let fixture = try GitFixture()
-        defer { fixture.cleanup() }
-        fixture.commitFile("a.txt", "a\n")
-        fixture.commitFile("dir/b.txt", "b\n")
-        // Make a different, uncommitted working change that must NOT appear.
-        fixture.writeFile("c-uncommitted.txt", "c\n")
-
-        let files = try await git.listTree(repoPath: fixture.repoPath, ref: "main")
-        #expect(files.contains("a.txt"))
-        #expect(files.contains("dir/b.txt"))
-        #expect(files.contains("c-uncommitted.txt") == false)
-    }
-
-    @Test("show reads file content at a ref")
-    func showFile() async throws {
-        let fixture = try GitFixture()
-        defer { fixture.cleanup() }
-        fixture.commitFile("a.txt", "hello snapshot\n")
-        // Change working copy; show must return the committed content.
-        fixture.writeFile("a.txt", "MODIFIED\n")
-
-        let data = try await git.showFile(repoPath: fixture.repoPath, ref: "main", path: "a.txt")
-        #expect(String(decoding: data, as: UTF8.self) == "hello snapshot\n")
     }
 
     @Test("status on a non-git directory throws notAGitRepository")

--- a/Tests/TreebranchCoreTests/ServicesTests.swift
+++ b/Tests/TreebranchCoreTests/ServicesTests.swift
@@ -50,44 +50,12 @@ struct ServicesTests {
         #expect(fake.workingDiffStagedFlags == [false])
     }
 
-    @Test("BranchService resolves configured base when present")
-    func resolveConfiguredBase() async throws {
+    @Test("BranchService lists a repo's branches")
+    func branchesList() async throws {
         let fake = FakeGitClient()
         fake.branchesResult = [Branch(name: "main"), Branch(name: "develop")]
         let service = BranchService(git: fake)
-        let configured = Repository(path: "/repo", baseBranch: "develop")
-        let base = try await service.resolveBaseBranch(for: configured)
-        #expect(base == "develop")
-    }
-
-    @Test("BranchService falls back to main")
-    func resolveDefaultBase() async throws {
-        let fake = FakeGitClient()
-        fake.branchesResult = [Branch(name: "master"), Branch(name: "main"), Branch(name: "topic")]
-        let service = BranchService(git: fake)
-        let base = try await service.resolveBaseBranch(for: repo)
-        #expect(base == "main")
-    }
-
-    @Test("BranchService throws missingBaseBranch when none match")
-    func resolveMissingBase() async throws {
-        let fake = FakeGitClient()
-        fake.branchesResult = [Branch(name: "topic")]
-        let service = BranchService(git: fake)
-        await #expect(throws: GitError.self) {
-            _ = try await service.resolveBaseBranch(for: repo)
-        }
-    }
-
-    @Test("BranchService filters remotes from local names")
-    func localNamesOnly() async throws {
-        let fake = FakeGitClient()
-        fake.branchesResult = [
-            Branch(name: "main"),
-            Branch(name: "origin/main", isRemote: true),
-        ]
-        let service = BranchService(git: fake)
-        let names = try await service.localBranchNames(for: repo)
-        #expect(names == ["main"])
+        let names = try await service.branches(for: repo).map(\.name)
+        #expect(names == ["main", "develop"])
     }
 }

--- a/Tests/TreebranchTests/Fakes.swift
+++ b/Tests/TreebranchTests/Fakes.swift
@@ -8,11 +8,7 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     var worktreesResult: [Worktree] = []
     var branchesResult: [Branch] = []
     var statusResult = StatusResult()
-    var nameStatusResult: [NameStatusEntry] = []
-    var committedDiffResult: DiffFile?
     var workingDiffResult: DiffFile?
-    var listTreeResult: [String] = []
-    var showFileResult = Data()
     var worktreesError: GitError?
 
     private(set) var stagedPaths: [[String]] = []
@@ -20,7 +16,6 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     private(set) var discardedWorking: [[String]] = []
     private(set) var discardedUntracked: [[String]] = []
     private(set) var commitMessages: [String] = []
-    private(set) var checkouts: [String] = []
 
     func worktrees(repoPath: String) async throws -> [Worktree] {
         if let worktreesError { throw worktreesError }
@@ -28,17 +23,12 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     }
     func branches(repoPath: String) async throws -> [Branch] { branchesResult }
     func status(worktreePath: String) async throws -> StatusResult { statusResult }
-    func changedFilesVsBase(worktreePath: String, base: String) async throws -> [NameStatusEntry] { nameStatusResult }
-    func committedDiff(worktreePath: String, base: String, path: String) async throws -> DiffFile? { committedDiffResult }
     func workingDiff(worktreePath: String, path: String, staged: Bool) async throws -> DiffFile? { workingDiffResult }
-    func listTree(repoPath: String, ref: String) async throws -> [String] { listTreeResult }
-    func showFile(repoPath: String, ref: String, path: String) async throws -> Data { showFileResult }
     func stage(worktreePath: String, paths: [String]) async throws { stagedPaths.append(paths) }
     func unstage(worktreePath: String, paths: [String]) async throws { unstagedPaths.append(paths) }
     func discardWorking(worktreePath: String, paths: [String]) async throws { discardedWorking.append(paths) }
     func discardUntracked(worktreePath: String, paths: [String]) async throws { discardedUntracked.append(paths) }
     func commit(worktreePath: String, message: String) async throws { commitMessages.append(message) }
-    func checkout(worktreePath: String, branch: String) async throws { checkouts.append(branch) }
     func addWorktree(repoPath: String, path: String, branch: String?, createBranch: Bool) async throws {}
     func removeWorktree(repoPath: String, worktreePath: String, force: Bool) async throws {}
     @discardableResult

--- a/Tests/TreebranchTests/UserStoryTests.swift
+++ b/Tests/TreebranchTests/UserStoryTests.swift
@@ -1,0 +1,268 @@
+import Testing
+import Foundation
+import AppKit
+@testable import Treebranch
+import TreebranchCore
+
+// Executable coverage for user stories in FEATURE_AUDIT.csv that are testable at
+// the view-model layer. Green tests assert behavior that is correct today;
+// `.bug` tests assert the *expected* behavior of a documented defect (red until
+// the fix lands in the audit's fix phase).
+
+@MainActor
+@Suite("User stories: repositories (A)")
+struct RepoStoryTests {
+    @Test("A3: adding the same repo twice does not duplicate")
+    func a3NoDuplicate() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let app = AppModel(environment: makeTestEnvironment(git: git))
+        #expect(await app.addRepository(path: "/repo") == true)
+        #expect(await app.addRepository(path: "/repo") == false)
+        #expect(app.repositories.count == 1)
+    }
+
+    @Test("A4: removing a repo persists the removal")
+    func a4RemovePersists() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let env = makeTestEnvironment(git: git)
+        let app = AppModel(environment: env)
+        _ = await app.addRepository(path: "/repo")
+        app.removeRepository(Repository(path: "/repo"))
+        #expect(env.store.load().repositories.isEmpty)
+    }
+}
+
+@MainActor
+@Suite("User stories: file ops (F)")
+struct FileOpStoryTests {
+    @Test("F1: open forwards a file to the opener; F-dir: directories are ignored")
+    func f1Open() {
+        let opener = FakeFileOpener()
+        let app = AppModel(environment: makeTestEnvironment(opener: opener))
+        app.open(FileNode(path: "/r/a.swift", isDirectory: false))
+        app.open(FileNode(path: "/r/dir", isDirectory: true))
+        #expect(opener.opened.map(\.path) == ["/r/a.swift"])
+    }
+
+    @Test("F9: Copy Path writes the absolute path to the pasteboard")
+    func f9CopyPath() {
+        let app = AppModel(environment: makeTestEnvironment())
+        app.copyPath(FileNode(path: "/r/deep/file.txt", isDirectory: false))
+        #expect(NSPasteboard.general.string(forType: .string) == "/r/deep/file.txt")
+    }
+
+    @Test("F10: Move to Trash routes through ops.moveToTrash after confirm")
+    func f10Trash() async {
+        let ops = FakeFileOps()
+        let model = WorktreeModel(environment: makeTestEnvironment(ops: ops))
+        await model.load(worktreePath: "/r", repo: Repository(path: "/r"))
+        model.requestTrash(path: "/r/gone.txt")
+        #expect(model.pendingMutation?.kind == .trash)
+        await model.confirmPendingMutation()
+        #expect(ops.trashed.map(\.path) == ["/r/gone.txt"])
+    }
+}
+
+@MainActor
+@Suite("User stories: changes (D)")
+struct ChangeStoryTests {
+    private func tempDir() -> (String, () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("tb-us-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir.path, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test("D4: unstage forwards the path to the serial queue")
+    func d4Unstage() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let git = FakeGitClient()
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        await model.unstage(FileChange(path: "a.txt", indexStatus: .modified))
+        #expect(git.unstagedPaths == [["a.txt"]])
+    }
+
+    @Test("D6: discarding an untracked file routes to git clean, not restore")
+    func d6DiscardUntracked() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let git = FakeGitClient()
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.requestDiscard(FileChange(path: "new.txt", worktreeStatus: .untracked))
+        #expect(model.pendingMutation?.kind == .discardUntracked)
+        await model.confirmPendingMutation()
+        #expect(git.discardedUntracked == [["new.txt"]])
+        #expect(git.discardedWorking.isEmpty)
+    }
+
+    @Test("D7b: commit stages the unstaged half of a partially-staged file")
+    func d7PartialStaged() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let git = FakeGitClient()
+        git.statusResult = StatusResult(changes: [
+            FileChange(path: "partial.txt", indexStatus: .modified, worktreeStatus: .modified),
+            FileChange(path: "stagedonly.txt", indexStatus: .added, worktreeStatus: .unmodified),
+        ])
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.commitMessage = "msg"
+        await model.commitPending()
+        // Only partial.txt has an unstaged delta to add; stagedonly.txt is already staged.
+        #expect(git.stagedPaths == [["partial.txt"]])
+        #expect(git.commitMessages == ["msg"])
+    }
+
+    @Test("D8: commit is a no-op when the message is blank")
+    func d8BlankMessage() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let git = FakeGitClient()
+        git.statusResult = StatusResult(changes: [FileChange(path: "a.txt", worktreeStatus: .modified)])
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.commitMessage = "   "
+        await model.commitPending()
+        #expect(git.commitMessages.isEmpty)
+    }
+}
+
+@MainActor
+@Suite("User stories: files (E)")
+struct FileStoryTests {
+    private func tempTree() -> (String, () -> Void) {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("tb-usf-\(UUID().uuidString)")
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? "old".write(to: dir.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        try? "new".write(to: dir.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        return (dir.path, { try? fm.removeItem(at: dir) })
+    }
+
+    @Test("E5: recently-changed sort orders newer files first")
+    func e5RecentSort() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        // Make new.txt strictly newer than old.txt.
+        let newer = Date().addingTimeInterval(60)
+        try FileManager.default.setAttributes([.modificationDate: newer], ofItemAtPath: dir + "/new.txt")
+        let older = Date().addingTimeInterval(-60)
+        try FileManager.default.setAttributes([.modificationDate: older], ofItemAtPath: dir + "/old.txt")
+
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.sortOrder = .recent
+        let names = model.visibleRows.map(\.node.name)
+        #expect(names.firstIndex(of: "new.txt")! < names.firstIndex(of: "old.txt")!)
+    }
+}
+
+@MainActor
+@Suite("User stories: persistence (I)")
+struct PersistStoryTests {
+    @Test("I2: bootstrap restores repositories, floatOnTop, and the last selected repo")
+    func i2RestoreRepo() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repoB", branch: "main", isPrimary: true),
+        ]
+        let env = makeTestEnvironment(git: git)
+        // Seed persisted state with two repos, B last-selected, floatOnTop on.
+        var seed = AppState()
+        seed.repositories = [PersistedRepository(path: "/repoA"), PersistedRepository(path: "/repoB")]
+        seed.lastSelectedRepoPath = "/repoB"
+        seed.floatOnTop = true
+        try? env.store.save(seed)
+
+        let app = AppModel(environment: env)
+        await app.bootstrap()
+        #expect(app.repositories.map(\.path) == ["/repoA", "/repoB"])
+        #expect(app.floatOnTop == true)
+        #expect(app.selector.selectedRepo?.path == "/repoB")
+    }
+
+    @Test("I3: bootstrap restores the last selected worktree, not just the primary")
+    func i3RestoreWorktree() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-feature", branch: "feature"),
+        ]
+        let env = makeTestEnvironment(git: git)
+        var seed = AppState()
+        seed.repositories = [PersistedRepository(path: "/repo")]
+        seed.lastSelectedRepoPath = "/repo"
+        seed.lastSelectedWorktreePath = "/repo-feature"
+        try? env.store.save(seed)
+
+        let app = AppModel(environment: env)
+        await app.bootstrap()
+        #expect(app.selector.selectedWorktree?.path == "/repo-feature")
+    }
+
+    @Test("I1: switching the selected worktree persists it durably (no quit hook needed)")
+    func i1PersistSelection() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-feature", branch: "feature"),
+        ]
+        let env = makeTestEnvironment(git: git)
+        let app = AppModel(environment: env)
+        _ = await app.addRepository(path: "/repo")   // selects primary
+        await app.selector.selectWorktree(Worktree(path: "/repo-feature", branch: "feature"))
+        // Persisted immediately on selection — survives a relaunch with no terminate hook.
+        let saved = env.store.load()
+        #expect(saved.lastSelectedRepoPath == "/repo")
+        #expect(saved.lastSelectedWorktreePath == "/repo-feature")
+    }
+}
+
+@MainActor
+@Suite("User stories: live & activity (C/J)")
+struct LiveActivityStoryTests {
+    private func tempDir() -> (String, () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("tb-la-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir.path, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test("J2: a file-watch event during teebe's own write is NOT recorded as activity")
+    func j2SelfWriteSuppressed() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let monitor = WorktreeActivityMonitor()
+        let model = WorktreeModel(environment: makeTestEnvironment(monitor: monitor))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let t = Date(timeIntervalSince1970: 1000)
+        model.noteSelfWrite(at: t)
+        await model.handleFileSystemEvent(now: t.addingTimeInterval(0.2))   // inside ignore window
+        #expect(monitor.isBusy(worktreePath: dir, within: 5, now: t.addingTimeInterval(0.3)) == false)
+    }
+
+    @Test("J2: an external file-watch event IS recorded and notifies onActivity")
+    func j2ExternalRecorded() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let monitor = WorktreeActivityMonitor()
+        let model = WorktreeModel(environment: makeTestEnvironment(monitor: monitor))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        var notified: String?
+        model.onActivity = { notified = $0 }
+        let t = Date(timeIntervalSince1970: 2000)
+        await model.handleFileSystemEvent(now: t)   // no prior self-write
+        #expect(monitor.isBusy(worktreePath: dir, within: 5, now: t.addingTimeInterval(1)) == true)
+        #expect(notified == dir)
+    }
+
+    @Test("C4: refreshLiveState lights a worktree the activity monitor reports busy")
+    func c4RefreshLive() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let monitor = WorktreeActivityMonitor()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, monitor: monitor))
+        await selector.selectRepo(Repository(path: "/repo"))
+        #expect(selector.info(for: Worktree(path: "/repo")).isLive == false)
+        let t = Date(timeIntervalSince1970: 3000)
+        monitor.recordActivity(worktreePath: "/repo", at: t)
+        selector.refreshLiveState(now: t.addingTimeInterval(1))
+        #expect(selector.info(for: Worktree(path: "/repo")).isLive == true)
+    }
+}

--- a/Tests/TreebranchTests/ViewModelTests.swift
+++ b/Tests/TreebranchTests/ViewModelTests.swift
@@ -65,19 +65,6 @@ struct SelectorModelTests {
         #expect(selector.worktree.worktreePath == "/repo")
     }
 
-    @Test("browsing a branch loads a read-only snapshot")
-    func browseBranch() async {
-        let git = FakeGitClient()
-        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
-        git.listTreeResult = ["a.txt", "src/b.swift"]
-        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
-        await selector.selectRepo(Repository(path: "/repo"))
-
-        await selector.browse(branch: Branch(name: "feature"))
-        #expect(selector.browseBranch?.name == "feature")
-        #expect(selector.worktree.isBrowsingSnapshot == true)
-        #expect(selector.worktree.root?.children?.isEmpty == false)
-    }
 }
 
 @MainActor
@@ -258,21 +245,6 @@ struct PreviewModelTests {
         await model.toggle(for: node, worktreePath: "/repo")
         #expect(model.isVisible == false)
         #expect(model.content == .empty)
-    }
-
-    @Test("snapshot browse previews committed content via git show, not disk (D2)")
-    func snapshotPreviewUsesGitShow() async {
-        let git = FakeGitClient()
-        git.listTreeResult = ["a.txt"]
-        git.showFileResult = Data("committed snapshot content".utf8)
-        let env = makeTestEnvironment(git: git)
-        let worktree = WorktreeModel(environment: env)
-        await worktree.loadSnapshot(repo: Repository(path: "/repo"), ref: "feature")
-        let node = worktree.root?.children?.first { $0.name == "a.txt" }
-
-        let preview = PreviewModel(environment: env)
-        await preview.toggle(for: node, worktreePath: "/repo", snapshot: worktree)
-        #expect(preview.content == .text("committed snapshot content"))
     }
 
     @Test("unchanged text file previews its content")


### PR DESCRIPTION
## teebe v0.1.0 — first release

**teebe** is a native macOS, worktree-aware file browser for the multi-agent era: a calm control room that shows you — across all your repos and git worktrees — what files exist and what's changing while several AI coding agents (Claude Code, Codex, etc.) work in parallel. It doesn't replace your editor; it's the navigator that launches files into whatever native app you already use.

### Highlights
- **Multi-repo, worktree-aware browsing** — files and live changes across every repo and worktree at once.
- **Live activity indicator** — a per-worktree dot that pulses on external agent writes; teebe ignores its *own* writes (stage/commit/discard/new/rename), so the indicator only fires for outside changes.
- **Working-diff peek + Quick Look** — preview what changed and open files into your editor of choice.
- **Stage & commit in-app** — commit with ⌘↩, including correct handling of partially-staged files.
- **All | Changed file filter** in the FILES menu.
- **Durable state** — selection and the active worktree persist across launches.
- **Polished feel** — press feedback and comfortable hit areas on controls, tabular rolling counts (changes / commit / ahead-behind), animated disclosure and live indicators, and dark-mode-aware surfaces.

### Install notes
- The release `.app` is **ad-hoc signed only** — no Developer ID signing or notarization yet, so Gatekeeper will warn on first open (right-click → Open).
- Requires **macOS 14+**.

### What's in this release
- Feature audit + reachable-defect fixes — persistence, live activity, Quick Look, commit, filter (#1)
- UI feel polish — press feedback, hit areas, tabular numbers, motion (#2)
- Ignore AI/agent process artifacts (gitignore hygiene)
