### PR TITLE
Publish stable teebe-macos.zip asset on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
             sparkle-updates
           cp sparkle-updates/teebe-*.zip .
           cp sparkle-updates/appcast.xml .
+          # Also publish a stable, version-independent filename so the website's
+          # download link (releases/latest/download/teebe-macos.zip) stays valid
+          # across every release. Sparkle's appcast still references the versioned
+          # zip in sparkle-updates/; this is just an extra alias for humans.
+          cp "teebe-${GITHUB_REF_NAME}.zip" teebe-macos.zip
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
The website's Download buttons link to
releases/latest/download/teebe-macos.zip — a version-independent URL
that starts the download directly. Emit that stable filename as an
alias alongside the versioned teebe-vX.Y.Z.zip so the link stays valid
on every future release. Sparkle's appcast is unchanged; it still
references the versioned enclosure.
