### PR TITLE
Fix section toggle bounce and refine sidebar chrome

### DIFF
--- a/Sources/Teebe/Views/ChangesSection.swift
+++ b/Sources/Teebe/Views/ChangesSection.swift
@@ -24,12 +24,12 @@ struct ChangesSection: View {
 
             if isOpen {
                 VStack(spacing: 0) {
-                    commitBox
                     ScrollView {
                         changeList
                     }
                     .scrollBounceBehavior(.basedOnSize)
                 }
+                .padding(.top, 8)
                 .padding(.bottom, 6)
                 .transition(.opacity)
             }
@@ -38,68 +38,10 @@ struct ChangesSection: View {
         .clipped()
     }
 
-    private var commitBox: some View {
-        VStack(spacing: 7) {
-            TextField(
-                "Message (⌘↩ to commit on \(app.selector.selectedWorktree?.branch ?? "—"))",
-                text: $worktree.commitMessage,
-                axis: .vertical
-            )
-            .textFieldStyle(.plain)
-            .font(.system(size: 12))
-            .lineLimit(1...3)
-            .padding(.horizontal, 9).padding(.vertical, 7)
-            .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
-            .onSubmit { Task { await worktree.commitPending() } }
-
-            Button {
-                Task { await worktree.commitPending() }
-            } label: {
-                Text(commitLabel)
-                    .font(.system(size: 12.5, weight: .semibold))
-                    .monospacedDigit()
-                    .contentTransition(.numericText())
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 30)
-                    .foregroundStyle(commitEnabled ? .white : Palette.secondaryText)
-                    .background(commitEnabled ? Palette.accent : Color.primary.opacity(0.05),
-                                in: RoundedRectangle(cornerRadius: 6))
-                    .contentShape(RoundedRectangle(cornerRadius: 6))
-            }
-            .buttonStyle(PressableButtonStyle())
-            .disabled(!commitEnabled)
-            .keyboardShortcut(.return, modifiers: .command)   // ⌘↩ (matches the field's placeholder)
-            .animation(.easeOut(duration: 0.2), value: commitEnabled)
-            .animation(.snappy(duration: 0.22), value: worktree.changeCount)
-        }
-        .padding(.horizontal, 11).padding(.top, 8).padding(.bottom, 6)
-    }
-
-    private var commitEnabled: Bool {
-        worktree.changeCount > 0 && !worktree.commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
-    private var commitLabel: String {
-        if worktree.changeCount == 0 { return "✓ Nothing to commit" }
-        if worktree.commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "Enter a message to commit" }
-        return "Commit \(worktree.changeCount) change\(worktree.changeCount == 1 ? "" : "s")"
-    }
-
     private var changeList: some View {
         VStack(spacing: 0) {
-            ForEach(worktree.changeGroups) { group in
-                if !group.folder.isEmpty {
-                    HStack(spacing: 6) {
-                        Text("▾").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).frame(width: 13)
-                        Text(group.folder).font(.system(size: 12.5)).foregroundStyle(.primary)
-                        Spacer()
-                        Circle().fill(Palette.amber).frame(width: 6, height: 6)
-                    }
-                    .padding(.horizontal, 11).padding(.leading, 14).frame(height: 24)
-                }
-                ForEach(group.changes) { change in
-                    changeRow(change, indented: !group.folder.isEmpty)
-                }
+            ForEach(worktree.changes) { change in
+                changeRow(change, indented: false)
             }
             if worktree.changeCount == 0 {
                 Text("No changes")

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -161,15 +161,25 @@ struct SectionHeader<Trailing: View>: View {
 
     var body: some View {
         HStack(spacing: 5) {
-            Text("▸")
-                .font(.system(size: 15))
+            // The native macOS DisclosureGroup glyph: a `chevron.right` is a thin,
+            // doubly-symmetric stroke whose ink centroid coincides with its
+            // bounding-box center, so rotating it about the default `.center` anchor
+            // is a true spin-in-place. A *filled* `arrowtriangle.right.fill` has its
+            // area-centroid 1/3 from the base, NOT at the bbox center, so rotating it
+            // swept the visual mass through an arc — a left/down lurch read as a
+            // "bounce" that survives any easing curve and any glyph SOURCE swap
+            // (text→symbol) because it is geometric, not temporal. A square frame +
+            // explicit `.center` anchor pins the pivot to the glyph's visual center.
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(Palette.secondaryText)
-                .frame(width: 13)
-                .rotationEffect(.degrees(isOpen ? 90 : 0))
-                // The chevron rotates on its own clean ease — no overshoot — so it
-                // animates independently of the window/layout resize without being
-                // the one thing left bouncing. See RootView.setOpen.
-                .animation(.easeInOut(duration: 0.2), value: isOpen)
+                .frame(width: 13, height: 13)
+                .rotationEffect(.degrees(isOpen ? 90 : 0), anchor: .center)
+                // Linear, not eased: everything else on a toggle snaps, so the
+                // arrow was the lone element with an ease-out landing — that soft
+                // settle read as a "bounce". A short constant-speed flip with a hard
+                // stop has no accel/decel and nothing to settle.
+                .animation(.linear(duration: 0.1), value: isOpen)
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -166,6 +166,10 @@ struct SectionHeader<Trailing: View>: View {
                 .foregroundStyle(Palette.secondaryText)
                 .frame(width: 13)
                 .rotationEffect(.degrees(isOpen ? 90 : 0))
+                // The chevron rotates on its own clean ease — no overshoot — so it
+                // animates independently of the window/layout resize without being
+                // the one thing left bouncing. See RootView.setOpen.
+                .animation(.easeInOut(duration: 0.2), value: isOpen)
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)
@@ -178,7 +182,10 @@ struct SectionHeader<Trailing: View>: View {
         .padding(.horizontal, 9)
         .frame(height: 32)
         .contentShape(Rectangle())
-        .onTapGesture { withAnimation(.snappy(duration: 0.26)) { onToggle() } }
+        // The layout/window resize is animated by RootView.setOpen (it eases on
+        // open but snaps on close, so the window and content never desync and
+        // bounce). The header just reports the toggle.
+        .onTapGesture { onToggle() }
     }
 }
 

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -92,10 +92,12 @@ struct FileRow: View {
     var body: some View {
         HStack(spacing: 6) {
             if node.isDirectory {
-                Text("▸")
-                    .font(.system(size: 13)).frame(width: 13)
-                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    .animation(.snappy(duration: 0.2), value: isExpanded)   // was an instant snap
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold)).frame(width: 13, height: 13)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0), anchor: .center)
+                    // Short constant-speed flip, hard stop — no spring, no ease-out
+                    // settle (which read as a "bounce" on the lone moving element).
+                    .animation(.linear(duration: 0.1), value: isExpanded)
                     .foregroundStyle(isSelected ? .white : Palette.secondaryText)
             } else {
                 Spacer().frame(width: 13)

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -159,6 +159,9 @@ struct RootView: View {
     private func setOpen(_ section: Section, _ open: Bool) {
         // Remember the free-resize height before leaving a scrollable layout.
         if heightLocked == false, let window { expandedHeight = window.frame.height }
+        // Snap the content state — the *window* owns the open/close motion (see
+        // applyWindowSizing). Animating the content here would race the window's
+        // content-pinned min-size and bounce.
         switch section {
         case .worktrees: openWorktrees = open
         case .changes: openChanges = open
@@ -230,11 +233,15 @@ struct RootView: View {
         guard let window else { return }
         let target = targetHeight()
         setHeightLocked(heightLocked, height: target)
-        // Animate growth, but snap any shrink: the content is top-anchored, so an
-        // animated window lags behind the instantly-collapsed headers and flashes
-        // an empty "chin" below the last header until it catches up.
+        // Animate only a grow into a *free* (scrollable) layout — the window glides
+        // open to reveal CHANGES / FILES. Everything else snaps:
+        //  • Shrinks snap, or the top-anchored content flashes an empty "chin" while
+        //    the window lags behind the collapsed headers.
+        //  • Height-locked states are content-pinned (windowResizability is
+        //    .contentMinSize), so an animated frame races the content's min-size and
+        //    bounces. Snapping keeps the window and content in lockstep.
         let shrinking = target < window.frame.height
-        setWindowHeight(target, animated: animated && !shrinking)
+        setWindowHeight(target, animated: animated && !shrinking && !heightLocked)
     }
 
     /// User finished dragging the window edge → remember the new height, but only

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -101,11 +101,8 @@ struct WorktreesSection: View {
             Image(systemName: "shippingbox").font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
             Text(repo.name).font(.system(size: 12.5, weight: .semibold)).lineLimit(1)
             Spacer(minLength: 6)
-            if let active = selector.selectedWorktree {
-                Text(selector.info(for: active).syncText)
-                    .font(.system(size: 11)).monospacedDigit().foregroundStyle(Palette.secondaryText)
-                    .fixedSize()
-            }
+            // The sync indicator belongs on individual worktree rows, not the repo
+            // root — the root isn't itself a branch with an ahead/behind count.
         }
         .padding(.horizontal, 11).frame(height: 25)
     }


### PR DESCRIPTION
## Summary
- Eliminate the disclosure-arrow "bounce" on section open/close by swapping the text ▸ for a centered `chevron.right` symbol rotated about its visual center on a short linear flip (Changes/Files sections).
- Flatten the changes list: drop the in-section commit box and folder grouping in favor of a flat change-row list.
- Show the ahead/behind sync indicator only on individual worktree rows, not next to the repo root (the root isn't itself a branch).

## Testing
- `swift build` ✅
- `swift test` ✅ (120 tests)
- `swiftlint` — not installed locally; runs in CI.