### PR TITLE
Ship v0.2.2 (resolve resource bundle, fix launch crash)

### DIFF
--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -8,9 +8,27 @@ enum Brand {
 
     /// The teebe logo, loaded once from the app bundle. Used for the empty state
     /// and the Dock / app icon.
-    static let logo: NSImage? = Bundle.module
+    static let logo: NSImage? = resourceBundle?
         .url(forResource: "teebe-logo", withExtension: "png")
         .flatMap(NSImage.init(contentsOf:))
+
+    /// Locate the SwiftPM resource bundle (`Teebe_Teebe.bundle`) across run modes.
+    /// We deliberately avoid `Bundle.module`: its generated accessor only checks
+    /// the app *root* (`Bundle.main.bundleURL/Teebe_Teebe.bundle`) plus a hardcoded
+    /// build path, and **fatal-errors** when neither exists. A code-signed `.app`
+    /// can't keep resources at its root (codesign requires everything under
+    /// `Contents/`), so in a packaged build the bundle lives in `Contents/Resources/`.
+    /// Probe both that and the dir next to the executable (`swift run`).
+    private static let resourceBundle: Bundle? = {
+        let bundleName = "Teebe_Teebe.bundle"
+        let roots = [Bundle.main.resourceURL, Bundle.main.bundleURL].compactMap { $0 }
+        for root in roots {
+            let candidate = root.appendingPathComponent(bundleName)
+            if let bundle = Bundle(url: candidate) { return bundle }
+        }
+        // Fall back to the main bundle itself (resources copied in flat).
+        return Bundle.main
+    }()
 }
 
 /// Shared color palette.

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -32,15 +32,15 @@ rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp "$BIN" "$APP/Contents/MacOS/teebe"
 
-# Copy the SwiftPM resource bundle(s) into the app. The generated accessor
-# resolves `Bundle.module` from `Bundle.main.bundleURL/<Product>_<Target>.bundle`
-# — which for a wrapped .app is the bundle ROOT (teebe.app/Teebe_Teebe.bundle),
-# NOT Contents/Resources. Without it here the packaged app fatal-errors on launch
-# ("could not load resource bundle"). SwiftPM stages each bundle next to the binary.
-echo "==> copying SwiftPM resource bundles to app root"
+# Copy the SwiftPM resource bundle(s) into Contents/Resources. They MUST live
+# under Contents/ — a code-signed .app rejects "unsealed contents in the bundle
+# root", so the bundle can't sit at the app root (where Bundle.module would look).
+# The app's Brand.resourceBundle probes Contents/Resources for them at runtime.
+# SwiftPM stages each as <Product>_<Target>.bundle next to the built binary.
+echo "==> copying SwiftPM resource bundles into Contents/Resources"
 shopt -s nullglob
 for b in "$BINDIR"/*.bundle; do
-  cp -R "$b" "$APP/"
+  cp -R "$b" "$APP/Contents/Resources/"
 done
 shopt -u nullglob
 


### PR DESCRIPTION
Brings `main` in line with `dev` (#28). Fixes the packaged-app launch crash: resolve `Teebe_Teebe.bundle` from `Contents/Resources` (codesign-valid) rather than `Bundle.module` (which fatal-errors unless the bundle is at the app root, where codesign rejects it).

Branched off `main` because linear-history protection blocks squash-merging the diverged `dev`. Resulting files are byte-identical to `dev`. Verified locally: codesign --verify --deep --strict passes; app launches from a clean dir.