### PR TITLE
Fix Release workflow to package teebe.app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
         run: ./scripts/make-app.sh release
 
       - name: Zip the app
-        run: ditto -c -k --keepParent Treebranch.app "Treebranch-${GITHUB_REF_NAME}.zip"
+        run: ditto -c -k --keepParent teebe.app "teebe-${GITHUB_REF_NAME}.zip"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: Treebranch-*.zip
+          files: teebe-*.zip
           generate_release_notes: true
           draft: true


### PR DESCRIPTION
The Release job builds `teebe.app` (via `scripts/make-app.sh`) but the zip and release-asset steps still referenced the old `Treebranch.app` / `Treebranch-*.zip` names. The `v0.1.0` tag build therefore failed at the zip step (`ditto: Cannot get the real path for source 'Treebranch.app'`).

Points the zip step and `files:` glob at `teebe.app` / `teebe-*.zip`. CI-YAML only; no Swift changes.