### PR TITLE
Release v0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ CLAUDE.md
 *_FINDINGS.md
 .agents/
 skills-lock.json
+
+# Local screenshots / scratch captures — never committed (assets/ is tracked).
+Screenshot*.png
+Screenshot*.jpeg

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 A native macOS file browser built for the multi-agent era.
 
+Gave up on your IDE and you're just vibecoding from the terminal? That's exactly
+who teebe is for. Your agents and your shell stay front and center; teebe is the
+window beside them that shows what they're touching, file by file, as it happens.
+
 When you have several AI coding agents (Claude Code, Codex/CMAX, etc.) working in
 parallel across git worktrees, **teebe** is the calm control room that shows
 you, across all your repos and worktrees, what files exist and what's changing.
 It does not replace your editor: it's the navigator that launches files into
 whatever native app you already use.
-
-Gave up on your IDE and you're just vibecoding from the terminal? That's exactly
-who teebe is for. Your agents and your shell stay front and center; teebe is the
-window beside them that shows what they're touching, file by file, as it happens.
 
 <p align="center">
   <img src="assets/teebe-overview.png" alt="teebe showing a worktree's files alongside an inline diff" width="760">

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -32,14 +32,15 @@ rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp "$BIN" "$APP/Contents/MacOS/teebe"
 
-# Copy the SwiftPM resource bundle(s) into the app. `Bundle.module` resolves via
-# Bundle.main.resourceURL (Contents/Resources) at runtime, so without this the
-# packaged app fatal-errors on launch ("could not load resource bundle"). SwiftPM
-# stages each as <Product>_<Target>.bundle next to the built binary.
-echo "==> copying SwiftPM resource bundles"
+# Copy the SwiftPM resource bundle(s) into the app. The generated accessor
+# resolves `Bundle.module` from `Bundle.main.bundleURL/<Product>_<Target>.bundle`
+# — which for a wrapped .app is the bundle ROOT (teebe.app/Teebe_Teebe.bundle),
+# NOT Contents/Resources. Without it here the packaged app fatal-errors on launch
+# ("could not load resource bundle"). SwiftPM stages each bundle next to the binary.
+echo "==> copying SwiftPM resource bundles to app root"
 shopt -s nullglob
 for b in "$BINDIR"/*.bundle; do
-  cp -R "$b" "$APP/Contents/Resources/"
+  cp -R "$b" "$APP/"
 done
 shopt -u nullglob
 

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.2.1}"
+APP_VERSION="${APP_VERSION:-0.2.2}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with
@@ -31,6 +31,17 @@ echo "==> assembling $APP"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp "$BIN" "$APP/Contents/MacOS/teebe"
+
+# Copy the SwiftPM resource bundle(s) into the app. `Bundle.module` resolves via
+# Bundle.main.resourceURL (Contents/Resources) at runtime, so without this the
+# packaged app fatal-errors on launch ("could not load resource bundle"). SwiftPM
+# stages each as <Product>_<Target>.bundle next to the built binary.
+echo "==> copying SwiftPM resource bundles"
+shopt -s nullglob
+for b in "$BINDIR"/*.bundle; do
+  cp -R "$b" "$APP/Contents/Resources/"
+done
+shopt -u nullglob
 
 # Embed Sparkle.framework (SwiftPM stages it next to the binary) and point the
 # executable's runtime search path at the bundle's Frameworks dir.


### PR DESCRIPTION
Patch release — fixes the packaged-app launch crash.

- Copy the SwiftPM resource bundle to the .app root so Bundle.module resolves it (#22, #24). v0.2.0/v0.2.1 packaged builds were unlaunchable.
- Version 0.2.2.