### PR TITLE
Release notes across surfaces from a single CHANGELOG.md

### DIFF
--- a/.github/workflows/publish-appcast.yml
+++ b/.github/workflows/publish-appcast.yml
@@ -32,6 +32,17 @@ jobs:
           echo "Downloaded appcast.xml for $TAG:"
           cat appcast.xml
 
+      - name: Fetch CHANGELOG.md at the released tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Mirror the changelog onto the site so the changelog page can read it
+          # same-origin. CHANGELOG.md in the app repo stays the single source.
+          gh api "repos/$GITHUB_REPOSITORY/contents/CHANGELOG.md?ref=$TAG" \
+            -H "Accept: application/vnd.github.raw" > CHANGELOG.md || true
+          head -5 CHANGELOG.md || true
+
       - name: Check out teebe-site
         uses: actions/checkout@v7
         with:
@@ -39,18 +50,19 @@ jobs:
           ssh-key: ${{ secrets.SITE_DEPLOY_KEY }}
           path: site
 
-      - name: Commit appcast if changed
+      - name: Commit appcast + changelog if changed
         env:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           cp appcast.xml site/appcast.xml
+          [ -s CHANGELOG.md ] && cp CHANGELOG.md site/CHANGELOG.md
           cd site
-          if git diff --quiet -- appcast.xml; then
-            echo "appcast.xml unchanged; nothing to publish."
+          if git diff --quiet -- appcast.xml CHANGELOG.md; then
+            echo "appcast.xml and CHANGELOG.md unchanged; nothing to publish."
             exit 0
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add appcast.xml
-          git commit -m "Publish Sparkle appcast for ${TAG}"
+          git add appcast.xml CHANGELOG.md
+          git commit -m "Publish appcast + changelog for ${TAG}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,24 @@ jobs:
           # increase per release or Sparkle never sees a newer version.
           APP_VERSION="${GITHUB_REF_NAME#v}" ./scripts/make-app.sh release
 
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          # Single source of truth: the tag's CHANGELOG.md section feeds both the
+          # GitHub release body and the Sparkle appcast notes below.
+          VER="${GITHUB_REF_NAME#v}"
+          ./scripts/changelog-section.sh "$VER" > RELEASE_NOTES.md || true
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::warning::No CHANGELOG.md section for $VER — notes fall back to auto-generated."
+            printf '_No changelog entry for %s._\n' "$VER" > RELEASE_NOTES.md
+          fi
+          echo "----- release notes -----"; cat RELEASE_NOTES.md
+
       - name: Stage update archive
         run: |
           mkdir -p sparkle-updates
           ditto -c -k --keepParent teebe.app "sparkle-updates/teebe-${GITHUB_REF_NAME}.zip"
+          # Same-basename .md → generate_appcast attaches it as this item's notes.
+          cp RELEASE_NOTES.md "sparkle-updates/teebe-${GITHUB_REF_NAME}.md"
 
       - name: Generate & sign Sparkle appcast
         env:
@@ -47,6 +61,7 @@ jobs:
           # and point download URLs at this release's assets.
           printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$GEN" \
             --ed-key-file - \
+            --embed-release-notes \
             --download-url-prefix "https://github.com/klein-t/teebe/releases/download/${GITHUB_REF_NAME}/" \
             sparkle-updates
           cp sparkle-updates/teebe-*.zip .
@@ -75,5 +90,8 @@ jobs:
             teebe-*.zip
             teebe-macos.dmg
             appcast.xml
