### PR TITLE
Host Sparkle appcast on teebe.io

### DIFF
--- a/.github/workflows/publish-appcast.yml
+++ b/.github/workflows/publish-appcast.yml
@@ -6,8 +6,10 @@ name: Publish appcast
 # version. The .app zip enclosures the appcast points at stay on GitHub Releases;
 # only the feed XML lives on our domain.
 #
-# Requires a repo secret SITE_DEPLOY_TOKEN: a fine-grained PAT scoped to the
-# klein-t/teebe-site repo with Contents: read and write.
+# Requires a repo secret SITE_DEPLOY_KEY: the private half of an SSH deploy key
+# whose public half is installed on klein-t/teebe-site with write access. A
+# deploy key is scoped to that one repo and is not tied to a user account, so its
+# blast radius is exactly "can push to teebe-site" and nothing else.
 on:
   release:
     types: [published]
@@ -34,7 +36,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: klein-t/teebe-site
-          token: ${{ secrets.SITE_DEPLOY_TOKEN }}
+          ssh-key: ${{ secrets.SITE_DEPLOY_KEY }}
           path: site
 
       - name: Commit appcast if changed

--- a/.github/workflows/publish-appcast.yml
+++ b/.github/workflows/publish-appcast.yml
@@ -1,0 +1,54 @@
+name: Publish appcast
+
+# When a GitHub Release is published (the manual draft -> publish step that ships
+# an update), copy that release's signed appcast.xml into the teebe-site repo so
+# Sparkle's feed at https://teebe.io/appcast.xml tracks the newest published
+# version. The .app zip enclosures the appcast points at stay on GitHub Releases;
+# only the feed XML lives on our domain.
+#
+# Requires a repo secret SITE_DEPLOY_TOKEN: a fine-grained PAT scoped to the
+# klein-t/teebe-site repo with Contents: read and write.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Push appcast.xml to teebe-site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download appcast.xml from the published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'appcast.xml' --output appcast.xml --clobber
+          echo "Downloaded appcast.xml for $TAG:"
+          cat appcast.xml
+
+      - name: Check out teebe-site
+        uses: actions/checkout@v7
+        with:
+          repository: klein-t/teebe-site
+          token: ${{ secrets.SITE_DEPLOY_TOKEN }}
+          path: site
+
+      - name: Commit appcast if changed
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          cp appcast.xml site/appcast.xml
+          cd site
+          if git diff --quiet -- appcast.xml; then
+            echo "appcast.xml unchanged; nothing to publish."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add appcast.xml
+          git commit -m "Publish Sparkle appcast for ${TAG}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,12 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          # Publish both the app zip and the appcast; SUFeedURL points at
-          # releases/latest/download/appcast.xml so the feed tracks the newest tag.
-          # NOTE: the release is drafted — GitHub's `latest` ignores drafts, so the
-          # appcast URL only resolves once the draft is published. Publishing the
-          # release is the step that actually ships the update to existing users.
+          # Attach both the app zip and the signed appcast to the release. The zip
+          # is the update enclosure (stays on GitHub Releases); the appcast.xml is
+          # the source the publish-appcast workflow copies to teebe.io on publish.
+          # NOTE: the release is drafted. SUFeedURL points at https://teebe.io/
+          # appcast.xml, which is only updated when the draft is published (that
+          # fires publish-appcast). Publishing is what actually ships the update.
           files: |
             teebe-*.zip
             appcast.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,12 @@ licenses.
 ## Shipping updates (Sparkle)
 
 teebe self-updates via [Sparkle](https://sparkle-project.org). Updates are
-delivered through an **appcast** (`appcast.xml`) published as an asset on each
-GitHub Release; the app's `SUFeedURL` points at
-`releases/latest/download/appcast.xml`, so the feed always reflects the newest
-tag. Each update is integrity-signed with an **EdDSA key** — this is Sparkle's
-own signature and is independent of Apple notarization (which governs
+delivered through an **appcast** (`appcast.xml`). The app's `SUFeedURL` points at
+**`https://teebe.io/appcast.xml`** — hosted on our own domain (the `teebe-site`
+GitHub Pages repo) so the feed URL baked into shipped binaries is
+host-independent. The appcast's `.app` zip enclosures still live on GitHub
+Releases. Each update is integrity-signed with an **EdDSA key** — this is
+Sparkle's own signature and is independent of Apple notarization (which governs
 first-launch Gatekeeper trust, not updates).
 
 ### One-time signing-key setup (maintainer)
@@ -97,11 +98,17 @@ which is what Sparkle compares to detect a newer version), zips it, runs
 `generate_appcast` (signing each update with the private key), and uploads both
 the zip and `appcast.xml` to a **draft** release.
 
