### PR TITLE
Ignore local screenshot captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ CLAUDE.md
 *_FINDINGS.md
 .agents/
 skills-lock.json
+
+# Local screenshots / scratch captures — never committed (assets/ is tracked).
+Screenshot*.png
+Screenshot*.jpeg


### PR DESCRIPTION
Adds `Screenshot*.png` / `Screenshot*.jpeg` to .gitignore so ad-hoc screen captures dropped in the repo root are never committed. `assets/` PNGs stay tracked.