### PR TITLE
Fix accordion bounce + refine section chrome

### DIFF
--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -175,11 +175,12 @@ struct SectionHeader<Trailing: View>: View {
                 .foregroundStyle(Palette.secondaryText)
                 .frame(width: 13, height: 13)
                 .rotationEffect(.degrees(isOpen ? 90 : 0), anchor: .center)
-                // Linear, not eased: everything else on a toggle snaps, so the
-                // arrow was the lone element with an ease-out landing — that soft
-                // settle read as a "bounce". A short constant-speed flip with a hard
-                // stop has no accel/decel and nothing to settle.
-                .animation(.linear(duration: 0.1), value: isOpen)
+                // No animation — snap in lockstep with the window. A section toggle
+                // resizes the window, which SNAPS (setFrame display:true) on close
+                // and on the worktree-only grow; a chevron animating its rotation
+                // against that synchronous snap hitches, and THAT was the residual
+                // "bounce". Snapping the arrow removes it. (Opening CHANGES/FILES
+                // glides the window open; an already-flipped arrow rides along fine.)
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)


### PR DESCRIPTION
## Summary
Follow-up to #12, which already merged the section-toggle bounce fix, the `chevron.right` disclosure glyph, and the section-chrome refinements into `dev`. This PR adds the final piece (one commit):

**Snap the section-header disclosure arrows in lockstep with the window.** The header arrows sit on the window that a section toggle resizes; that resize *snaps* on close and on the content-pinned worktree-only grow, so a chevron animating its rotation against the synchronous snap hitched — the last visible "bounce". Dropping the arrow's own animation makes it flip in lockstep with the window. (Opening CHANGES/FILES glides the window; the already-flipped arrow rides along.) File-tree folder arrows keep their fast linear flip.

Commit: `74b2829`.

## Test
- `swift build` clean.
- `swift test` — 120/120 pass.