-**Publishing the draft is what ships the update.** `SUFeedURL` points at
-`releases/latest/download/appcast.xml`, and GitHub's `latest` ignores drafts —
-so until you publish the release, existing apps won't see the new `appcast.xml`.
-Once published, existing users get an in-app "Update available" prompt; the menu
-also has **Check for Updates…**.
+**Publishing the draft is what ships the update.** Publishing fires the
+`publish-appcast` workflow, which pushes that release's signed `appcast.xml` into
+the `teebe-site` repo so it's served at `https://teebe.io/appcast.xml` (where
+`SUFeedURL` points). Until you publish, the appcast on teebe.io still points at
+the previous release, so existing apps see nothing new. Once published, existing
+users get an in-app "Update available" prompt; the menu also has **Check for
+Updates…**.
+
+> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_TOKEN`** — a
+> fine-grained PAT scoped to `klein-t/teebe-site` with *Contents: read and write*
+> — so CI can commit the appcast to that repo.
 
 > Note: until the app is Developer ID-signed and **notarized**, first-time
 > downloads still hit Gatekeeper (right-click → Open). Notarization is separate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,13 @@ the previous release, so existing apps see nothing new. Once published, existing
 users get an in-app "Update available" prompt; the menu also has **Check for
 Updates…**.
 
-> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_TOKEN`** — a
-> fine-grained PAT scoped to `klein-t/teebe-site` with *Contents: read and write*
-> — so CI can commit the appcast to that repo.
+> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_KEY`** — the
+> private half of an SSH **deploy key** whose public half is installed on
+> `klein-t/teebe-site` with write access. A deploy key is scoped to that single
+> repo and isn't tied to a personal account, so a leak can only push to
+> teebe-site and nothing else. To rotate: delete the deploy key on teebe-site,
+> generate a new `ed25519` keypair, add the public half as a write deploy key,
+> and replace the `SITE_DEPLOY_KEY` secret with the new private half.
 
 > Note: until the app is Developer ID-signed and **notarized**, first-time
 > downloads still hit Gatekeeper (right-click → Open). Notarization is separate

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -16,9 +16,12 @@ APP_VERSION="${APP_VERSION:-0.2.2}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with
-# the EdDSA private key used to sign updates (see CONTRIBUTING.md). The feed
-# points at the appcast published alongside each GitHub Release.
-SU_FEED_URL="${SU_FEED_URL:-https://github.com/klein-t/teebe/releases/latest/download/appcast.xml}"
+# the EdDSA private key used to sign updates (see CONTRIBUTING.md). The feed is
+# hosted on our own domain (teebe.io, served by the teebe-site GitHub Pages repo)
+# so the URL baked into shipped binaries is host-independent. The .app zip
+# enclosures it references still live on GitHub Releases. The publish-appcast
+# workflow pushes each published release's appcast.xml to teebe-site.
+SU_FEED_URL="${SU_FEED_URL:-https://teebe.io/appcast.xml}"
 SU_PUBLIC_ED_KEY="${SU_PUBLIC_ED_KEY:-REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY}"
 
 echo "==> swift build -c $CONFIG"


### PR DESCRIPTION
## What
Move the Sparkle update **feed** to our own domain: `SUFeedURL` now points at **https://teebe.io/appcast.xml** (served by the `teebe-site` GitHub Pages repo) instead of a GitHub Releases URL. The `.app` zip enclosures the appcast references stay on GitHub Releases.

## Why
The feed URL is baked into every shipped binary and can't be changed for already-installed apps. Hosting it on teebe.io makes it host-independent — we can move hosts or rebrand later without orphaning installed apps. Done now while there are no external users, so there's zero migration risk.

## How
- `make-app.sh`: `SU_FEED_URL` default → `https://teebe.io/appcast.xml`.
- New **publish-appcast** workflow: on `release: published`, download that release's signed `appcast.xml` and commit it into `teebe-site` → served at teebe.io. Keeps the manual draft→publish step as the single 'ship it' trigger.
- `release.yml` still builds/signs/attaches `appcast.xml` to the draft (now the source the publish workflow copies); comments updated.
- CONTRIBUTING updated.

## Action required before this helps a real release
Add repo secret **`SITE_DEPLOY_TOKEN`** — a fine-grained PAT scoped to `klein-t/teebe-site` with *Contents: read and write*. The seed appcast (v0.2.2) is already live at https://teebe.io/appcast.xml.

## Test
No Swift code changed. Shell + YAML syntax validated locally; full build/test runs in CI.