### PR TITLE
Quick wins: Dock icon, updater start, sticky error

### DIFF
--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -10,7 +10,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
     }
     func applicationDidFinishLaunching(_ notification: Notification) {
-        if let logo = Brand.logo { NSApp.applicationIconImage = logo }   // Dock / app-switcher icon
+        // Don't override `applicationIconImage`: that replaces the bundle's
+        // `AppIcon.icns` (which macOS masks into the rounded squircle with depth)
+        // with the raw full-bleed PNG, so the running app's Dock icon goes flat.
+        // Leaving it unset lets the system icon render correctly while running too.
         NSApp.activate(ignoringOtherApps: true)
     }
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -9,7 +9,11 @@ import TeebeCore
 final class AppModel {
     private(set) var repositories: [Repository] = []
     var floatOnTop: Bool { didSet { persist() } }
-    var errorMessage: String?
+    private(set) var errorMessage: String?
+
+    /// Auto-dismiss timer for the current error banner, so a transient failure
+    /// (e.g. "Not a git repository") never sticks around indefinitely.
+    @ObservationIgnored private var errorClearTask: Task<Void, Never>?
 
     let environment: AppEnvironment
     let selector: SelectorModel
@@ -18,8 +22,25 @@ final class AppModel {
         self.environment = environment
         self.selector = SelectorModel(environment: environment)
         self.floatOnTop = false
-        // Persist whenever the selection changes so the app reopens where it was left.
-        self.selector.onSelectionChange = { [weak self] in self?.persist() }
+        // Persist whenever the selection changes, and clear any stale global error —
+        // navigating to a different repo/worktree should dismiss the banner.
+        self.selector.onSelectionChange = { [weak self] in
+            self?.persist()
+            self?.setError(nil)
+        }
+    }
+
+    /// Single entry point for the global error banner. Replaces any existing
+    /// message and (re)arms a timer that clears it, so it can't get stuck.
+    func setError(_ message: String?) {
+        errorMessage = message
+        errorClearTask?.cancel()
+        guard message != nil else { return }
+        errorClearTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(6))
+            guard !Task.isCancelled else { return }
+            self?.errorMessage = nil
+        }
     }
 
     /// Load persisted state and hydrate repositories + selection.
@@ -47,11 +68,12 @@ final class AppModel {
         // Canonicalize (tilde + realpath) so it matches the paths git reports for
         // worktrees (firmlink /var → /private/var), avoiding duplicate/mismatched entries.
         let standardized = PathUtil.standardized((path as NSString).expandingTildeInPath)
+        setError(nil)   // a fresh attempt clears any stale banner
         guard !repositories.contains(where: { $0.path == standardized }) else { return false }
         do {
             _ = try await environment.git.worktrees(repoPath: standardized)
         } catch {
-            errorMessage = "Not a git repository: \(standardized)"
+            setError("Not a git repository: \(standardized)")
             return false
         }
         let repo = Repository(path: standardized)
@@ -78,9 +100,9 @@ final class AppModel {
         guard !node.isDirectory else { return }
         do {
             try environment.opener.open(URL(fileURLWithPath: node.path))
-            errorMessage = nil
+            setError(nil)
         } catch {
-            errorMessage = "Couldn't open \(node.name)"
+            setError("Couldn't open \(node.name)")
         }
     }
 
@@ -139,7 +161,7 @@ final class AppModel {
             selector.worktree.noteSelfWrite()
             Task { await selector.worktree.refresh() }
         } catch {
-            errorMessage = "File operation failed: \(WorktreeModel.describe(error))"
+            setError("File operation failed: \(WorktreeModel.describe(error))")
         }
     }
 

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -43,6 +43,68 @@ struct AppModelTests {
         #expect(app.repositories.isEmpty)
         #expect(app.selector.selectedRepo == nil)
     }
