### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
-# CD: on a version tag (vX.Y.Z), build a release .app bundle and attach it to a
-# GitHub Release. The bundle is ad-hoc signed only (see scripts/make-app.sh);
-# Developer ID signing + notarization are out of scope until signing certs are
-# wired in as repository secrets.
+# CD: on a version tag (vX.Y.Z), build a release .app bundle, sign a Sparkle
+# appcast, and attach both to a GitHub Release. The bundle is ad-hoc code-signed
+# only (see scripts/make-app.sh); Developer ID signing + notarization are out of
+# scope until signing certs are wired in as repository secrets. Sparkle updates
+# are integrity-signed with an EdDSA key independent of Apple notarization.
 on:
   push:
     tags:
@@ -23,14 +24,44 @@ jobs:
         run: swift --version
 
       - name: Build release .app bundle
-        run: ./scripts/make-app.sh release
+        env:
+          # Sparkle: public key embedded in Info.plist must pair with the private
+          # key used to sign the appcast below. Set as a repo variable/secret.
+          SU_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+        run: |
+          # Stamp the release version into the bundle. CFBundleVersion must
+          # increase per release or Sparkle never sees a newer version.
+          APP_VERSION="${GITHUB_REF_NAME#v}" ./scripts/make-app.sh release
 
-      - name: Zip the app
-        run: ditto -c -k --keepParent teebe.app "teebe-${GITHUB_REF_NAME}.zip"
+      - name: Stage update archive
+        run: |
+          mkdir -p sparkle-updates
+          ditto -c -k --keepParent teebe.app "sparkle-updates/teebe-${GITHUB_REF_NAME}.zip"
+
+      - name: Generate & sign Sparkle appcast
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          GEN="$(find .build/artifacts -name generate_appcast -path '*/bin/*' | head -1)"
+          # Sign update enclosures with the EdDSA private key (read from stdin),
+          # and point download URLs at this release's assets.
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$GEN" \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/klein-t/teebe/releases/download/${GITHUB_REF_NAME}/" \
+            sparkle-updates
+          cp sparkle-updates/teebe-*.zip .
+          cp sparkle-updates/appcast.xml .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: teebe-*.zip
+          # Publish both the app zip and the appcast; SUFeedURL points at
+          # releases/latest/download/appcast.xml so the feed tracks the newest tag.
+          # NOTE: the release is drafted — GitHub's `latest` ignores drafts, so the
+          # appcast URL only resolves once the draft is published. Publishing the
+          # release is the step that actually ships the update to existing users.
+          files: |
+            teebe-*.zip
+            appcast.xml
           generate_release_notes: true
           draft: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,55 @@ first contribution is merged, you must agree to the
 PR that you agree to the CLA. This lets the project stay offerable under both
 licenses.
 