+          # Curated notes from CHANGELOG.md, with the auto-generated commit/PR list
+          # appended below them.
+          body_path: RELEASE_NOTES.md
           generate_release_notes: true
           draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to teebe are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Worktrees added or removed **outside** teebe (e.g. `git worktree add` / `remove`
+  in a terminal) are now detected automatically and appear in the WORKTREES list
+  without a manual action. The Refresh button forces a full re-scan.
+- A **What's New** window that shows this changelog inside the app — opened
+  automatically the first time you launch a new version, and any time from
+  Help → What's New.
+
+## [0.3.0] - 2026-06-24
+
+### Changed
+- Window resizing reworked into a coherent content-wrap model — no more
+  bounce / jump / gap on resize.
+
+### Added
+- Branded `.dmg` download for the website, with centered teebe / Applications icons.
+- The Sparkle appcast is now hosted on teebe.io; releases also ship a stable
+  `teebe-macos.zip` asset.
+
+### Fixed
+- Dock icon rendering, updater start-up, and a sticky error banner.
+
+## [0.2.2] - 2026-06-23
+
+### Fixed
+- **Packaged-app launch crash.** v0.2.0 / v0.2.1 release builds crashed on launch
+  ("could not load resource bundle") because the resource bundle wasn't resolvable
+  in a code-signed `.app`. The app now resolves it from `Contents/Resources`.
+
+## [0.2.1] - 2026-06-23
+
+### Changed
+- The CHANGES section now hugs its rows like WORKTREES instead of taking the
+  flexible vertical space — FILES is the sole space-filling section, and the
+  window resizes as the change count changes.
+
+## [0.2.0] - 2026-06-23
+
+### Added
+- Sparkle in-app auto-updates.
+
+### Fixed
+- Section-toggle bounce; refined sidebar chrome.
+
+## [0.1.0] - 2026-06-23
+
+### Added
+- Initial release: browse a git repository's worktrees, changes, and files.

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -26,6 +26,7 @@ struct TeebeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var app: AppModel
     @State private var preview: PreviewModel