+
+    @Test("a stale error clears when a fresh add attempt succeeds")
+    func errorClearsOnNewAdd() async {
+        let git = FakeGitClient()
+        git.worktreesError = .notAGitRepository(path: "/x")
+        let app = AppModel(environment: makeTestEnvironment(git: git))
+
+        _ = await app.addRepository(path: "/x")
+        #expect(app.errorMessage != nil)
+
+        git.worktreesError = nil
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        _ = await app.addRepository(path: "/repo")
+        #expect(app.errorMessage == nil)
+    }
+
+    @Test("selecting a repo dismisses a stale global error")
+    func errorClearsOnSelection() async {
+        let git = FakeGitClient()
+        git.worktreesError = .notAGitRepository(path: "/x")
+        let app = AppModel(environment: makeTestEnvironment(git: git))
+
+        _ = await app.addRepository(path: "/x")
+        #expect(app.errorMessage != nil)
+
+        git.worktreesError = nil
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        await app.selector.selectRepo(Repository(path: "/repo"))
+        #expect(app.errorMessage == nil)
+    }
+}
+
+@MainActor
+@Suite("UpdaterController configuration")
+struct UpdaterConfigTests {
+    /// A valid Sparkle EdDSA public key is 32 random bytes, base64-encoded.
+    private var validKey: String { Data(repeating: 7, count: 32).base64EncodedString() }
+    private let feed = "https://example.com/appcast.xml"
+
+    @Test("the make-app.sh placeholder key is rejected")
+    func placeholderRejected() {
+        #expect(!UpdaterController.isConfigured(publicKey: UpdaterController.placeholderKey, feedURL: feed))
+    }
+
+    @Test("a missing or empty key/feed is rejected")
+    func missingRejected() {
+        #expect(!UpdaterController.isConfigured(publicKey: nil, feedURL: feed))
+        #expect(!UpdaterController.isConfigured(publicKey: "", feedURL: feed))
+        #expect(!UpdaterController.isConfigured(publicKey: validKey, feedURL: nil))
+        #expect(!UpdaterController.isConfigured(publicKey: validKey, feedURL: ""))
+    }
+
+    @Test("a malformed (non-32-byte) key is rejected")
+    func malformedRejected() {
+        #expect(!UpdaterController.isConfigured(publicKey: "not-base64!!", feedURL: feed))
+        #expect(!UpdaterController.isConfigured(publicKey: Data(repeating: 1, count: 16).base64EncodedString(), feedURL: feed))
+    }
+
+    @Test("a real key + feed is accepted")
+    func validAccepted() {
+        #expect(UpdaterController.isConfigured(publicKey: validKey, feedURL: feed))
+    }
 }
 
 @MainActor

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -76,38 +76,6 @@ struct AppModelTests {
 }
 
 @MainActor
-@Suite("UpdaterController configuration")
-struct UpdaterConfigTests {
-    /// A valid Sparkle EdDSA public key is 32 random bytes, base64-encoded.
-    private var validKey: String { Data(repeating: 7, count: 32).base64EncodedString() }
-    private let feed = "https://example.com/appcast.xml"
-
-    @Test("the make-app.sh placeholder key is rejected")
-    func placeholderRejected() {
-        #expect(!UpdaterController.isConfigured(publicKey: UpdaterController.placeholderKey, feedURL: feed))
-    }
-
-    @Test("a missing or empty key/feed is rejected")
-    func missingRejected() {
-        #expect(!UpdaterController.isConfigured(publicKey: nil, feedURL: feed))
-        #expect(!UpdaterController.isConfigured(publicKey: "", feedURL: feed))
-        #expect(!UpdaterController.isConfigured(publicKey: validKey, feedURL: nil))
-        #expect(!UpdaterController.isConfigured(publicKey: validKey, feedURL: ""))
-    }
-
-    @Test("a malformed (non-32-byte) key is rejected")
-    func malformedRejected() {
-        #expect(!UpdaterController.isConfigured(publicKey: "not-base64!!", feedURL: feed))
-        #expect(!UpdaterController.isConfigured(publicKey: Data(repeating: 1, count: 16).base64EncodedString(), feedURL: feed))
-    }
-
-    @Test("a real key + feed is accepted")
-    func validAccepted() {
-        #expect(UpdaterController.isConfigured(publicKey: validKey, feedURL: feed))
-    }
-}
-
-@MainActor
 @Suite("SelectorModel")
 struct SelectorModelTests {
     @Test("selecting a repo loads worktrees + branches and focuses primary")


### PR DESCRIPTION
Three independent quick fixes (tickets 1–3 from the scoping pass).

## 1. Dock icon goes flat while running
The launch handler overrode `applicationIconImage` with the raw full-bleed logo PNG, replacing the bundle's masked `AppIcon.icns`. Removed the override so macOS renders the proper squircle/depth icon whether the app is closed or running.

## 2. "The updater failed to start"
Dev/unsigned builds ship the `make-app.sh` placeholder `SUPublicEDKey`, which makes Sparkle fail to start when the user picks Check for Updates. Now validate the key (real 32-byte EdDSA key) + feed URL up front; if absent/placeholder/malformed the updater isn't started and the menu item stays disabled instead of throwing the error dialog. Released builds (real key injected by CI) are unaffected.

## 3. Sticky "Not a git repository" banner
`AppModel.errorMessage` was only cleared on a successful op, so a failed repo-add lingered indefinitely. Routed it through a setter that clears on each fresh add attempt and on selection change, and auto-dismisses after 6s.

Tests added for the updater config gate and the error-clearing behavior. `swift build` + `swift test` (126 passing) green locally; SwiftLint not installed locally (line_length disabled in config, no new violations).