### PR TITLE
Test live-dot window logic; clean up repo subheader

### DIFF
--- a/Sources/Treebranch/Views/WorktreesSection.swift
+++ b/Sources/Treebranch/Views/WorktreesSection.swift
@@ -95,8 +95,10 @@ struct WorktreesSection: View {
 
     private func repoSubheader(_ repo: Repository) -> some View {
         HStack(spacing: 7) {
-            Text("▾").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).frame(width: 13)
-            Image(systemName: "square.dashed").font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
+            // No disclosure triangle: there's only ever one repo root to show, so a
+            // collapse affordance would be a no-op. Reintroduce it if/when the
+            // workspace can hold multiple repos.
+            Image(systemName: "shippingbox").font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
             Text(repo.name).font(.system(size: 12.5, weight: .semibold)).lineLimit(1)
             Spacer(minLength: 6)
             if let active = selector.selectedWorktree {

--- a/Tests/TreebranchCoreTests/GitWritesTests.swift
+++ b/Tests/TreebranchCoreTests/GitWritesTests.swift
@@ -103,4 +103,42 @@ struct GitWriteGuardTests {
         #expect(monitor.isBusy(worktreePath: "/wt", within: 5, now: base.addingTimeInterval(10)) == false)
         #expect(monitor.isBusy(worktreePath: "/unknown", within: 5, now: base) == false)
     }
+
+    @Test("live window is half-open: live up to but not at the boundary")
+    func busyWindowBoundary() {
+        let monitor = WorktreeActivityMonitor()
+        let base = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/wt", at: base)
+
+        // At the instant of activity it is live.
+        #expect(monitor.isBusy(worktreePath: "/wt", within: 5, now: base) == true)
+        // Just inside the window: still live.
+        #expect(monitor.isBusy(worktreePath: "/wt", within: 5, now: base.addingTimeInterval(4.999)) == true)
+        // Exactly at the window edge: no longer live (half-open interval).
+        #expect(monitor.isBusy(worktreePath: "/wt", within: 5, now: base.addingTimeInterval(5)) == false)
+    }
+
+    @Test("a fresh write re-lights an expired worktree")
+    func busyReactivates() {
+        let monitor = WorktreeActivityMonitor()
+        let base = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/wt", at: base)
+        let expired = base.addingTimeInterval(10)
+        #expect(monitor.isBusy(worktreePath: "/wt", within: 5, now: expired) == false)
+
+        // A new write at `expired` restarts the window from that moment.
+        monitor.recordActivity(worktreePath: "/wt", at: expired)
+        #expect(monitor.isBusy(worktreePath: "/wt", within: 5, now: expired.addingTimeInterval(2)) == true)
+    }
+
+    @Test("activity tracking is keyed per worktree")
+    func busyPerWorktree() {
+        let monitor = WorktreeActivityMonitor()
+        let base = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/repo/wt-a", at: base)
+
+        // Only the written-to worktree is live; a sibling with no writes is not.
+        #expect(monitor.isBusy(worktreePath: "/repo/wt-a", within: 5, now: base.addingTimeInterval(1)) == true)
+        #expect(monitor.isBusy(worktreePath: "/repo/wt-b", within: 5, now: base.addingTimeInterval(1)) == false)
+    }
 }

--- a/Tests/TreebranchTests/ViewModelTests.swift
+++ b/Tests/TreebranchTests/ViewModelTests.swift
@@ -65,6 +65,43 @@ struct SelectorModelTests {
         #expect(selector.worktree.worktreePath == "/repo")
     }
 
+    @Test("live dot lights for a worktree written to within the window, off after it")
+    func liveDotWindow() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-wt", branch: "feature")
+        ]
+        let monitor = WorktreeActivityMonitor()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, monitor: monitor))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        let t = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/repo-wt", at: t)
+
+        // Just after the write: only the written-to worktree's dot is live.
+        selector.refreshLiveState(now: t.addingTimeInterval(2))
+        #expect(selector.info(for: git.worktreesResult[1]).isLive == true)
+        #expect(selector.info(for: git.worktreesResult[0]).isLive == false)
+
+        // Once the window elapses, the dot goes idle again.
+        selector.refreshLiveState(now: t.addingTimeInterval(5))
+        #expect(selector.info(for: git.worktreesResult[1]).isLive == false)
+    }
+
+    @Test("refreshWorktreeInfo computes live state alongside sync counts")
+    func liveDotViaRefreshInfo() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let monitor = WorktreeActivityMonitor()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, monitor: monitor))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        let t = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/repo", at: t)
+        await selector.refreshWorktreeInfo(now: t.addingTimeInterval(1))
+        #expect(selector.info(for: git.worktreesResult[0]).isLive == true)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Add boundary/reactivation/per-worktree tests for WorktreeActivityMonitor
(the half-open 5s window that drives the live pulse dot) and SelectorModel
tests asserting isLive flips on within the window and off after it.

Remove the non-functional disclosure triangle from the repo subheader (a
single repo root has nothing to collapse) and replace the placeholder
square.dashed icon with shippingbox.
