### PR TITLE
Add Sparkle in-app auto-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
-# CD: on a version tag (vX.Y.Z), build a release .app bundle and attach it to a
-# GitHub Release. The bundle is ad-hoc signed only (see scripts/make-app.sh);
-# Developer ID signing + notarization are out of scope until signing certs are
-# wired in as repository secrets.
+# CD: on a version tag (vX.Y.Z), build a release .app bundle, sign a Sparkle
+# appcast, and attach both to a GitHub Release. The bundle is ad-hoc code-signed
+# only (see scripts/make-app.sh); Developer ID signing + notarization are out of
+# scope until signing certs are wired in as repository secrets. Sparkle updates
+# are integrity-signed with an EdDSA key independent of Apple notarization.
 on:
   push:
     tags:
@@ -23,14 +24,38 @@ jobs:
         run: swift --version
 
       - name: Build release .app bundle
+        env:
+          # Sparkle: public key embedded in Info.plist must pair with the private
+          # key used to sign the appcast below. Set as a repo variable/secret.
+          SU_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
         run: ./scripts/make-app.sh release
 
-      - name: Zip the app
-        run: ditto -c -k --keepParent teebe.app "teebe-${GITHUB_REF_NAME}.zip"
+      - name: Stage update archive
+        run: |
+          mkdir -p sparkle-updates
+          ditto -c -k --keepParent teebe.app "sparkle-updates/teebe-${GITHUB_REF_NAME}.zip"
+
+      - name: Generate & sign Sparkle appcast
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          GEN="$(find .build/artifacts -name generate_appcast -path '*/bin/*' | head -1)"
+          # Sign update enclosures with the EdDSA private key (read from stdin),
+          # and point download URLs at this release's assets.
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$GEN" \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/klein-t/teebe/releases/download/${GITHUB_REF_NAME}/" \
+            sparkle-updates
+          cp sparkle-updates/teebe-*.zip .
+          cp sparkle-updates/appcast.xml .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: teebe-*.zip
+          # Publish both the app zip and the appcast; SUFeedURL points at
+          # releases/latest/download/appcast.xml so the feed tracks the newest tag.
+          files: |
+            teebe-*.zip
+            appcast.xml
           generate_release_notes: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
           # Sparkle: public key embedded in Info.plist must pair with the private
           # key used to sign the appcast below. Set as a repo variable/secret.
           SU_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
-        run: ./scripts/make-app.sh release
+        run: |
+          # Stamp the release version into the bundle. CFBundleVersion must
+          # increase per release or Sparkle never sees a newer version.
+          APP_VERSION="${GITHUB_REF_NAME#v}" ./scripts/make-app.sh release
 
       - name: Stage update archive
         run: |
@@ -54,6 +57,9 @@ jobs:
         with:
           # Publish both the app zip and the appcast; SUFeedURL points at
           # releases/latest/download/appcast.xml so the feed tracks the newest tag.
+          # NOTE: the release is drafted — GitHub's `latest` ignores drafts, so the
+          # appcast URL only resolves once the draft is published. Publishing the
+          # release is the step that actually ships the update to existing users.
           files: |
             teebe-*.zip
             appcast.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,49 @@ first contribution is merged, you must agree to the
 PR that you agree to the CLA. This lets the project stay offerable under both
 licenses.
 
+## Shipping updates (Sparkle)
+
+teebe self-updates via [Sparkle](https://sparkle-project.org). Updates are
+delivered through an **appcast** (`appcast.xml`) published as an asset on each
+GitHub Release; the app's `SUFeedURL` points at
+`releases/latest/download/appcast.xml`, so the feed always reflects the newest
+tag. Each update is integrity-signed with an **EdDSA key** — this is Sparkle's
+own signature and is independent of Apple notarization (which governs
+first-launch Gatekeeper trust, not updates).
+
+### One-time signing-key setup (maintainer)
+
+Sparkle ships a `generate_keys` tool (in the resolved package under
+`.build/artifacts/sparkle/Sparkle/bin/`). Run it once **in your Terminal** (it
+stores the private key in the login Keychain):
+
+```sh
+.build/artifacts/sparkle/Sparkle/bin/generate_keys      # prints the public key
+.build/artifacts/sparkle/Sparkle/bin/generate_keys -x sparkle_private.key   # export for CI
+```
+
+Then add these to the GitHub repo (Settings → Secrets and variables → Actions):
+
+- `SPARKLE_PUBLIC_ED_KEY` — the public key string (embedded in `Info.plist` at
+  build time via `SU_PUBLIC_ED_KEY`).
+- `SPARKLE_ED_PRIVATE_KEY` — the contents of `sparkle_private.key` (used by CI
+  to sign the appcast). Treat it like any signing secret; do not commit it.
+
+Delete `sparkle_private.key` after adding the secret. The private key is the
+root of update trust — if it leaks, rotate it (new keypair, new public key in
+the next release).
+
+### What happens on release
+
+The Release workflow builds the `.app` with the public key baked in, zips it,
+runs `generate_appcast` (signing each update with the private key), and uploads
+both the zip and `appcast.xml`. Existing users get an in-app "Update available"
+prompt; the menu also has **Check for Updates…**.
+
+> Note: until the app is Developer ID-signed and **notarized**, first-time
+> downloads still hit Gatekeeper (right-click → Open). Notarization is separate
+> from Sparkle and tracked independently.
+
 ## Security
 
 Never commit secrets. See [`SECURITY.md`](SECURITY.md) for the reporting policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,16 @@ the next release).
 
 ### What happens on release
 
