### PR TITLE
Auto-detect external worktree add/remove

### DIFF
--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -31,6 +31,13 @@ final class SelectorModel {
     var onSelectionChange: (() -> Void)?
 
     private let environment: AppEnvironment
+    /// Watches the selected repo's git dir so an external `git worktree add`/`remove`
+    /// shows up without a manual refresh.
+    private var repoWatcher: FileSystemWatcher?
+    /// Coalescing flags for watcher-driven re-scans (mirrors `WorktreeModel`): a burst
+    /// of `.git/worktrees` events collapses into at most one queued follow-up.
+    private var isRescanning = false
+    private var rescanQueued = false
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -55,6 +62,8 @@ final class SelectorModel {
     }
 
     func clearSelection() {
+        repoWatcher?.stop()
+        repoWatcher = nil
         selectedRepo = nil
         worktrees = []
         selectedWorktree = nil
@@ -67,6 +76,7 @@ final class SelectorModel {
     /// worktree.
     func selectRepo(_ repo: Repository) async {
         selectedRepo = repo
+        startRepoWatching(repo)
         do {
             worktrees = try await environment.worktreeService.worktrees(for: repo)
             branches = try await environment.branchService.branches(for: repo)
@@ -81,6 +91,75 @@ final class SelectorModel {
             await selectWorktree(primary)
         }
         onSelectionChange?()
+    }
+
+    // MARK: - Auto-detecting worktree add/remove
+
+    /// Watch the selected repo's git dir. A `git worktree add`/`remove` (or `prune`)
+    /// rewrites `.git/worktrees/…`, which `handleRepoWatchEvent` filters for; routine
+    /// index/ref writes in the primary checkout are ignored.
+    private func startRepoWatching(_ repo: Repository) {
+        repoWatcher?.stop()
+        let watcher = environment.makeWatcher()
+        let gitDir = (repo.path as NSString).appendingPathComponent(".git")
+        watcher.start(paths: [gitDir], debounce: 0.5) { [weak self] paths in
+            Task { @MainActor in await self?.handleRepoWatchEvent(paths) }
+        }
+        repoWatcher = watcher
+    }
+
+    /// FSEvents on the repo's git dir: re-scan only when the change touched the
+    /// worktree admin area (`.git/worktrees/…`). Internal + async so it is unit-
+    /// testable without real FSEvents.
+    func handleRepoWatchEvent(_ changedPaths: [String]) async {
+        guard let repo = selectedRepo else { return }
+        let adminDir = (repo.path as NSString).appendingPathComponent(".git/worktrees")
+        guard changedPaths.contains(where: { $0.hasPrefix(adminDir) }) else { return }
+        await refreshWorktrees()
+    }
+
+    /// Re-discover the repo's worktrees + branches in place — the manual Refresh
+    /// button and the auto-detect watcher both land here. Unlike `selectRepo` it
+    /// preserves the current selection (only falling back to the primary if the
+    /// selected worktree has vanished), so a refresh never yanks the user off their
+    /// worktree. Concurrent calls coalesce into a single queued follow-up.
+    func refreshWorktrees() async {
+        if isRescanning { rescanQueued = true; return }
+        isRescanning = true
+        defer { isRescanning = false }
+        repeat {
+            rescanQueued = false
+            await rescanWorktrees()
+        } while rescanQueued
+    }
+
+    private func rescanWorktrees() async {
+        guard let repo = selectedRepo else { return }
+        let discovered: [Worktree]
+        let discoveredBranches: [Branch]
+        do {
+            discovered = try await environment.worktreeService.worktrees(for: repo)
+            discoveredBranches = try await environment.branchService.branches(for: repo)
+            errorMessage = nil
+        } catch {
+            // A transient failure shouldn't blank the list — keep what we have.
+            errorMessage = "\(error)"
+            return
+        }
+        worktrees = discovered
+        branches = discoveredBranches
+        await refreshWorktreeInfo()
+        // Keep the current selection if it still exists; only re-focus when it's gone.
+        if let current = selectedWorktree, discovered.contains(where: { $0.path == current.path }) {
+            return
+        }
+        if let fallback = discovered.first(where: { $0.isPrimary }) ?? discovered.first {
+            await selectWorktree(fallback)
+        } else {
+            selectedWorktree = nil
+            worktree.clear()
+            onSelectionChange?()
+        }
     }
 
     /// Load per-worktree ahead/behind + change count + live state for the

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -38,6 +38,10 @@ final class SelectorModel {
     /// of `.git/worktrees` events collapses into at most one queued follow-up.
     private var isRescanning = false
     private var rescanQueued = false
+    /// Absolute path to the repo's `worktrees` admin dir (inside the git *common*
+    /// dir), used to filter watcher events. Resolved via `git rev-parse` so it's
+    /// correct even when `<repo>/.git` is a gitlink file rather than a directory.
+    private var worktreesAdminDir: String?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -64,6 +68,7 @@ final class SelectorModel {
     func clearSelection() {
         repoWatcher?.stop()
         repoWatcher = nil
+        worktreesAdminDir = nil
         selectedRepo = nil
         worktrees = []
         selectedWorktree = nil
@@ -76,7 +81,7 @@ final class SelectorModel {
     /// worktree.
     func selectRepo(_ repo: Repository) async {
         selectedRepo = repo
-        startRepoWatching(repo)
+        await startRepoWatching(repo)
         do {
             worktrees = try await environment.worktreeService.worktrees(for: repo)
             branches = try await environment.branchService.branches(for: repo)
@@ -95,25 +100,37 @@ final class SelectorModel {
 
     // MARK: - Auto-detecting worktree add/remove
 
-    /// Watch the selected repo's git dir. A `git worktree add`/`remove` (or `prune`)
-    /// rewrites `.git/worktrees/…`, which `handleRepoWatchEvent` filters for; routine
-    /// index/ref writes in the primary checkout are ignored.
-    private func startRepoWatching(_ repo: Repository) {
+    /// Watch the selected repo's git common dir. A `git worktree add`/`remove` (or
+    /// `prune`) rewrites `worktrees/…` there, which `handleRepoWatchEvent` filters
+    /// for; routine index/ref writes in the primary checkout are ignored.
+    private func startRepoWatching(_ repo: Repository) async {
         repoWatcher?.stop()
+        let commonDir = await resolveGitCommonDir(for: repo)
+        worktreesAdminDir = (commonDir as NSString).appendingPathComponent("worktrees")
         let watcher = environment.makeWatcher()
-        let gitDir = (repo.path as NSString).appendingPathComponent(".git")
-        watcher.start(paths: [gitDir], debounce: 0.5) { [weak self] paths in
+        watcher.start(paths: [commonDir], debounce: 0.5) { [weak self] paths in
             Task { @MainActor in await self?.handleRepoWatchEvent(paths) }
         }
         repoWatcher = watcher
     }
 
-    /// FSEvents on the repo's git dir: re-scan only when the change touched the
-    /// worktree admin area (`.git/worktrees/…`). Internal + async so it is unit-
-    /// testable without real FSEvents.
+    /// The repo's git *common* dir — where worktree admin data lives regardless of
+    /// whether `<repo>/.git` is a real directory or a gitlink. Falls back to
+    /// `<repo>/.git` if `git rev-parse` can't answer.
+    private func resolveGitCommonDir(for repo: Repository) async -> String {
+        let fallback = (repo.path as NSString).appendingPathComponent(".git")
+        guard let result = try? await environment.git.run(["rev-parse", "--git-common-dir"], in: repo.path),
+              result.succeeded else { return fallback }
+        let raw = result.stdoutString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return fallback }
+        return (raw as NSString).isAbsolutePath ? raw : (repo.path as NSString).appendingPathComponent(raw)
+    }
+
+    /// FSEvents on the repo's git common dir: re-scan only when the change touched the
+    /// worktree admin area (`worktrees/…`). Internal + async so it is unit-testable
+    /// without real FSEvents.
     func handleRepoWatchEvent(_ changedPaths: [String]) async {
-        guard let repo = selectedRepo else { return }
-        let adminDir = (repo.path as NSString).appendingPathComponent(".git/worktrees")
+        guard selectedRepo != nil, let adminDir = worktreesAdminDir else { return }
         guard changedPaths.contains(where: { $0.hasPrefix(adminDir) }) else { return }
         await refreshWorktrees()
     }

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -34,11 +34,11 @@ struct WorktreesSection: View {
                         }
                         .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
                         .help("Repository actions")
-                        Button { Task { await selector.refreshWorktreeInfo() } } label: {
+                        Button { Task { await selector.refreshWorktrees() } } label: {
                             Image(systemName: "arrow.clockwise").font(.system(size: 11))
                         }
                         .buttonStyle(IconButtonStyle()).foregroundStyle(Palette.secondaryText)
-                        .help("Refresh")
+                        .help("Refresh worktrees")
                     }
                 } else if let active = selector.selectedWorktree {
                     HStack(spacing: 5) {

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -44,9 +44,16 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     func commit(worktreePath: String, message: String) async throws { commitMessages.append(message) }
     func addWorktree(repoPath: String, path: String, branch: String?, createBranch: Bool) async throws {}
     func removeWorktree(repoPath: String, worktreePath: String, force: Bool) async throws {}
+    /// Scripted stdout for `git rev-parse --git-common-dir` (the repo's git common
+    /// dir). When nil, `run` returns empty stdout and callers fall back to `.git`.
+    var gitCommonDirOutput: String?
     @discardableResult
     func run(_ arguments: [String], in directory: String) async throws -> GitInvocationResult {
-        GitInvocationResult(arguments: arguments, exitCode: 0, standardOutput: Data(), standardError: "")
+        var stdout = Data()
+        if arguments == ["rev-parse", "--git-common-dir"], let gitCommonDirOutput {
+            stdout = Data(gitCommonDirOutput.utf8)
+        }
+        return GitInvocationResult(arguments: arguments, exitCode: 0, standardOutput: stdout, standardError: "")
     }
 }
 

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -91,8 +91,38 @@ final class FakeFileOps: FileOps, @unchecked Sendable {
 
 final class FakeWatcher: FileSystemWatcher, @unchecked Sendable {
     private(set) var isWatching = false
-    func start(paths: [String], debounce: TimeInterval, onChange: @escaping @Sendable ([String]) -> Void) { isWatching = true }
-    func stop() { isWatching = false }
+    private(set) var watchedPaths: [String] = []
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private var handler: (@Sendable ([String]) -> Void)?
+
+    func start(paths: [String], debounce: TimeInterval, onChange: @escaping @Sendable ([String]) -> Void) {
+        isWatching = true
+        watchedPaths = paths
+        startCount += 1
+        handler = onChange
+    }
+
+    func stop() {
+        isWatching = false
+        stopCount += 1
+        handler = nil
+    }
+
+    /// Simulate a coalesced FSEvents change batch.
+    func fire(_ paths: [String]) { handler?(paths) }
+}
+
+/// Hands out and records every `FakeWatcher` the test environment creates, so a test
+/// can grab a specific one (e.g. the repo `.git` watcher) and fire events at it.
+@MainActor
+final class WatcherBox {
+    private(set) var watchers: [FakeWatcher] = []
+    func make() -> FakeWatcher { let watcher = FakeWatcher(); watchers.append(watcher); return watcher }
+    /// The most recently started watcher whose watched paths contain `needle`.
+    func watching(_ needle: String) -> FakeWatcher? {
+        watchers.last { $0.watchedPaths.contains { $0.contains(needle) } }
+    }
 }
 
 // MARK: - Test environment
@@ -103,7 +133,8 @@ func makeTestEnvironment(
     opener: FakeFileOpener = FakeFileOpener(),
     ops: FakeFileOps = FakeFileOps(),
     store: AppStateStore? = nil,
-    monitor: WorktreeActivityMonitor = WorktreeActivityMonitor()
+    monitor: WorktreeActivityMonitor = WorktreeActivityMonitor(),
+    makeWatcher: (@MainActor () -> FileSystemWatcher)? = nil
 ) -> AppEnvironment {
     let storeURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("tb-test-\(UUID().uuidString)")
@@ -114,6 +145,6 @@ func makeTestEnvironment(
         ops: ops,
         store: store ?? AppStateStore(url: storeURL),
         activityMonitor: monitor,
-        makeWatcher: { FakeWatcher() }
+        makeWatcher: makeWatcher ?? { FakeWatcher() }
     )
 }

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -171,6 +171,27 @@ struct SelectorModelTests {
         #expect(repoWatcher?.isWatching == false)
     }
 
+    @Test("the watcher follows the git common dir when <repo>/.git is a gitlink")
+    func repoWatcherResolvesGitCommonDir() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/wt-root", branch: "feature", isPrimary: true)]
+        git.gitCommonDirOutput = "/main/.git"   // <repo>/.git is a gitlink → real data lives here
+        let box = WatcherBox()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, makeWatcher: { box.make() }))
+        await selector.selectRepo(Repository(path: "/wt-root"))
+
+        // It watches the resolved common dir, not /wt-root/.git.
+        #expect(box.watching("/main/.git")?.watchedPaths == ["/main/.git"])
+
+        // An add under the common dir's worktrees admin area is detected.
+        git.worktreesResult = [
+            Worktree(path: "/wt-root", branch: "feature", isPrimary: true),
+            Worktree(path: "/wt-2", branch: "feature-2"),
+        ]
+        await selector.handleRepoWatchEvent(["/main/.git/worktrees/wt-2/HEAD"])
+        #expect(selector.worktrees.count == 2)
+    }
+
     @Test("an external git worktree add is auto-detected via the repo .git watcher")
     func autoDetectAdd() async {
         let git = FakeGitClient()

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -154,6 +154,111 @@ struct SelectorModelTests {
         await selector.refreshWorktreeInfo(now: t.addingTimeInterval(1))
         #expect(selector.info(for: git.worktreesResult[0]).isLive == true)
     }
+
+    @Test("repo watcher watches the repo's .git dir and stops when the selection clears")
+    func repoWatcherLifecycle() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let box = WatcherBox()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, makeWatcher: { box.make() }))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        let repoWatcher = box.watching("/repo/.git")
+        #expect(repoWatcher?.watchedPaths == ["/repo/.git"])
+        #expect(repoWatcher?.isWatching == true)
+
+        selector.clearSelection()
+        #expect(repoWatcher?.isWatching == false)
+    }
+
+    @Test("an external git worktree add is auto-detected via the repo .git watcher")
+    func autoDetectAdd() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let box = WatcherBox()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, makeWatcher: { box.make() }))
+        await selector.selectRepo(Repository(path: "/repo"))
+        #expect(selector.worktrees.count == 1)
+
+        // `git worktree add ../wt feature` lands a new admin dir under .git/worktrees.
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt", branch: "feature"),
+        ]
+        await selector.handleRepoWatchEvent(["/repo/.git/worktrees/wt/HEAD"])
+        #expect(selector.worktrees.map(\.path) == ["/repo", "/wt"])
+    }
+
+    @Test("a non-worktree .git write does not trigger a re-scan")
+    func ignoresNonWorktreeGitWrites() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        // The set changes underneath, but an index write in the primary checkout is
+        // not under .git/worktrees, so the list must stay put.
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt", branch: "feature"),
+        ]
+        await selector.handleRepoWatchEvent(["/repo/.git/index"])
+        #expect(selector.worktrees.count == 1)
+    }
+
+    @Test("refreshWorktrees picks up a new worktree without yanking the selection")
+    func refreshPreservesSelection() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt-a", branch: "feature-a"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+        await selector.selectWorktree(git.worktreesResult[1])   // focus feature-a
+        #expect(selector.selectedWorktree?.path == "/wt-a")
+
+        git.worktreesResult.append(Worktree(path: "/wt-b", branch: "feature-b"))
+        await selector.refreshWorktrees()
+        #expect(selector.worktrees.count == 3)
+        #expect(selector.selectedWorktree?.path == "/wt-a")
+    }
+
+    @Test("refreshWorktrees falls back to primary when the selected worktree disappears")
+    func refreshFallsBackWhenSelectionRemoved() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt-a", branch: "feature-a"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+        await selector.selectWorktree(git.worktreesResult[1])
+        #expect(selector.selectedWorktree?.path == "/wt-a")
+
+        // feature-a is removed externally.
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        await selector.refreshWorktrees()
+        #expect(selector.worktrees.map(\.path) == ["/repo"])
+        #expect(selector.selectedWorktree?.path == "/repo")
+    }
+
+    @Test("a transient discovery failure keeps the existing worktree list")
+    func refreshKeepsListOnError() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt-a", branch: "feature-a"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+        #expect(selector.worktrees.count == 2)
+
+        git.worktreesError = .notAGitRepository(path: "/repo")
+        await selector.refreshWorktrees()
+        #expect(selector.worktrees.count == 2)   // unchanged — not blanked
+        #expect(selector.selectedWorktree?.path == "/repo")
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## What

