### PR TITLE
Release: fix v0.1.0 build packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
         run: ./scripts/make-app.sh release
 
       - name: Zip the app
-        run: ditto -c -k --keepParent Treebranch.app "Treebranch-${GITHUB_REF_NAME}.zip"
+        run: ditto -c -k --keepParent teebe.app "teebe-${GITHUB_REF_NAME}.zip"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: Treebranch-*.zip
+          files: teebe-*.zip
           generate_release_notes: true
           draft: true


### PR DESCRIPTION
Carries the Release-workflow fix (#4) onto `main` so the `v0.1.0` tag build can package `teebe.app` and publish the release asset. No app-code changes since the previous release merge.