-The Release workflow builds the `.app` with the public key baked in, zips it,
-runs `generate_appcast` (signing each update with the private key), and uploads
-both the zip and `appcast.xml`. Existing users get an in-app "Update available"
-prompt; the menu also has **Check for Updates…**.
+The Release workflow builds the `.app` (stamping the tag as `CFBundleVersion`,
+which is what Sparkle compares to detect a newer version), zips it, runs
+`generate_appcast` (signing each update with the private key), and uploads both
+the zip and `appcast.xml` to a **draft** release.
+
+**Publishing the draft is what ships the update.** `SUFeedURL` points at
+`releases/latest/download/appcast.xml`, and GitHub's `latest` ignores drafts —
+so until you publish the release, existing apps won't see the new `appcast.xml`.
+Once published, existing users get an in-app "Update available" prompt; the menu
+also has **Check for Updates…**.
 
 > Note: until the app is Developer ID-signed and **notarized**, first-time
 > downloads still hit Gatekeeper (right-click → Open). Notarization is separate

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,11 @@ let package = Package(
         .library(name: "TeebeCore", targets: ["TeebeCore"]),
         .executable(name: "Teebe", targets: ["Teebe"]),
     ],
+    dependencies: [
+        // Sparkle: in-app auto-update framework (appcast + EdDSA-signed updates).
+        // App-layer only — TeebeCore stays UI/dependency-free.
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
+    ],
     targets: [
         // Pure, UI-independent core: models, git layer, parsers, services.
         .target(
@@ -18,7 +23,10 @@ let package = Package(
         // SwiftUI app: thin views + @Observable view models. Depends on Core.
         .executableTarget(
             name: "Teebe",
-            dependencies: ["TeebeCore"],
+            dependencies: [
+                "TeebeCore",
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             resources: [.process("Resources")]
         ),
         // Core unit + integration tests (Swift Testing).

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -23,6 +23,7 @@ struct TeebeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var app: AppModel
     @State private var preview: PreviewModel
+    @StateObject private var updater = UpdaterController()
 
     init() {
         // One shared environment, constructed exactly once.
@@ -39,6 +40,12 @@ struct TeebeApp: App {
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
+        .commands {
+            // Standard "Check for Updates…" item, placed in the app menu next to About.
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesCommand(updater: updater)
+            }
+        }
 
         // Separate floating Quick Look panel (D4 / PRD §5.2).
         Window("Quick Look", id: "preview") {

--- a/Sources/Teebe/Updater.swift
+++ b/Sources/Teebe/Updater.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Sparkle
+
+/// Wraps Sparkle's standard updater so the app can check for and install updates
+/// in place (appcast + EdDSA-signed deltas). The updater reads `SUFeedURL` and
+/// `SUPublicEDKey` from the bundle's `Info.plist` (see `scripts/make-app.sh`).
+///
+/// `startingUpdater: true` lets Sparkle schedule its own background checks per
+/// the user's preference; the menu command below drives a manual check.
+@MainActor
+final class UpdaterController: ObservableObject {
+    private let controller: SPUStandardUpdaterController
+
+    /// Mirrors `canCheckForUpdates` so the menu item disables itself while a
+    /// check is already in flight.
+    @Published var canCheckForUpdates = false
+
+    init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        controller.updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+
+    func checkForUpdates() {
+        controller.updater.checkForUpdates()
+    }
+}
+
+/// "Check for Updates…" item in the app menu, wired to the shared updater.
+struct CheckForUpdatesCommand: View {
+    @ObservedObject var updater: UpdaterController
+
+    var body: some View {
+        Button("Check for Updates…") { updater.checkForUpdates() }
+            .disabled(!updater.canCheckForUpdates)
+    }
+}

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,42 @@
+# Third-party licenses
+
+teebe bundles the following third-party components. Their license notices are
+reproduced here as required.
+
+## Sparkle
+
+In-app software update framework. <https://sparkle-project.org>
+
+Licensed under the MIT License.
+
+```
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+Sparkle additionally bundles permissively licensed components (e.g. `bsdiff`
+under a BSD-style license and an Ed25519 implementation). See the Sparkle
+distribution for their full notices.

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,6 +8,13 @@ CONFIG="${1:-debug}"   # debug | release
 APP="teebe.app"
 LOGO="Sources/Teebe/Resources/teebe-logo.png"
 
+# Version stamped into the bundle. CFBundleVersion is what Sparkle's comparator
+# uses to decide whether an update is newer, so it MUST increase per release —
+# CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
+# every release look identical and Sparkle would never offer an update.
+APP_VERSION="${APP_VERSION:-0.1.0}"
+BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
+
 # Sparkle auto-update config. Override via env in CI; the public key pairs with
 # the EdDSA private key used to sign updates (see CONTRIBUTING.md). The feed
 # points at the appcast published alongside each GitHub Release.
@@ -55,8 +62,8 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundleExecutable</key><string>teebe</string>
   <key>CFBundleIconFile</key><string>AppIcon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.1.0</string>
-  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleShortVersionString</key><string>${APP_VERSION}</string>
+  <key>CFBundleVersion</key><string>${BUILD_NUMBER}</string>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSPrincipalClass</key><string>NSApplication</string>
   <key>NSHighResolutionCapable</key><true/>

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,15 +8,28 @@ CONFIG="${1:-debug}"   # debug | release
 APP="teebe.app"
 LOGO="Sources/Teebe/Resources/teebe-logo.png"
 
+# Sparkle auto-update config. Override via env in CI; the public key pairs with
+# the EdDSA private key used to sign updates (see CONTRIBUTING.md). The feed
+# points at the appcast published alongside each GitHub Release.
+SU_FEED_URL="${SU_FEED_URL:-https://github.com/klein-t/teebe/releases/latest/download/appcast.xml}"
+SU_PUBLIC_ED_KEY="${SU_PUBLIC_ED_KEY:-REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY}"
+
 echo "==> swift build -c $CONFIG"
 swift build -c "$CONFIG"
 
-BIN="$(swift build -c "$CONFIG" --show-bin-path)/Teebe"
+BINDIR="$(swift build -c "$CONFIG" --show-bin-path)"
+BIN="$BINDIR/Teebe"
 
 echo "==> assembling $APP"
 rm -rf "$APP"
-mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp "$BIN" "$APP/Contents/MacOS/teebe"
+
+# Embed Sparkle.framework (SwiftPM stages it next to the binary) and point the
+# executable's runtime search path at the bundle's Frameworks dir.
+echo "==> embedding Sparkle.framework"
+cp -R "$BINDIR/Sparkle.framework" "$APP/Contents/Frameworks/"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/teebe" 2>/dev/null || true
 
 # Build a multi-resolution AppIcon.icns from the logo so it shows in Finder,
 # the Dock, and the app switcher.
@@ -31,7 +44,7 @@ if [[ -f "$LOGO" ]]; then
   iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/AppIcon.icns"
 fi
 
-cat > "$APP/Contents/Info.plist" <<'PLIST'
+cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -47,11 +60,17 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSPrincipalClass</key><string>NSApplication</string>
   <key>NSHighResolutionCapable</key><true/>
+  <key>SUFeedURL</key><string>${SU_FEED_URL}</string>
+  <key>SUPublicEDKey</key><string>${SU_PUBLIC_ED_KEY}</string>
+  <key>SUEnableAutomaticChecks</key><true/>
 </dict>
 </plist>
 PLIST
 
-# Ad-hoc sign so macOS is happy launching it locally.
+# Ad-hoc sign so macOS is happy launching it locally. Sign the embedded
+# framework first (inside-out), then the app. Real distribution replaces "-"
+# with a Developer ID identity + notarization (see CONTRIBUTING.md).
+codesign --force --deep --sign - "$APP/Contents/Frameworks/Sparkle.framework" >/dev/null 2>&1 || true
 codesign --force --deep --sign - "$APP" >/dev/null 2>&1 || true
 
 echo "==> built $APP"


### PR DESCRIPTION
## What

Integrates [Sparkle](https://sparkle-project.org) so teebe can check for and install updates in place via an **EdDSA-signed appcast**.

- Sparkle 2.9.x added as an **app-layer** SwiftPM dependency — `TeebeCore` stays pure.
- `SPUStandardUpdaterController` + a **Check for Updates…** menu command; automatic background checks enabled.
- `make-app.sh` embeds and ad-hoc-signs `Sparkle.framework`, adds the `@executable_path/../Frameworks` rpath, and writes `SUFeedURL` / `SUPublicEDKey` / `SUEnableAutomaticChecks` into `Info.plist` (public key injected via `SU_PUBLIC_ED_KEY` at build time).
- Release workflow generates + EdDSA-signs the appcast and publishes it next to the app zip. The feed tracks `releases/latest/download/appcast.xml`.
- Maintainer signing-key setup documented in `CONTRIBUTING.md`; Sparkle's MIT notice added to `THIRD-PARTY-LICENSES.md`.

## License

Sparkle is MIT — compatible with both the GPL-3.0 and commercial arms of teebe's dual license. Attribution added.

## Verified

`swift build`, `swift test` (120 tests), release bundle build, `codesign --verify`, and a dyld load smoke-test all pass locally. (swiftlint not run locally — no binary on the dev machine; runs in CI.)

## Follow-up — required before updates work (maintainer)

1. Run Sparkle's `generate_keys` in a real Terminal; add repo secrets `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_ED_PRIVATE_KEY`. Until then the bundle ships a placeholder public key.
2. Notarization (first-launch Gatekeeper trust) is separate and still pending.