### PR TITLE
Add privacy notice + route install through dl.teebe.io

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,43 @@
+# Privacy
+
+teebe is a local macOS app. Short version: we count downloads in aggregate so we
+know roughly how many people use teebe, and that's it. No accounts, no personal
+data, no tracking of what you do inside the app.
+
+The canonical, always-current version of this notice lives at
+**https://teebe.io/privacy.html**.
+
+## What we collect
+
+When you install teebe, the download is served through `dl.teebe.io`, which
+records one anonymous, aggregate event:
+
+- the app **version** you downloaded,
+- your **country** (derived at the edge, not stored as a precise location), and
+- the **user-agent** string your downloader sends.
+
+We use this only to gauge interest and adoption. It is not tied to your identity
+and is not sold or shared.
+
+## What we don't collect
+
+- We do **not** store your IP address.
+- We do **not** track anything you do inside the app — teebe contains no in-app
+  analytics or telemetry.
+- We do **not** use cookies or ad trackers.
+- We have no accounts, so there is no personal profile to collect.
+
+## Updates
+
+teebe checks for new versions via [Sparkle](https://sparkle-project.org/), which
+fetches an update feed from teebe.io. These are ordinary web requests subject to
+standard server logs; they are not used to profile you.
+
+## If this ever changes
+
+If we ever add in-app analytics, it will be **opt-in** and this notice will be
+updated first.
+
+## Contact
+
+Questions? Open an issue on [GitHub](https://github.com/klein-t/teebe).

--- a/install.sh
+++ b/install.sh
@@ -5,28 +5,30 @@
 # Installs teebe.app into /Applications without the Gatekeeper "unverified
 # developer" block. curl-downloaded files carry no com.apple.quarantine flag,
 # so the app opens on first launch with no dialog. Sparkle handles updates after.
+#
+# The download is fetched via https://dl.teebe.io, which records anonymous,
+# aggregate install stats (app version, country, user-agent — never your IP)
+# then redirects to the GitHub release asset. See https://teebe.io/privacy.html.
 set -euo pipefail
 
 REPO="klein-t/teebe"
 APP="teebe.app"
 DEST="/Applications"
 
-echo "Fetching latest teebe release…"
-# Pull the .zip asset URL from the latest release (zip name is versioned).
-ZIP_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep -o '"browser_download_url": *"[^"]*\.zip"' \
-  | head -1 | sed 's/.*"https/https/; s/"$//')
-
-if [ -z "${ZIP_URL}" ]; then
-  echo "error: could not find a .zip asset on the latest release" >&2
-  exit 1
-fi
-
 TMP=$(mktemp -d)
 trap 'rm -rf "${TMP}"' EXIT
 
-echo "Downloading ${ZIP_URL##*/}…"
-curl -fsSL "${ZIP_URL}" -o "${TMP}/teebe.zip"
+echo "Downloading teebe…"
+# Primary: through the download endpoint (counts the install). Falls back to a
+# direct GitHub fetch if the endpoint is unreachable.
+if ! curl -fsSL "https://dl.teebe.io" -o "${TMP}/teebe.zip"; then
+  echo "Download endpoint unavailable, fetching from GitHub…"
+  ZIP_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -o '"browser_download_url": *"[^"]*\.zip"' \
+    | head -1 | sed 's/.*"https/https/; s/"$//')
+  [ -n "${ZIP_URL}" ] || { echo "error: could not find a .zip asset on the latest release" >&2; exit 1; }
+  curl -fsSL "${ZIP_URL}" -o "${TMP}/teebe.zip"
+fi
 
 echo "Unpacking…"
 unzip -q "${TMP}/teebe.zip" -d "${TMP}"


### PR DESCRIPTION
Adds `PRIVACY.md` and routes `install.sh` downloads through `dl.teebe.io` (the Cloudflare Worker now live), so installs are counted with anonymous, aggregate stats (version, country, user-agent — never IP). GitHub fallback preserved if the endpoint is down.

The website side (teebe.io/install.sh + /privacy.html + footer link) is already live via the teebe-site repo. This syncs the app repo's copy and adds the canonical privacy doc to GitHub.

No app/build changes — no release required to merge.