Teebe now auto-detects worktrees added or removed **outside** the app (e.g. `git worktree add` / `remove` / `prune` in a terminal) — they appear in the WORKTREES list without any manual action. The Refresh button forces this same full re-scan as a fallback.

## How

- The selected repo's git **common dir** (resolved via `git rev-parse --git-common-dir`) is watched with the existing FSEvents `FileSystemWatcher`. Changes under its `worktrees/…` admin area (which `git worktree add/remove/prune` rewrites) trigger a re-scan; routine index/ref writes in the primary checkout are filtered out. Resolving the common dir keeps this correct even when `<repo>/.git` is a gitlink file (submodule / linked-worktree root); it falls back to `<repo>/.git` if rev-parse can't answer.
- The re-scan (`refreshWorktrees`) **preserves the current selection**, only falling back to the primary worktree if the selected one disappeared — so an auto-refresh never yanks the user off their worktree. Concurrent events coalesce into one queued follow-up (same pattern as `WorktreeModel`).
- The WORKTREES **Refresh** button now calls `refreshWorktrees` (full list re-scan) instead of `refreshWorktreeInfo` (which only recomputed per-worktree sync/live counts).

## Tests

7 new `SelectorModel` tests: watcher lifecycle, common-dir resolution through a gitlink, auto-detect on a `worktrees/` event, filtering of non-worktree git writes, selection preserved on refresh, fallback to primary when the selection vanishes, and list kept intact on a transient discovery failure. Full suite: 131 tests green; `swift build` clean.