### PR TITLE
Reduce resource use: in-memory state, coalesced refreshes, parallel status

### DIFF
--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -18,8 +18,18 @@ final class AppModel {
     let environment: AppEnvironment
     let selector: SelectorModel
 
+    /// In-memory copy of the persisted state, loaded once at init and written back
+    /// on change. Avoids a disk read-modify-write on every persist/layout update,
+    /// and lets `persist()` and `saveLayout()` mutate disjoint fields of one value
+    /// without reloading to avoid clobbering each other.
+    @ObservationIgnored private var state: AppState
+    /// True only while `bootstrap()` hydrates the model from `state`; suppresses the
+    /// `persist()` that property assignments would otherwise trigger during load.
+    @ObservationIgnored private var isHydrating = false
+
     init(environment: AppEnvironment) {
         self.environment = environment
+        self.state = environment.store.load()
         self.selector = SelectorModel(environment: environment)
         self.floatOnTop = false
         // Persist whenever the selection changes, and clear any stale global error —
@@ -45,16 +55,23 @@ final class AppModel {
 
     /// Load persisted state and hydrate repositories + selection.
     func bootstrap() async {
-        let state = environment.store.load()
+        // Hydrate from the in-memory state without letting the assignments below
+        // persist a half-built state back over what we just loaded.
+        isHydrating = true
         floatOnTop = state.floatOnTop
         repositories = state.repositories.map { Repository(path: $0.path) }
         selector.setRepositories(repositories)
-        let target = state.lastSelectedRepoPath.flatMap { last in repositories.first { $0.path == last } }
+        // Snapshot the restore targets before selecting anything: selection triggers
+        // persist(), which overwrites these fields of the shared `state`.
+        let lastRepoPath = state.lastSelectedRepoPath
+        let lastWorktreePath = state.lastSelectedWorktreePath
+        let target = lastRepoPath.flatMap { last in repositories.first { $0.path == last } }
             ?? repositories.first
+        isHydrating = false
         guard let target else { return }
         await selector.selectRepo(target)   // focuses the primary worktree
         // Restore the last selected worktree if it still exists (else keep primary).
-        if let wtPath = state.lastSelectedWorktreePath,
+        if let wtPath = lastWorktreePath,
            selector.selectedWorktree?.path != wtPath,
            let saved = selector.worktrees.first(where: { $0.path == wtPath }) {
             await selector.selectWorktree(saved)
@@ -232,7 +249,7 @@ final class AppModel {
     }
 
     func persist() {
-        var state = environment.store.load()
+        guard !isHydrating else { return }
         state.repositories = repositories.map { PersistedRepository(path: $0.path) }
         state.floatOnTop = floatOnTop
         state.lastSelectedRepoPath = selector.selectedRepo?.path
@@ -245,13 +262,12 @@ final class AppModel {
     /// The saved accordion layout for a repository, or nil if it's never been opened.
     func layout(forRepo path: String?) -> SectionLayout? {
         guard let path else { return nil }
-        return environment.store.load().layoutByRepo?[path]
+        return state.layoutByRepo?[path]
     }
 
     /// Remember a repository's accordion layout (open sections + window height).
     func saveLayout(_ layout: SectionLayout, forRepo path: String?) {
         guard let path else { return }
-        var state = environment.store.load()
         var byRepo = state.layoutByRepo ?? [:]
         byRepo[path] = layout
         state.layoutByRepo = byRepo

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -86,15 +86,30 @@ final class SelectorModel {
     /// Load per-worktree ahead/behind + change count + live state for the
     /// WORKTREES list (drives the sync arrows and pulse dot).
     func refreshWorktreeInfo(now: Date = Date()) async {
+        let statusService = environment.statusService
+        let worktrees = self.worktrees
+        // Fetch each worktree's status concurrently — these are independent git
+        // reads, so a repo with many worktrees shouldn't serialize N `git status`
+        // calls on every repo switch.
+        let statuses = await withTaskGroup(of: (String, StatusResult?).self) { group in
+            for worktree in worktrees {
+                let path = worktree.path
+                group.addTask { (path, try? await statusService.status(worktreePath: path)) }
+            }
+            var byPath: [String: StatusResult] = [:]
+            for await (path, status) in group {
+                if let status { byPath[path] = status }
+            }
+            return byPath
+        }
         var info: [String: WorktreeInfo] = [:]
         for worktree in worktrees {
-            let status = try? await environment.statusService.status(worktreePath: worktree.path)
-            let live = environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
+            let status = statuses[worktree.path]
             info[worktree.path] = WorktreeInfo(
                 ahead: status?.ahead ?? 0,
                 behind: status?.behind ?? 0,
                 changeCount: status?.changes.count ?? 0,
-                isLive: live
+                isLive: environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
             )
         }
         worktreeInfo = info

--- a/Sources/Teebe/ViewModels/WorktreeModel.swift
+++ b/Sources/Teebe/ViewModels/WorktreeModel.swift
@@ -58,6 +58,11 @@ final class WorktreeModel {
     private var ignoredPaths: Set<String> = []
     /// Overlaid children of expanded directories (path → children).
     private var childrenCache: [String: [FileNode]] = [:]
+    /// Coalesces watcher-driven refreshes: while one is running, further events
+    /// collapse into a single queued follow-up, so a burst of file-watch events
+    /// can't stack a backlog of `git status` calls behind one slow refresh.
+    private var isRefreshing = false
+    private var refreshQueued = false
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -150,7 +155,20 @@ final class WorktreeModel {
             environment.activityMonitor.recordActivity(worktreePath: worktreePath, at: now)
             onActivity?(worktreePath)
         }
-        await refresh()
+        await coalescedRefresh()
+    }
+
+    /// Run `refresh()`, collapsing concurrent watcher events into at most one
+    /// queued follow-up rather than one `git status` per event. Safe because the
+    /// model is `@MainActor`-isolated: the flag checks never interleave.
+    private func coalescedRefresh() async {
+        if isRefreshing { refreshQueued = true; return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        repeat {
+            refreshQueued = false
+            await refresh()
+        } while refreshQueued
     }
 
     /// Mark that teebe just wrote into the worktree, so the imminent file-watch

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -17,12 +17,25 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     private(set) var discardedUntracked: [[String]] = []
     private(set) var commitMessages: [String] = []
 
+    // Instrumentation for refresh tests. The counter is lock-guarded because
+    // `refreshWorktreeInfo` now fetches statuses concurrently.
+    private let statusLock = NSLock()
+    private var statusCalls = 0
+    var statusCallCount: Int { statusLock.lock(); defer { statusLock.unlock() }; return statusCalls }
+    /// When set, each `status` call awaits this before returning — lets a test hold a
+    /// refresh "in flight" to exercise coalescing of watcher events.
+    var statusGate: (@Sendable () async -> Void)?
+
     func worktrees(repoPath: String) async throws -> [Worktree] {
         if let worktreesError { throw worktreesError }
         return worktreesResult
     }
     func branches(repoPath: String) async throws -> [Branch] { branchesResult }
-    func status(worktreePath: String) async throws -> StatusResult { statusResult }
+    func status(worktreePath: String) async throws -> StatusResult {
+        statusLock.lock(); statusCalls += 1; statusLock.unlock()
+        if let statusGate { await statusGate() }
+        return statusResult
+    }
     func workingDiff(worktreePath: String, path: String, staged: Bool) async throws -> DiffFile? { workingDiffResult }
     func stage(worktreePath: String, paths: [String]) async throws { stagedPaths.append(paths) }
     func unstage(worktreePath: String, paths: [String]) async throws { unstagedPaths.append(paths) }
@@ -34,6 +47,26 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     @discardableResult
     func run(_ arguments: [String], in directory: String) async throws -> GitInvocationResult {
         GitInvocationResult(arguments: arguments, exitCode: 0, standardOutput: Data(), standardError: "")
+    }
+}
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called, after which it
+/// returns immediately. Lets a test hold a faked `git status` in flight while it
+/// fires further events.
+actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let resume = waiters
+        waiters.removeAll()
+        for continuation in resume { continuation.resume() }
     }
 }
 

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -73,6 +73,28 @@ struct AppModelTests {
         await app.selector.selectRepo(Repository(path: "/repo"))
         #expect(app.errorMessage == nil)
     }
+
+    @Test("a repo's layout persists, survives unrelated state writes, and reloads")
+    func layoutPersistence() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let env = makeTestEnvironment(git: git)
+        let app = AppModel(environment: env)
+        _ = await app.addRepository(path: "/repo")   // triggers persist()
+
+        let layout = SectionLayout(worktreesOpen: false, changesOpen: true, filesOpen: false, windowHeight: 720)
+        app.saveLayout(layout, forRepo: "/repo")
+
+        // A later persist() (here via floatOnTop) must not clobber the saved layout —
+        // both now mutate one in-memory AppState rather than reloading from disk.
+        app.floatOnTop = true
+        #expect(app.layout(forRepo: "/repo") == layout)
+
+        // And it round-trips through disk to a freshly constructed model.
+        let reopened = AppModel(environment: env)
+        #expect(reopened.layout(forRepo: "/repo") == layout)
+        #expect(reopened.layout(forRepo: "/unknown") == nil)
+    }
 }
 
 @MainActor
@@ -206,6 +228,38 @@ struct WorktreeModelTests {
         await model.confirmPendingMutation()
         #expect(model.pendingMutation == nil)
         #expect(git.discardedWorking == [["a.txt"]])
+    }
+
+    @Test("watcher events coalesce: a burst behind a slow refresh runs one follow-up")
+    func refreshCoalesces() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let git = FakeGitClient()
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        #expect(git.statusCallCount == 1)   // initial refresh from load()
+
+        // Gate status so the next refresh blocks until we release it.
+        let gate = Gate()
+        git.statusGate = { await gate.wait() }
+
+        // First watcher event enters status (call #2) and blocks in flight.
+        let inFlight = Task { await model.handleFileSystemEvent(now: Date(timeIntervalSince1970: 1)) }
+        while git.statusCallCount < 2 { await Task.yield() }
+
+        // Five more events while #2 is in flight must collapse into a single queued
+        // follow-up rather than each spawning its own status call.
+        let burst = (0..<5).map { i in
+            Task { await model.handleFileSystemEvent(now: Date(timeIntervalSince1970: Double(2 + i))) }
+        }
+        for _ in 0..<50 { await Task.yield() }
+        #expect(git.statusCallCount == 2)   // still only the in-flight call
+
+        await gate.open()
+        await inFlight.value
+        for task in burst { await task.value }
+
+        // In-flight refresh + exactly one coalesced follow-up == one more status call.
+        #expect(git.statusCallCount == 3)
     }
 }
 


### PR DESCRIPTION
## What

Three follow-ups from a runtime resource audit of the app. No user-facing behavior change — same outputs, lighter resource profile.

- **In-memory app state** — `AppModel` keeps the persisted `AppState` in memory and writes it back on change, instead of a disk read-modify-write on every persist/layout update. `bootstrap()` snapshots its restore targets before selecting, so the `persist()` that selection triggers can't clobber the last-selected worktree it still needs to restore.
- **Coalesced refreshes** — `WorktreeModel` collapses a burst of file-watch events into a single queued follow-up refresh, rather than stacking one `git status` per event behind a slow refresh.
- **Parallel status on repo switch** — `SelectorModel` fetches each worktree's status concurrently instead of serializing N `git status` calls.

## Tests

- Clean build; 124 tests pass (added: refresh coalescing; layout persistence/no-clobber).
- SwiftLint clean — no new violations.

## Notes

The in-memory-state change had a subtle trap caught by a test: hydrating on launch could overwrite the last-selected worktree before it was restored. Fixed and covered.