+    @State private var whatsNew: WhatsNewModel
     @StateObject private var updater = UpdaterController()
 
     init() {
@@ -33,20 +34,32 @@ struct TeebeApp: App {
         let environment = AppEnvironment.live()
         _app = State(initialValue: AppModel(environment: environment))
         _preview = State(initialValue: PreviewModel(environment: environment))
+        _whatsNew = State(initialValue: WhatsNewModel(
+            version: Brand.appVersion,
+            changelogMarkdown: Brand.changelogMarkdown,
+            store: environment.store
+        ))
     }
 
     var body: some Scene {
         WindowGroup(Brand.name) {
             RootView(app: app, preview: preview)
-                .task { await app.bootstrap() }
+                .task {
+                    await app.bootstrap()
+                    whatsNew.presentIfUpdated()   // greet once after an update
+                }
+                .sheet(isPresented: $whatsNew.isPresented) {
+                    WhatsNewView(model: whatsNew)
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
         .commands {
-            // Standard "Check for Updates…" item, placed in the app menu next to About.
+            // "Check for Updates…" and "What's New" in the app menu next to About.
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
+                Button("What's New in \(Brand.name)") { whatsNew.present() }
             }
         }
 

--- a/Sources/Teebe/ViewModels/WhatsNewModel.swift
+++ b/Sources/Teebe/ViewModels/WhatsNewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Observation
+import TeebeCore
+
+/// Drives the "What's New" window: the parsed changelog plus the once-per-version
+/// auto-present logic. Pure enough to unit-test by injecting the version, markdown,
+/// and store.
+@MainActor
+@Observable
+final class WhatsNewModel {
+    private(set) var entries: [ChangelogEntry]
+    var isPresented = false
+    /// User-facing app version (`CFBundleShortVersionString`), or `nil` when unknown
+    /// (e.g. running via `swift run`, which has no Info.plist).
+    let version: String?
+
+    private let store: AppStateStore
+
+    init(version: String?, changelogMarkdown: String?, store: AppStateStore) {
+        self.version = version
+        self.entries = changelogMarkdown.map(ChangelogParser.parse) ?? []
+        self.store = store
+    }
+
+    var hasContent: Bool { !entries.isEmpty }
+
+    /// Auto-present once after an update: when the running version is newer than the
+    /// version we last showed. A fresh install (no record) is *not* greeted with the
+    /// changelog — it's just recorded as seen. A dev build (no version) never
+    /// auto-presents. Either way the current version is marked seen so it won't
+    /// re-trigger.
+    func presentIfUpdated() {
+        guard let version else { return }
+        let lastSeen = store.load().lastSeenVersion
+        if let lastSeen, SemVer.isGreater(version, than: lastSeen) {
+            isPresented = true
+        }
+        markSeen(version)
+    }
+
+    /// Manual open (Help → What's New).
+    func present() { isPresented = true }
+
+    func dismiss() { isPresented = false }
+
+    private func markSeen(_ version: String) {
+        var state = store.load()
+        guard state.lastSeenVersion != version else { return }
+        state.lastSeenVersion = version
+        try? store.save(state)
+    }
+
+    /// The app version read from the bundle, formatted for display ("v0.3.0"), or a
+    /// dev placeholder when unknown.
+    var displayVersion: String { version.map { "v\($0)" } ?? "dev build" }
+}

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -12,6 +12,29 @@ enum Brand {
         .url(forResource: "teebe-logo", withExtension: "png")
         .flatMap(NSImage.init(contentsOf:))
 
+    /// The packaged `CHANGELOG.md`, drives the "What's New" window. In a release the
+    /// `.app` carries it in `Contents/Resources/` (copied by `make-app.sh`); under
+    /// `swift run`/tests there's no bundle copy, so fall back to walking up from the
+    /// executable to the repo-root `CHANGELOG.md` so the window still works in dev.
+    static let changelogMarkdown: String? = {
+        if let url = Bundle.main.url(forResource: "CHANGELOG", withExtension: "md"),
+           let text = try? String(contentsOf: url, encoding: .utf8) {
+            return text
+        }
+        var dir = URL(fileURLWithPath: Bundle.main.bundlePath)
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent("CHANGELOG.md")
+            if let text = try? String(contentsOf: candidate, encoding: .utf8) { return text }
+            dir.deleteLastPathComponent()
+        }
+        return nil
+    }()
+
+    /// User-facing version string from the bundle's `Info.plist`, or `nil` in dev.
+    static var appVersion: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
     /// Locate the SwiftPM resource bundle (`Teebe_Teebe.bundle`) across run modes.
     /// We deliberately avoid `Bundle.module`: its generated accessor only checks
     /// the app *root* (`Bundle.main.bundleURL/Teebe_Teebe.bundle`) plus a hardcoded

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -417,6 +417,12 @@ private struct EmptyStateView: View {
             .controlSize(.large)
             .buttonStyle(.borderedProminent)
             .modifier(StaggeredReveal(revealed: revealed, step: 3))
+            if let version = Brand.appVersion {
+                Text("\(Brand.name) v\(version)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Palette.secondaryText)
+                    .modifier(StaggeredReveal(revealed: revealed, step: 4))
+            }
         }
         .frame(maxWidth: .infinity, minHeight: 300)
         .padding(40)

--- a/Sources/Teebe/Views/WhatsNewView.swift
+++ b/Sources/Teebe/Views/WhatsNewView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import TeebeCore
+
+/// The "What's New" window: the app logo + version, then the changelog rendered as
+/// grouped, bulleted release notes. Shown automatically the first launch after an
+/// update, and on demand from Help → What's New.
+struct WhatsNewView: View {
+    @Bindable var model: WhatsNewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if model.hasContent {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 22) {
+                        ForEach(model.entries) { entry in
+                            entryView(entry)
+                        }
+                    }
+                    .padding(20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            } else {
+                Text("No release notes available.")
+                    .font(.callout).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 440, height: 520)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            if let logo = Brand.logo {
+                Image(nsImage: logo).resizable().interpolation(.high).scaledToFit()
+                    .frame(width: 44, height: 44)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text("What's New in \(Brand.name)")
+                    .font(.system(size: 16, weight: .semibold))
+                Text(model.displayVersion)
+                    .font(.system(size: 12)).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20).padding(.vertical, 16)
+    }
+
+    private func entryView(_ entry: ChangelogEntry) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(entry.isUnreleased ? "Unreleased" : "Version \(entry.version)")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Palette.accent)
+                if let date = entry.date {
+                    Text(date).font(.system(size: 11)).foregroundStyle(.secondary)
+                }
+            }
+            // Flat bullet list per version — the Added/Changed/Fixed groupings live
+            // in CHANGELOG.md for authoring, but users just see what changed.
+            VStack(alignment: .leading, spacing: 5) {
+                ForEach(entry.groups.flatMap(\.items), id: \.self) { item in
+                    bullet(item)
+                }
+            }
+        }
+    }
+
+    private func bullet(_ item: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Text("•").foregroundStyle(Palette.secondaryText)
+            Text(attributed(item))
+                .font(.system(size: 12.5))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Render inline markdown (bold, code, links) for a bullet, falling back to plain
+    /// text if it can't be parsed.
+    private func attributed(_ item: String) -> AttributedString {
+        (try? AttributedString(markdown: item)) ?? AttributedString(item)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}

--- a/Sources/TeebeCore/AppStateStore.swift
+++ b/Sources/TeebeCore/AppStateStore.swift
@@ -42,6 +42,9 @@ public struct AppState: Codable, Equatable, Sendable {
     /// Accordion layout keyed by repository path. Optional so older state files
     /// (without this key) still decode instead of resetting everything.
     public var layoutByRepo: [String: SectionLayout]?
+    /// The app version we last showed the "What's New" window for. Optional so older
+    /// state files decode; `nil` means "never shown" (treated as a fresh install).
+    public var lastSeenVersion: String?
 
     public init(
         repositories: [PersistedRepository] = [],
@@ -50,7 +53,8 @@ public struct AppState: Codable, Equatable, Sendable {
         floatOnTop: Bool = false,
         lastSelectedRepoPath: String? = nil,
         lastSelectedWorktreePath: String? = nil,
-        layoutByRepo: [String: SectionLayout]? = nil
+        layoutByRepo: [String: SectionLayout]? = nil,
+        lastSeenVersion: String? = nil
     ) {
         self.repositories = repositories
         self.showChangedOnly = showChangedOnly
@@ -59,6 +63,7 @@ public struct AppState: Codable, Equatable, Sendable {
         self.lastSelectedRepoPath = lastSelectedRepoPath
         self.lastSelectedWorktreePath = lastSelectedWorktreePath
         self.layoutByRepo = layoutByRepo
+        self.lastSeenVersion = lastSeenVersion
     }
 }
 

--- a/Sources/TeebeCore/Changelog.swift
+++ b/Sources/TeebeCore/Changelog.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// One version's worth of a parsed changelog: a version label, an optional date,
+/// and its grouped bullet items. Pure value types so the parser is fully testable
+/// without any UI.
+public struct ChangelogEntry: Equatable, Sendable, Identifiable {
+    /// Version label, e.g. `"0.3.0"` or `"Unreleased"`.
+    public var version: String
+    /// Raw date string from the header (e.g. `"2026-06-24"`), when present.
+    public var date: String?
+    public var groups: [ChangelogGroup]
+
+    public var id: String { version }
+    public var isUnreleased: Bool { version.lowercased() == "unreleased" }
+
+    public init(version: String, date: String? = nil, groups: [ChangelogGroup] = []) {
+        self.version = version
+        self.date = date
+        self.groups = groups
+    }
+}
+
+/// A titled group of bullet items within an entry (e.g. `### Added`). `title` is
+/// `nil` for bullets that appear before any `###` subheading.
+public struct ChangelogGroup: Equatable, Sendable, Identifiable {
+    public var title: String?
+    public var items: [String]
+
+    public var id: String { title ?? "—" }
+
+    public init(title: String? = nil, items: [String] = []) {
+        self.title = title
+        self.items = items
+    }
+}
+
+/// Parses [Keep a Changelog](https://keepachangelog.com/) markdown into entries.
+///
+/// Grammar (everything else is ignored): `## [version] - date` starts an entry,
+/// `### Group` starts a group, and `- ` / `* ` lines are bullets. Bullet text that
+/// wraps onto continuation lines is rejoined. Item text keeps its inline markdown
+/// so the view can render emphasis/code.
+public enum ChangelogParser {
+    public static func parse(_ markdown: String) -> [ChangelogEntry] {
+        var entries: [ChangelogEntry] = []
+        var groups: [ChangelogGroup] = []
+        var currentGroup: ChangelogGroup?
+        var version: String?
+        var date: String?
+
+        func flushGroup() {
+            if let group = currentGroup, !group.items.isEmpty { groups.append(group) }
+            currentGroup = nil
+        }
+        func flushEntry() {
+            flushGroup()
+            if let version { entries.append(ChangelogEntry(version: version, date: date, groups: groups)) }
+            version = nil
+            date = nil
+            groups = []
+        }
+        func appendContinuation(_ text: String) {
+            guard version != nil, currentGroup != nil,
+                  let last = currentGroup?.items.indices.last else { return }
+            currentGroup?.items[last] += " " + text
+        }
+
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("## ") {
+                flushEntry()
+                (version, date) = parseHeader(String(line.dropFirst(3)))
+            } else if line.hasPrefix("### ") {
+                flushGroup()
+                let title = String(line.dropFirst(4)).trimmingCharacters(in: .whitespaces)
+                currentGroup = ChangelogGroup(title: title.isEmpty ? nil : title, items: [])
+            } else if line.hasPrefix("- ") || line.hasPrefix("* ") {
+                guard version != nil else { continue }
+                if currentGroup == nil { currentGroup = ChangelogGroup(title: nil, items: []) }
+                currentGroup?.items.append(String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces))
+            } else if !line.isEmpty {
+                appendContinuation(line)
+            }
+        }
+        flushEntry()
+        return entries
+    }
+
+    /// Split a `## ` header body into version + optional date. Accepts `[0.3.0] -
+    /// 2026-06-24`, `0.3.0 - 2026-06-24`, and `[Unreleased]`.
+    private static func parseHeader(_ text: String) -> (String, String?) {
+        var version = text
+        var date: String?
+        if let dash = text.range(of: " - ") {
+            version = String(text[..<dash.lowerBound])
+            date = String(text[dash.upperBound...]).trimmingCharacters(in: .whitespaces)
+        }
+        version = version.trimmingCharacters(in: CharacterSet(charactersIn: "[] "))
+        return (version, (date?.isEmpty ?? true) ? nil : date)
+    }
+}
+
+/// Minimal dotted-numeric version comparison — enough to decide "is this build
+/// newer than the one we last showed What's New for". Non-numeric segments count
+/// as 0, so `"0.10.0" > "0.9.0"` and `"0.3.0" > "0.3"`.
+public enum SemVer {
+    public static func components(_ version: String) -> [Int] {
+        version.split(separator: ".").map { segment in
+            Int(segment.prefix { $0.isNumber }) ?? 0
+        }
+    }
+
+    /// `true` when `lhs` is a strictly greater version than `rhs`.
+    public static func isGreater(_ lhs: String, than rhs: String) -> Bool {
+        let left = components(lhs)
+        let right = components(rhs)
+        for index in 0..<max(left.count, right.count) {
+            let leftValue = index < left.count ? left[index] : 0
+            let rightValue = index < right.count ? right[index] : 0
+            if leftValue != rightValue { return leftValue > rightValue }
+        }
+        return false
+    }
+}

--- a/Tests/TeebeCoreTests/ChangelogParserTests.swift
+++ b/Tests/TeebeCoreTests/ChangelogParserTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import TeebeCore
+
+@Suite("ChangelogParser")
+struct ChangelogParserTests {
+    private let sample = """
+    # Changelog
+
+    Intro paragraph that should be ignored.
+
+    ## [Unreleased]
+
+    ### Added
+    - A brand new thing.
+
+    ## [0.3.0] - 2026-06-24
+
+    ### Changed
+    - Window resizing reworked into a coherent model — no more bounce on a
+      window drag.
+
+    ### Fixed
+    - Dock icon rendering.
+    - Updater start-up.
+
+    ## [0.2.0] - 2026-06-23
+
+    - An ungrouped bullet before any subheading.
+    """
+
+    @Test("parses entries newest-first with versions and dates")
+    func entriesAndDates() {
+        let entries = ChangelogParser.parse(sample)
+        #expect(entries.map(\.version) == ["Unreleased", "0.3.0", "0.2.0"])
+        #expect(entries[0].isUnreleased)
+        #expect(entries[1].date == "2026-06-24")
+        #expect(entries[0].date == nil)
+    }
+
+    @Test("groups bullets under their ### subheadings")
+    func groups() {
+        let entries = ChangelogParser.parse(sample)
+        let v030 = entries[1]
+        #expect(v030.groups.map(\.title) == ["Changed", "Fixed"])
+        #expect(v030.groups[1].items == ["Dock icon rendering.", "Updater start-up."])
+    }
+
+    @Test("rejoins a bullet that wraps across lines")
+    func wrappedBullet() {
+        let entries = ChangelogParser.parse(sample)
+        let changed = entries[1].groups[0].items
+        #expect(changed == ["Window resizing reworked into a coherent model — no more bounce on a window drag."])
+    }
+
+    @Test("bullets before any subheading land in an untitled group")
+    func ungroupedBullets() {
+        let entries = ChangelogParser.parse(sample)
+        let v020 = entries[2]
+        #expect(v020.groups.count == 1)
+        #expect(v020.groups[0].title == nil)
+        #expect(v020.groups[0].items == ["An ungrouped bullet before any subheading."])
+    }
+
+    @Test("empty input yields no entries")
+    func empty() {
+        #expect(ChangelogParser.parse("").isEmpty)
+        #expect(ChangelogParser.parse("# Changelog\n\nNothing here yet.").isEmpty)
+    }
+}
+
+@Suite("SemVer")
+struct SemVerTests {
+    @Test("compares dotted numeric versions")
+    func compare() {
+        #expect(SemVer.isGreater("0.3.0", than: "0.2.2"))
+        #expect(SemVer.isGreater("0.10.0", than: "0.9.0"))   // numeric, not lexicographic
+        #expect(SemVer.isGreater("1.0.0", than: "0.99.99"))
+        #expect(SemVer.isGreater("0.3.1", than: "0.3"))      // 0.3.1 > 0.3.0
+    }
+
+    @Test("equal or lower versions are not greater")
+    func notGreater() {
+        #expect(!SemVer.isGreater("0.3.0", than: "0.3.0"))
+        #expect(!SemVer.isGreater("0.2.0", than: "0.3.0"))
+        #expect(!SemVer.isGreater("0.3", than: "0.3.0"))     // trailing zero == equal
+        #expect(!SemVer.isGreater("0.3.0", than: "0.3"))
+    }
+}

--- a/Tests/TeebeTests/WhatsNewModelTests.swift
+++ b/Tests/TeebeTests/WhatsNewModelTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+@testable import Teebe
+import TeebeCore
+
+@MainActor
+@Suite("WhatsNewModel")
+struct WhatsNewModelTests {
+    private let changelog = """
+    # Changelog
+
+    ## [0.3.0] - 2026-06-24
+
+    ### Added
+    - A new thing.
+    """
+
+    private func makeStore() -> AppStateStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tb-wn-\(UUID().uuidString)")
+            .appendingPathComponent("state.json")
+        return AppStateStore(url: url)
+    }
+
+    @Test("parses the changelog into entries")
+    func parses() {
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: makeStore())
+        #expect(model.entries.map(\.version) == ["0.3.0"])
+        #expect(model.hasContent)
+        #expect(model.displayVersion == "v0.3.0")
+    }
+
+    @Test("a fresh install is recorded as seen but not greeted with the changelog")
+    func freshInstall() {
+        let store = makeStore()
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == false)
+        #expect(store.load().lastSeenVersion == "0.3.0")
+    }
+
+    @Test("auto-presents once after an update, then records the new version")
+    func presentsOnUpdate() {
+        let store = makeStore()
+        try? store.save(AppState(lastSeenVersion: "0.2.2"))
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == true)
+        #expect(store.load().lastSeenVersion == "0.3.0")
+    }
+
+    @Test("does not re-present for the same version")
+    func sameVersion() {
+        let store = makeStore()
+        try? store.save(AppState(lastSeenVersion: "0.3.0"))
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == false)
+    }
+
+    @Test("a dev build with no version never auto-presents and doesn't crash")
+    func devBuild() {
+        let store = makeStore()
+        let model = WhatsNewModel(version: nil, changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == false)
+        #expect(store.load().lastSeenVersion == nil)
+        #expect(model.displayVersion == "dev build")
+    }
+
+    @Test("manual present opens it regardless of seen state")
+    func manualPresent() {
+        let store = makeStore()
+        try? store.save(AppState(lastSeenVersion: "0.3.0"))
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.present()
+        #expect(model.isPresented == true)
+    }
+}

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Print one version's section body from CHANGELOG.md — everything between the
+# "## [VERSION]" heading and the next "## " heading, without the heading line
+# itself. This is the single source the Release workflow uses for BOTH the GitHub
+# release body and the Sparkle appcast release notes, so all surfaces stay in sync
+# with CHANGELOG.md.
+#
+# Usage: scripts/changelog-section.sh <version> [changelog-path]
+#   e.g. scripts/changelog-section.sh 0.3.0
+set -euo pipefail
+
+VERSION="${1:?usage: changelog-section.sh <version> [changelog-path]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+awk -v ver="$VERSION" '
+  /^## / {
+    if (inSection) exit            # next version heading ends the section
+    hdr = $0
+    sub(/^## /, "", hdr)
+    sub(/ - .*/, "", hdr)          # drop " - DATE"
+    gsub(/[][ ]/, "", hdr)         # drop brackets and spaces -> bare version
+    if (hdr == ver) { inSection = 1; next }
+  }
+  inSection { print }
+' "$CHANGELOG" \
+  | awk 'NF {seen=1} seen {print}' \
+  | awk '{ lines[NR]=$0 } END { last=NR; while (last>0 && lines[last]=="") last--; for (i=1;i<=last;i++) print lines[i] }'

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -47,6 +47,10 @@ for b in "$BINDIR"/*.bundle; do
 done
 shopt -u nullglob
 
+# Ship the changelog so the in-app "What's New" window can read it (Brand reads
+# CHANGELOG.md from Contents/Resources in a packaged build).
+cp CHANGELOG.md "$APP/Contents/Resources/CHANGELOG.md"
+
 # Embed Sparkle.framework (SwiftPM stages it next to the binary) and point the
 # executable's runtime search path at the bundle's Frameworks dir.
 echo "==> embedding Sparkle.framework"


### PR DESCRIPTION
## What

Adds **`CHANGELOG.md` as the single source of release notes** and surfaces it everywhere: in-app, the Sparkle update prompt, the GitHub release body, and the teebe.io changelog page.

## Surfaces (all fed by CHANGELOG.md)

- **In-app "What's New"** — a pure changelog parser + semver compare in `TeebeCore`, a `WhatsNewModel` that auto-presents **once per new version** (and a Help → What's New menu item), rendered as a flat bullet list per version. The app version shows in the empty state. Packaging bundles `CHANGELOG.md` into the `.app`; `Brand` reads it from `Contents/Resources` with a dev fallback so `swift run` works too.
- **Sparkle appcast + GitHub release** — `scripts/changelog-section.sh` extracts the tag's section; the Release workflow uses it for the GitHub body (`body_path`) and the Sparkle notes (`generate_appcast --embed-release-notes`), so the update prompt finally shows real notes.
- **Website** — `publish-appcast` mirrors `CHANGELOG.md` onto teebe-site; the new changelog page (separate repo) reads it same-origin.

## Tests / verification

- 144 tests green. New coverage: changelog parser (grouping, wrapped bullets, dates), semver compare, and the once-per-version auto-present logic.
- Verified locally: built the packaged `.app`, simulated an update from 0.2.2 → the What's New window auto-presented with the parsed changelog; extractor output checked against `CHANGELOG.md`.
- CI-only bits (appcast notes, GitHub body) can't run locally — verified the `generate_appcast` release-notes mechanism and the extractor by hand.

## Note

The in-app window flattens the Added/Changed/Fixed groups (cleaner for users); the website and GitHub keep the groupings. Same source, surface-appropriate rendering.