+## Shipping updates (Sparkle)
+
+teebe self-updates via [Sparkle](https://sparkle-project.org). Updates are
+delivered through an **appcast** (`appcast.xml`) published as an asset on each
+GitHub Release; the app's `SUFeedURL` points at
+`releases/latest/download/appcast.xml`, so the feed always reflects the newest
+tag. Each update is integrity-signed with an **EdDSA key** — this is Sparkle's
+own signature and is independent of Apple notarization (which governs
+first-launch Gatekeeper trust, not updates).
+
+### One-time signing-key setup (maintainer)
+
+Sparkle ships a `generate_keys` tool (in the resolved package under
+`.build/artifacts/sparkle/Sparkle/bin/`). Run it once **in your Terminal** (it
+stores the private key in the login Keychain):
+
+```sh
+.build/artifacts/sparkle/Sparkle/bin/generate_keys      # prints the public key
+.build/artifacts/sparkle/Sparkle/bin/generate_keys -x sparkle_private.key   # export for CI
+```
+
+Then add these to the GitHub repo (Settings → Secrets and variables → Actions):
+
+- `SPARKLE_PUBLIC_ED_KEY` — the public key string (embedded in `Info.plist` at
+  build time via `SU_PUBLIC_ED_KEY`).
+- `SPARKLE_ED_PRIVATE_KEY` — the contents of `sparkle_private.key` (used by CI
+  to sign the appcast). Treat it like any signing secret; do not commit it.
+
+Delete `sparkle_private.key` after adding the secret. The private key is the
+root of update trust — if it leaks, rotate it (new keypair, new public key in
+the next release).
+
+### What happens on release
+
+The Release workflow builds the `.app` (stamping the tag as `CFBundleVersion`,
+which is what Sparkle compares to detect a newer version), zips it, runs
+`generate_appcast` (signing each update with the private key), and uploads both
+the zip and `appcast.xml` to a **draft** release.
+
+**Publishing the draft is what ships the update.** `SUFeedURL` points at
+`releases/latest/download/appcast.xml`, and GitHub's `latest` ignores drafts —
+so until you publish the release, existing apps won't see the new `appcast.xml`.
+Once published, existing users get an in-app "Update available" prompt; the menu
+also has **Check for Updates…**.
+
+> Note: until the app is Developer ID-signed and **notarized**, first-time
+> downloads still hit Gatekeeper (right-click → Open). Notarization is separate
+> from Sparkle and tracked independently.
+
 ## Security
 
 Never commit secrets. See [`SECURITY.md`](SECURITY.md) for the reporting policy

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,11 @@ let package = Package(
         .library(name: "TeebeCore", targets: ["TeebeCore"]),
         .executable(name: "Teebe", targets: ["Teebe"]),
     ],
+    dependencies: [
+        // Sparkle: in-app auto-update framework (appcast + EdDSA-signed updates).
+        // App-layer only — TeebeCore stays UI/dependency-free.
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
+    ],
     targets: [
         // Pure, UI-independent core: models, git layer, parsers, services.
         .target(
@@ -18,7 +23,10 @@ let package = Package(
         // SwiftUI app: thin views + @Observable view models. Depends on Core.
         .executableTarget(
             name: "Teebe",
-            dependencies: ["TeebeCore"],
+            dependencies: [
+                "TeebeCore",
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             resources: [.process("Resources")]
         ),
         // Core unit + integration tests (Swift Testing).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ whatever native app you already use.
 > watcher, file ops, write queue) and the app's view models are implemented and
 > tested; the SwiftUI shell is functional and wired (visual design in progress).
 
+## Install
+
+Download the latest `teebe.app` from the
+[Releases](https://github.com/klein-t/teebe/releases) page, unzip it, and drag
+it into `/Applications`. On first launch, right-click the app and choose **Open**
+to get past Gatekeeper. The app keeps itself up to date via Sparkle.
+
+## Uninstall
+
+teebe is a self-contained `.app` with no installer, so removing it is just:
+
+```sh
+# 1. Quit teebe, then delete the app
+rm -rf /Applications/teebe.app
+
+# 2. Remove its saved state (added repos/worktrees, window layout)
+rm -rf ~/Library/Application\ Support/teebe
+
+# 3. Remove Sparkle's auto-update preferences and cache (optional)
+defaults delete dev.teebe.app 2>/dev/null
+rm -rf ~/Library/Caches/dev.teebe.app
+```
+
+teebe never touches your repositories themselves — uninstalling only removes the
+app and its own state.
+
 ## Build & test
 
 ```sh

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -23,6 +23,7 @@ struct TeebeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var app: AppModel
     @State private var preview: PreviewModel
+    @StateObject private var updater = UpdaterController()
 
     init() {
         // One shared environment, constructed exactly once.
@@ -39,6 +40,12 @@ struct TeebeApp: App {
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
+        .commands {
+            // Standard "Check for Updates…" item, placed in the app menu next to About.
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesCommand(updater: updater)
+            }
+        }
 
         // Separate floating Quick Look panel (D4 / PRD §5.2).
         Window("Quick Look", id: "preview") {

--- a/Sources/Teebe/Updater.swift
+++ b/Sources/Teebe/Updater.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Sparkle
+
+/// Wraps Sparkle's standard updater so the app can check for and install updates
+/// in place (appcast + EdDSA-signed deltas). The updater reads `SUFeedURL` and
+/// `SUPublicEDKey` from the bundle's `Info.plist` (see `scripts/make-app.sh`).
+///
+/// `startingUpdater: true` lets Sparkle schedule its own background checks per
+/// the user's preference; the menu command below drives a manual check.
+@MainActor
+final class UpdaterController: ObservableObject {
+    private let controller: SPUStandardUpdaterController
+
+    /// Mirrors `canCheckForUpdates` so the menu item disables itself while a
+    /// check is already in flight.
+    @Published var canCheckForUpdates = false
+
+    init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        controller.updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+
+    func checkForUpdates() {
+        controller.updater.checkForUpdates()
+    }
+}
+
+/// "Check for Updates…" item in the app menu, wired to the shared updater.
+struct CheckForUpdatesCommand: View {
+    @ObservedObject var updater: UpdaterController
+
+    var body: some View {
+        Button("Check for Updates…") { updater.checkForUpdates() }
+            .disabled(!updater.canCheckForUpdates)
+    }
+}

--- a/Sources/Teebe/Views/ChangesSection.swift
+++ b/Sources/Teebe/Views/ChangesSection.swift
@@ -24,12 +24,12 @@ struct ChangesSection: View {
 
             if isOpen {
                 VStack(spacing: 0) {
-                    commitBox
                     ScrollView {
                         changeList
                     }
                     .scrollBounceBehavior(.basedOnSize)
                 }
+                .padding(.top, 8)
                 .padding(.bottom, 6)
                 .transition(.opacity)
             }
@@ -38,68 +38,10 @@ struct ChangesSection: View {
         .clipped()
     }
 
-    private var commitBox: some View {
-        VStack(spacing: 7) {
-            TextField(
-                "Message (⌘↩ to commit on \(app.selector.selectedWorktree?.branch ?? "—"))",
-                text: $worktree.commitMessage,
-                axis: .vertical
-            )
-            .textFieldStyle(.plain)
-            .font(.system(size: 12))
-            .lineLimit(1...3)
-            .padding(.horizontal, 9).padding(.vertical, 7)
-            .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 6))
-            .onSubmit { Task { await worktree.commitPending() } }
-
-            Button {
-                Task { await worktree.commitPending() }
-            } label: {
-                Text(commitLabel)
-                    .font(.system(size: 12.5, weight: .semibold))
-                    .monospacedDigit()
-                    .contentTransition(.numericText())
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 30)
-                    .foregroundStyle(commitEnabled ? .white : Palette.secondaryText)
-                    .background(commitEnabled ? Palette.accent : Color.primary.opacity(0.05),
-                                in: RoundedRectangle(cornerRadius: 6))
-                    .contentShape(RoundedRectangle(cornerRadius: 6))
-            }
-            .buttonStyle(PressableButtonStyle())
-            .disabled(!commitEnabled)
-            .keyboardShortcut(.return, modifiers: .command)   // ⌘↩ (matches the field's placeholder)
-            .animation(.easeOut(duration: 0.2), value: commitEnabled)
-            .animation(.snappy(duration: 0.22), value: worktree.changeCount)
-        }
-        .padding(.horizontal, 11).padding(.top, 8).padding(.bottom, 6)
-    }
-
-    private var commitEnabled: Bool {
-        worktree.changeCount > 0 && !worktree.commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
-    private var commitLabel: String {
-        if worktree.changeCount == 0 { return "✓ Nothing to commit" }
-        if worktree.commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "Enter a message to commit" }
-        return "Commit \(worktree.changeCount) change\(worktree.changeCount == 1 ? "" : "s")"
-    }
-
     private var changeList: some View {
         VStack(spacing: 0) {
-            ForEach(worktree.changeGroups) { group in
-                if !group.folder.isEmpty {
-                    HStack(spacing: 6) {
-                        Text("▾").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).frame(width: 13)
-                        Text(group.folder).font(.system(size: 12.5)).foregroundStyle(.primary)
-                        Spacer()
-                        Circle().fill(Palette.amber).frame(width: 6, height: 6)
-                    }
-                    .padding(.horizontal, 11).padding(.leading, 14).frame(height: 24)
-                }
-                ForEach(group.changes) { change in
-                    changeRow(change, indented: !group.folder.isEmpty)
-                }
+            ForEach(worktree.changes) { change in
+                changeRow(change, indented: false)
             }
             if worktree.changeCount == 0 {
                 Text("No changes")

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -161,15 +161,25 @@ struct SectionHeader<Trailing: View>: View {
 
     var body: some View {
         HStack(spacing: 5) {
-            Text("▸")
-                .font(.system(size: 15))
+            // The native macOS DisclosureGroup glyph: a `chevron.right` is a thin,
+            // doubly-symmetric stroke whose ink centroid coincides with its
+            // bounding-box center, so rotating it about the default `.center` anchor
+            // is a true spin-in-place. A *filled* `arrowtriangle.right.fill` has its
+            // area-centroid 1/3 from the base, NOT at the bbox center, so rotating it
+            // swept the visual mass through an arc — a left/down lurch read as a
+            // "bounce" that survives any easing curve and any glyph SOURCE swap
+            // (text→symbol) because it is geometric, not temporal. A square frame +
+            // explicit `.center` anchor pins the pivot to the glyph's visual center.
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(Palette.secondaryText)
-                .frame(width: 13)
-                .rotationEffect(.degrees(isOpen ? 90 : 0))
-                // The chevron rotates on its own clean ease — no overshoot — so it
-                // animates independently of the window/layout resize without being
-                // the one thing left bouncing. See RootView.setOpen.
-                .animation(.easeInOut(duration: 0.2), value: isOpen)
+                .frame(width: 13, height: 13)
+                .rotationEffect(.degrees(isOpen ? 90 : 0), anchor: .center)
+                // Linear, not eased: everything else on a toggle snaps, so the
+                // arrow was the lone element with an ease-out landing — that soft
+                // settle read as a "bounce". A short constant-speed flip with a hard
+                // stop has no accel/decel and nothing to settle.
+                .animation(.linear(duration: 0.1), value: isOpen)
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -175,11 +175,12 @@ struct SectionHeader<Trailing: View>: View {
                 .foregroundStyle(Palette.secondaryText)
                 .frame(width: 13, height: 13)
                 .rotationEffect(.degrees(isOpen ? 90 : 0), anchor: .center)
-                // Linear, not eased: everything else on a toggle snaps, so the
-                // arrow was the lone element with an ease-out landing — that soft
-                // settle read as a "bounce". A short constant-speed flip with a hard
-                // stop has no accel/decel and nothing to settle.
-                .animation(.linear(duration: 0.1), value: isOpen)
+                // No animation — snap in lockstep with the window. A section toggle
+                // resizes the window, which SNAPS (setFrame display:true) on close
+                // and on the worktree-only grow; a chevron animating its rotation
+                // against that synchronous snap hitches, and THAT was the residual
+                // "bounce". Snapping the arrow removes it. (Opening CHANGES/FILES
+                // glides the window open; an already-flipped arrow rides along fine.)
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -166,6 +166,10 @@ struct SectionHeader<Trailing: View>: View {
                 .foregroundStyle(Palette.secondaryText)
                 .frame(width: 13)
                 .rotationEffect(.degrees(isOpen ? 90 : 0))
+                // The chevron rotates on its own clean ease — no overshoot — so it
+                // animates independently of the window/layout resize without being
+                // the one thing left bouncing. See RootView.setOpen.
+                .animation(.easeInOut(duration: 0.2), value: isOpen)
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)
@@ -178,7 +182,10 @@ struct SectionHeader<Trailing: View>: View {
         .padding(.horizontal, 9)
         .frame(height: 32)
         .contentShape(Rectangle())
-        .onTapGesture { withAnimation(.snappy(duration: 0.26)) { onToggle() } }
+        // The layout/window resize is animated by RootView.setOpen (it eases on
+        // open but snaps on close, so the window and content never desync and
+        // bounce). The header just reports the toggle.
+        .onTapGesture { onToggle() }
     }
 }
 

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -92,10 +92,12 @@ struct FileRow: View {
     var body: some View {
         HStack(spacing: 6) {
             if node.isDirectory {
-                Text("▸")
-                    .font(.system(size: 13)).frame(width: 13)
-                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    .animation(.snappy(duration: 0.2), value: isExpanded)   // was an instant snap
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold)).frame(width: 13, height: 13)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0), anchor: .center)
+                    // Short constant-speed flip, hard stop — no spring, no ease-out
+                    // settle (which read as a "bounce" on the lone moving element).
+                    .animation(.linear(duration: 0.1), value: isExpanded)
                     .foregroundStyle(isSelected ? .white : Palette.secondaryText)
             } else {
                 Spacer().frame(width: 13)

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -159,6 +159,9 @@ struct RootView: View {
     private func setOpen(_ section: Section, _ open: Bool) {
         // Remember the free-resize height before leaving a scrollable layout.
         if heightLocked == false, let window { expandedHeight = window.frame.height }
+        // Snap the content state — the *window* owns the open/close motion (see
+        // applyWindowSizing). Animating the content here would race the window's
+        // content-pinned min-size and bounce.
         switch section {
         case .worktrees: openWorktrees = open
         case .changes: openChanges = open
@@ -230,11 +233,15 @@ struct RootView: View {
         guard let window else { return }
         let target = targetHeight()
         setHeightLocked(heightLocked, height: target)
-        // Animate growth, but snap any shrink: the content is top-anchored, so an
-        // animated window lags behind the instantly-collapsed headers and flashes
-        // an empty "chin" below the last header until it catches up.
+        // Animate only a grow into a *free* (scrollable) layout — the window glides
+        // open to reveal CHANGES / FILES. Everything else snaps:
+        //  • Shrinks snap, or the top-anchored content flashes an empty "chin" while
+        //    the window lags behind the collapsed headers.
+        //  • Height-locked states are content-pinned (windowResizability is
+        //    .contentMinSize), so an animated frame races the content's min-size and
+        //    bounces. Snapping keeps the window and content in lockstep.
         let shrinking = target < window.frame.height
-        setWindowHeight(target, animated: animated && !shrinking)
+        setWindowHeight(target, animated: animated && !shrinking && !heightLocked)
     }
 
     /// User finished dragging the window edge → remember the new height, but only

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -101,11 +101,8 @@ struct WorktreesSection: View {
             Image(systemName: "shippingbox").font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
             Text(repo.name).font(.system(size: 12.5, weight: .semibold)).lineLimit(1)
             Spacer(minLength: 6)
-            if let active = selector.selectedWorktree {
-                Text(selector.info(for: active).syncText)
-                    .font(.system(size: 11)).monospacedDigit().foregroundStyle(Palette.secondaryText)
-                    .fixedSize()
-            }
+            // The sync indicator belongs on individual worktree rows, not the repo
+            // root — the root isn't itself a branch with an ahead/behind count.
         }
         .padding(.horizontal, 11).frame(height: 25)
     }

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,42 @@
+# Third-party licenses
+
+teebe bundles the following third-party components. Their license notices are
+reproduced here as required.
+
+## Sparkle
+
+In-app software update framework. <https://sparkle-project.org>
+
+Licensed under the MIT License.
+
+```
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+Sparkle additionally bundles permissively licensed components (e.g. `bsdiff`
+under a BSD-style license and an Ed25519 implementation). See the Sparkle
+distribution for their full notices.

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.1.0}"
+APP_VERSION="${APP_VERSION:-0.2.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -8,15 +8,35 @@ CONFIG="${1:-debug}"   # debug | release
 APP="teebe.app"
 LOGO="Sources/Teebe/Resources/teebe-logo.png"
 
+# Version stamped into the bundle. CFBundleVersion is what Sparkle's comparator
+# uses to decide whether an update is newer, so it MUST increase per release —
+# CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
+# every release look identical and Sparkle would never offer an update.
+APP_VERSION="${APP_VERSION:-0.1.0}"
+BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
+
+# Sparkle auto-update config. Override via env in CI; the public key pairs with
+# the EdDSA private key used to sign updates (see CONTRIBUTING.md). The feed
+# points at the appcast published alongside each GitHub Release.
+SU_FEED_URL="${SU_FEED_URL:-https://github.com/klein-t/teebe/releases/latest/download/appcast.xml}"
+SU_PUBLIC_ED_KEY="${SU_PUBLIC_ED_KEY:-REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY}"
+
 echo "==> swift build -c $CONFIG"
 swift build -c "$CONFIG"
 
-BIN="$(swift build -c "$CONFIG" --show-bin-path)/Teebe"
+BINDIR="$(swift build -c "$CONFIG" --show-bin-path)"
+BIN="$BINDIR/Teebe"
 
 echo "==> assembling $APP"
 rm -rf "$APP"
-mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp "$BIN" "$APP/Contents/MacOS/teebe"
+
+# Embed Sparkle.framework (SwiftPM stages it next to the binary) and point the
+# executable's runtime search path at the bundle's Frameworks dir.
+echo "==> embedding Sparkle.framework"
+cp -R "$BINDIR/Sparkle.framework" "$APP/Contents/Frameworks/"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/teebe" 2>/dev/null || true
 
 # Build a multi-resolution AppIcon.icns from the logo so it shows in Finder,
 # the Dock, and the app switcher.
@@ -31,7 +51,7 @@ if [[ -f "$LOGO" ]]; then
   iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/AppIcon.icns"
 fi
 
-cat > "$APP/Contents/Info.plist" <<'PLIST'
+cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -42,16 +62,22 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
   <key>CFBundleExecutable</key><string>teebe</string>
   <key>CFBundleIconFile</key><string>AppIcon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.1.0</string>
-  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleShortVersionString</key><string>${APP_VERSION}</string>
+  <key>CFBundleVersion</key><string>${BUILD_NUMBER}</string>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSPrincipalClass</key><string>NSApplication</string>
   <key>NSHighResolutionCapable</key><true/>
+  <key>SUFeedURL</key><string>${SU_FEED_URL}</string>
+  <key>SUPublicEDKey</key><string>${SU_PUBLIC_ED_KEY}</string>
+  <key>SUEnableAutomaticChecks</key><true/>
 </dict>
 </plist>
 PLIST
 
-# Ad-hoc sign so macOS is happy launching it locally.
+# Ad-hoc sign so macOS is happy launching it locally. Sign the embedded
+# framework first (inside-out), then the app. Real distribution replaces "-"
+# with a Developer ID identity + notarization (see CONTRIBUTING.md).
+codesign --force --deep --sign - "$APP/Contents/Frameworks/Sparkle.framework" >/dev/null 2>&1 || true
 codesign --force --deep --sign - "$APP" >/dev/null 2>&1 || true
 
 echo "==> built $APP"


### PR DESCRIPTION
First tagged release. Brings all dev work onto main: section accordion fixes, section chrome refinements, sync-indicator scoping, Sparkle auto-updates, and the v0.2.0 version bump.

After merge: tag v0.2.0 on main to trigger the Release workflow, then publish the drafted GitHub Release.