### PR TITLE
Resolve resource bundle without Bundle.module (fix launch crash)

### DIFF
--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -8,9 +8,27 @@ enum Brand {
 
     /// The teebe logo, loaded once from the app bundle. Used for the empty state
     /// and the Dock / app icon.
-    static let logo: NSImage? = Bundle.module
+    static let logo: NSImage? = resourceBundle?
         .url(forResource: "teebe-logo", withExtension: "png")
         .flatMap(NSImage.init(contentsOf:))
+
+    /// Locate the SwiftPM resource bundle (`Teebe_Teebe.bundle`) across run modes.
+    /// We deliberately avoid `Bundle.module`: its generated accessor only checks
+    /// the app *root* (`Bundle.main.bundleURL/Teebe_Teebe.bundle`) plus a hardcoded
+    /// build path, and **fatal-errors** when neither exists. A code-signed `.app`
+    /// can't keep resources at its root (codesign requires everything under
+    /// `Contents/`), so in a packaged build the bundle lives in `Contents/Resources/`.
+    /// Probe both that and the dir next to the executable (`swift run`).
+    private static let resourceBundle: Bundle? = {
+        let bundleName = "Teebe_Teebe.bundle"
+        let roots = [Bundle.main.resourceURL, Bundle.main.bundleURL].compactMap { $0 }
+        for root in roots {
+            let candidate = root.appendingPathComponent(bundleName)
+            if let bundle = Bundle(url: candidate) { return bundle }
+        }
+        // Fall back to the main bundle itself (resources copied in flat).
+        return Bundle.main
+    }()
 }
 
 /// Shared color palette.

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -32,15 +32,15 @@ rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp "$BIN" "$APP/Contents/MacOS/teebe"
 
-# Copy the SwiftPM resource bundle(s) into the app. The generated accessor
-# resolves `Bundle.module` from `Bundle.main.bundleURL/<Product>_<Target>.bundle`
-# — which for a wrapped .app is the bundle ROOT (teebe.app/Teebe_Teebe.bundle),
-# NOT Contents/Resources. Without it here the packaged app fatal-errors on launch
-# ("could not load resource bundle"). SwiftPM stages each bundle next to the binary.
-echo "==> copying SwiftPM resource bundles to app root"
+# Copy the SwiftPM resource bundle(s) into Contents/Resources. They MUST live
+# under Contents/ — a code-signed .app rejects "unsealed contents in the bundle
+# root", so the bundle can't sit at the app root (where Bundle.module would look).
+# The app's Brand.resourceBundle probes Contents/Resources for them at runtime.
+# SwiftPM stages each as <Product>_<Target>.bundle next to the built binary.
+echo "==> copying SwiftPM resource bundles into Contents/Resources"
 shopt -s nullglob
 for b in "$BINDIR"/*.bundle; do
-  cp -R "$b" "$APP/"
+  cp -R "$b" "$APP/Contents/Resources/"
 done
 shopt -u nullglob
 


### PR DESCRIPTION
## Root cause
`Brand.logo` loaded its resource via `Bundle.module`. The generated accessor only probes the app **root** (`Bundle.main.bundleURL/Teebe_Teebe.bundle`) + a hardcoded build path, and **fatal-errors** otherwise — so the packaged app crashed on launch (v0.2.0–v0.2.2).

The earlier attempts (#22 Contents/Resources, #24/#27 app root) couldn't win: a code-signed `.app` rejects *'unsealed contents in the bundle root'*, so there's **no** placement `Bundle.module` accepts in a signed app.

## Fix
- Resolve the bundle ourselves (`Brand.resourceBundle`) from `Contents/Resources` (packaged) or next to the executable (`swift run`) — never tripping the `Bundle.module` fatalError.
- Package the bundle into `Contents/Resources/` where codesign is happy.

## Verified
- `swift build` + 120 tests pass
- `codesign --verify --deep --strict` passes
- `.app` launches cleanly from a directory with no `.build/` sibling

Note: resource resolution can't be faithfully unit-tested (test host's `Bundle.main` differs from a packaged app), so verification is the codesign + clean-launch checks above.