### PR TITLE
Fix DMG build on CI (PEP 668 externally-managed Python)

### DIFF
--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -23,7 +23,12 @@ HERE="$(cd "$(dirname "$0")/dmg" && pwd)"
 [ -d "$APP" ] || { echo "error: app bundle not found: $APP" >&2; exit 1; }
 
 # dmgbuild is pure-Python; install on demand so this works locally and on CI.
-python3 -c 'import dmgbuild' 2>/dev/null || pip3 install --user --quiet dmgbuild
+# --break-system-packages is needed on PEP 668 "externally managed" Pythons (the
+# Homebrew python3 on GitHub's macOS runners); combined with --user it installs
+# into the user site without touching the system env, and is a harmless no-op on
+# non-managed Pythons.
+python3 -c 'import dmgbuild' 2>/dev/null \
+  || pip3 install --user --quiet --break-system-packages dmgbuild
 
 APP_ABS="$(cd "$(dirname "$APP")" && pwd)/$(basename "$APP")"
 rm -f "$OUT"


### PR DESCRIPTION
The v0.3.0 Release workflow failed at the new "Build drag-install DMG" step (added in #37): `pip3 install --user dmgbuild` is rejected by PEP 668 on the runner's Homebrew Python (`externally-managed-environment`). This step only runs on a release tag, so it was never exercised until the first post-#37 release.

Add `--break-system-packages` so the install goes into the user site without touching the system env. It's a harmless no-op on non-managed Pythons, so local runs are unaffected.