### PR TITLE
Release v0.3.1

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,43 @@
+# Privacy
+
+teebe is a local macOS app. Short version: we count downloads in aggregate so we
+know roughly how many people use teebe, and that's it. No accounts, no personal
+data, no tracking of what you do inside the app.
+
+The canonical, always-current version of this notice lives at
+**https://teebe.io/privacy.html**.
+
+## What we collect
+
+When you install teebe, the download is served through `dl.teebe.io`, which
+records one anonymous, aggregate event:
+
+- the app **version** you downloaded,
+- your **country** (derived at the edge, not stored as a precise location), and
+- the **user-agent** string your downloader sends.
+
+We use this only to gauge interest and adoption. It is not tied to your identity
+and is not sold or shared.
+
+## What we don't collect
+
+- We do **not** store your IP address.
+- We do **not** track anything you do inside the app — teebe contains no in-app
+  analytics or telemetry.
+- We do **not** use cookies or ad trackers.
+- We have no accounts, so there is no personal profile to collect.
+
+## Updates
+
+teebe checks for new versions via [Sparkle](https://sparkle-project.org/), which
+fetches an update feed from teebe.io. These are ordinary web requests subject to
+standard server logs; they are not used to profile you.
+
+## If this ever changes
+
+If we ever add in-app analytics, it will be **opt-in** and this notice will be
+updated first.
+
+## Contact
+
+Questions? Open an issue on [GitHub](https://github.com/klein-t/teebe).

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -18,8 +18,18 @@ final class AppModel {
     let environment: AppEnvironment
     let selector: SelectorModel
 
+    /// In-memory copy of the persisted state, loaded once at init and written back
+    /// on change. Avoids a disk read-modify-write on every persist/layout update,
+    /// and lets `persist()` and `saveLayout()` mutate disjoint fields of one value
+    /// without reloading to avoid clobbering each other.
+    @ObservationIgnored private var state: AppState
+    /// True only while `bootstrap()` hydrates the model from `state`; suppresses the
+    /// `persist()` that property assignments would otherwise trigger during load.
+    @ObservationIgnored private var isHydrating = false
+
     init(environment: AppEnvironment) {
         self.environment = environment
+        self.state = environment.store.load()
         self.selector = SelectorModel(environment: environment)
         self.floatOnTop = false
         // Persist whenever the selection changes, and clear any stale global error —
@@ -45,16 +55,23 @@ final class AppModel {
 
     /// Load persisted state and hydrate repositories + selection.
     func bootstrap() async {
-        let state = environment.store.load()
+        // Hydrate from the in-memory state without letting the assignments below
+        // persist a half-built state back over what we just loaded.
+        isHydrating = true
         floatOnTop = state.floatOnTop
         repositories = state.repositories.map { Repository(path: $0.path) }
         selector.setRepositories(repositories)
-        let target = state.lastSelectedRepoPath.flatMap { last in repositories.first { $0.path == last } }
+        // Snapshot the restore targets before selecting anything: selection triggers
+        // persist(), which overwrites these fields of the shared `state`.
+        let lastRepoPath = state.lastSelectedRepoPath
+        let lastWorktreePath = state.lastSelectedWorktreePath
+        let target = lastRepoPath.flatMap { last in repositories.first { $0.path == last } }
             ?? repositories.first
+        isHydrating = false
         guard let target else { return }
         await selector.selectRepo(target)   // focuses the primary worktree
         // Restore the last selected worktree if it still exists (else keep primary).
-        if let wtPath = state.lastSelectedWorktreePath,
+        if let wtPath = lastWorktreePath,
            selector.selectedWorktree?.path != wtPath,
            let saved = selector.worktrees.first(where: { $0.path == wtPath }) {
             await selector.selectWorktree(saved)
@@ -232,7 +249,7 @@ final class AppModel {
     }
 
     func persist() {
-        var state = environment.store.load()
+        guard !isHydrating else { return }
         state.repositories = repositories.map { PersistedRepository(path: $0.path) }
         state.floatOnTop = floatOnTop
         state.lastSelectedRepoPath = selector.selectedRepo?.path
@@ -245,13 +262,12 @@ final class AppModel {
     /// The saved accordion layout for a repository, or nil if it's never been opened.
     func layout(forRepo path: String?) -> SectionLayout? {
         guard let path else { return nil }
-        return environment.store.load().layoutByRepo?[path]
+        return state.layoutByRepo?[path]
     }
 
     /// Remember a repository's accordion layout (open sections + window height).
     func saveLayout(_ layout: SectionLayout, forRepo path: String?) {
         guard let path else { return }
-        var state = environment.store.load()
         var byRepo = state.layoutByRepo ?? [:]
         byRepo[path] = layout
         state.layoutByRepo = byRepo

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -31,6 +31,17 @@ final class SelectorModel {
     var onSelectionChange: (() -> Void)?
 
     private let environment: AppEnvironment
+    /// Watches the selected repo's git dir so an external `git worktree add`/`remove`
+    /// shows up without a manual refresh.
+    private var repoWatcher: FileSystemWatcher?
+    /// Coalescing flags for watcher-driven re-scans (mirrors `WorktreeModel`): a burst
+    /// of `.git/worktrees` events collapses into at most one queued follow-up.
+    private var isRescanning = false
+    private var rescanQueued = false
+    /// Absolute path to the repo's `worktrees` admin dir (inside the git *common*
+    /// dir), used to filter watcher events. Resolved via `git rev-parse` so it's
+    /// correct even when `<repo>/.git` is a gitlink file rather than a directory.
+    private var worktreesAdminDir: String?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -55,6 +66,9 @@ final class SelectorModel {
     }
 
     func clearSelection() {
+        repoWatcher?.stop()
+        repoWatcher = nil
+        worktreesAdminDir = nil
         selectedRepo = nil
         worktrees = []
         selectedWorktree = nil
@@ -67,6 +81,7 @@ final class SelectorModel {
     /// worktree.
     func selectRepo(_ repo: Repository) async {
         selectedRepo = repo
+        await startRepoWatching(repo)
         do {
             worktrees = try await environment.worktreeService.worktrees(for: repo)
             branches = try await environment.branchService.branches(for: repo)
@@ -81,6 +96,87 @@ final class SelectorModel {
             await selectWorktree(primary)
         }
         onSelectionChange?()
+    }
+
+    // MARK: - Auto-detecting worktree add/remove
+
+    /// Watch the selected repo's git common dir. A `git worktree add`/`remove` (or
+    /// `prune`) rewrites `worktrees/…` there, which `handleRepoWatchEvent` filters
+    /// for; routine index/ref writes in the primary checkout are ignored.
+    private func startRepoWatching(_ repo: Repository) async {
+        repoWatcher?.stop()
+        let commonDir = await resolveGitCommonDir(for: repo)
+        worktreesAdminDir = (commonDir as NSString).appendingPathComponent("worktrees")
+        let watcher = environment.makeWatcher()
+        watcher.start(paths: [commonDir], debounce: 0.5) { [weak self] paths in
+            Task { @MainActor in await self?.handleRepoWatchEvent(paths) }
+        }
+        repoWatcher = watcher
+    }
+
+    /// The repo's git *common* dir — where worktree admin data lives regardless of
+    /// whether `<repo>/.git` is a real directory or a gitlink. Falls back to
+    /// `<repo>/.git` if `git rev-parse` can't answer.
+    private func resolveGitCommonDir(for repo: Repository) async -> String {
+        let fallback = (repo.path as NSString).appendingPathComponent(".git")
+        guard let result = try? await environment.git.run(["rev-parse", "--git-common-dir"], in: repo.path),
+              result.succeeded else { return fallback }
+        let raw = result.stdoutString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return fallback }
+        return (raw as NSString).isAbsolutePath ? raw : (repo.path as NSString).appendingPathComponent(raw)
+    }
+
+    /// FSEvents on the repo's git common dir: re-scan only when the change touched the
+    /// worktree admin area (`worktrees/…`). Internal + async so it is unit-testable
+    /// without real FSEvents.
+    func handleRepoWatchEvent(_ changedPaths: [String]) async {
+        guard selectedRepo != nil, let adminDir = worktreesAdminDir else { return }
+        guard changedPaths.contains(where: { $0.hasPrefix(adminDir) }) else { return }
+        await refreshWorktrees()
+    }
+
+    /// Re-discover the repo's worktrees + branches in place — the manual Refresh
+    /// button and the auto-detect watcher both land here. Unlike `selectRepo` it
+    /// preserves the current selection (only falling back to the primary if the
+    /// selected worktree has vanished), so a refresh never yanks the user off their
+    /// worktree. Concurrent calls coalesce into a single queued follow-up.
+    func refreshWorktrees() async {
+        if isRescanning { rescanQueued = true; return }
+        isRescanning = true
+        defer { isRescanning = false }
+        repeat {
+            rescanQueued = false
+            await rescanWorktrees()
+        } while rescanQueued
+    }
+
+    private func rescanWorktrees() async {
+        guard let repo = selectedRepo else { return }
+        let discovered: [Worktree]
+        let discoveredBranches: [Branch]
+        do {
+            discovered = try await environment.worktreeService.worktrees(for: repo)
+            discoveredBranches = try await environment.branchService.branches(for: repo)
+            errorMessage = nil
+        } catch {
+            // A transient failure shouldn't blank the list — keep what we have.
+            errorMessage = "\(error)"
+            return
+        }
+        worktrees = discovered
+        branches = discoveredBranches
+        await refreshWorktreeInfo()
+        // Keep the current selection if it still exists; only re-focus when it's gone.
+        if let current = selectedWorktree, discovered.contains(where: { $0.path == current.path }) {
+            return
+        }
+        if let fallback = discovered.first(where: { $0.isPrimary }) ?? discovered.first {
+            await selectWorktree(fallback)
+        } else {
+            selectedWorktree = nil
+            worktree.clear()
+            onSelectionChange?()
+        }
     }
 
     /// Load per-worktree ahead/behind + change count + live state for the

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -86,15 +86,30 @@ final class SelectorModel {
     /// Load per-worktree ahead/behind + change count + live state for the
     /// WORKTREES list (drives the sync arrows and pulse dot).
     func refreshWorktreeInfo(now: Date = Date()) async {
+        let statusService = environment.statusService
+        let worktrees = self.worktrees
+        // Fetch each worktree's status concurrently — these are independent git
+        // reads, so a repo with many worktrees shouldn't serialize N `git status`
+        // calls on every repo switch.
+        let statuses = await withTaskGroup(of: (String, StatusResult?).self) { group in
+            for worktree in worktrees {
+                let path = worktree.path
+                group.addTask { (path, try? await statusService.status(worktreePath: path)) }
+            }
+            var byPath: [String: StatusResult] = [:]
+            for await (path, status) in group {
+                if let status { byPath[path] = status }
+            }
+            return byPath
+        }
         var info: [String: WorktreeInfo] = [:]
         for worktree in worktrees {
-            let status = try? await environment.statusService.status(worktreePath: worktree.path)
-            let live = environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
+            let status = statuses[worktree.path]
             info[worktree.path] = WorktreeInfo(
                 ahead: status?.ahead ?? 0,
                 behind: status?.behind ?? 0,
                 changeCount: status?.changes.count ?? 0,
-                isLive: live
+                isLive: environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
             )
         }
         worktreeInfo = info

--- a/Sources/Teebe/ViewModels/WorktreeModel.swift
+++ b/Sources/Teebe/ViewModels/WorktreeModel.swift
@@ -58,6 +58,11 @@ final class WorktreeModel {
     private var ignoredPaths: Set<String> = []
     /// Overlaid children of expanded directories (path → children).
     private var childrenCache: [String: [FileNode]] = [:]
+    /// Coalesces watcher-driven refreshes: while one is running, further events
+    /// collapse into a single queued follow-up, so a burst of file-watch events
+    /// can't stack a backlog of `git status` calls behind one slow refresh.
+    private var isRefreshing = false
+    private var refreshQueued = false
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -150,7 +155,20 @@ final class WorktreeModel {
             environment.activityMonitor.recordActivity(worktreePath: worktreePath, at: now)
             onActivity?(worktreePath)
         }
-        await refresh()
+        await coalescedRefresh()
+    }
+
+    /// Run `refresh()`, collapsing concurrent watcher events into at most one
+    /// queued follow-up rather than one `git status` per event. Safe because the
+    /// model is `@MainActor`-isolated: the flag checks never interleave.
+    private func coalescedRefresh() async {
+        if isRefreshing { refreshQueued = true; return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        repeat {
+            refreshQueued = false
+            await refresh()
+        } while refreshQueued
     }
 
     /// Mark that teebe just wrote into the worktree, so the imminent file-watch

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -34,11 +34,11 @@ struct WorktreesSection: View {
                         }
                         .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
                         .help("Repository actions")
-                        Button { Task { await selector.refreshWorktreeInfo() } } label: {
+                        Button { Task { await selector.refreshWorktrees() } } label: {
                             Image(systemName: "arrow.clockwise").font(.system(size: 11))
                         }
                         .buttonStyle(IconButtonStyle()).foregroundStyle(Palette.secondaryText)
-                        .help("Refresh")
+                        .help("Refresh worktrees")
                     }
                 } else if let active = selector.selectedWorktree {
                     HStack(spacing: 5) {

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -17,12 +17,25 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     private(set) var discardedUntracked: [[String]] = []
     private(set) var commitMessages: [String] = []
 
+    // Instrumentation for refresh tests. The counter is lock-guarded because
+    // `refreshWorktreeInfo` now fetches statuses concurrently.
+    private let statusLock = NSLock()
+    private var statusCalls = 0
+    var statusCallCount: Int { statusLock.lock(); defer { statusLock.unlock() }; return statusCalls }
+    /// When set, each `status` call awaits this before returning — lets a test hold a
+    /// refresh "in flight" to exercise coalescing of watcher events.
+    var statusGate: (@Sendable () async -> Void)?
+
     func worktrees(repoPath: String) async throws -> [Worktree] {
         if let worktreesError { throw worktreesError }
         return worktreesResult
     }
     func branches(repoPath: String) async throws -> [Branch] { branchesResult }
-    func status(worktreePath: String) async throws -> StatusResult { statusResult }
+    func status(worktreePath: String) async throws -> StatusResult {
+        statusLock.lock(); statusCalls += 1; statusLock.unlock()
+        if let statusGate { await statusGate() }
+        return statusResult
+    }
     func workingDiff(worktreePath: String, path: String, staged: Bool) async throws -> DiffFile? { workingDiffResult }
     func stage(worktreePath: String, paths: [String]) async throws { stagedPaths.append(paths) }
     func unstage(worktreePath: String, paths: [String]) async throws { unstagedPaths.append(paths) }
@@ -34,6 +47,26 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     @discardableResult
     func run(_ arguments: [String], in directory: String) async throws -> GitInvocationResult {
         GitInvocationResult(arguments: arguments, exitCode: 0, standardOutput: Data(), standardError: "")
+    }
+}
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called, after which it
+/// returns immediately. Lets a test hold a faked `git status` in flight while it
+/// fires further events.
+actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let resume = waiters
+        waiters.removeAll()
+        for continuation in resume { continuation.resume() }
     }
 }
 

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -44,9 +44,16 @@ final class FakeGitClient: GitClient, @unchecked Sendable {
     func commit(worktreePath: String, message: String) async throws { commitMessages.append(message) }
     func addWorktree(repoPath: String, path: String, branch: String?, createBranch: Bool) async throws {}
     func removeWorktree(repoPath: String, worktreePath: String, force: Bool) async throws {}
+    /// Scripted stdout for `git rev-parse --git-common-dir` (the repo's git common
+    /// dir). When nil, `run` returns empty stdout and callers fall back to `.git`.
+    var gitCommonDirOutput: String?
     @discardableResult
     func run(_ arguments: [String], in directory: String) async throws -> GitInvocationResult {
-        GitInvocationResult(arguments: arguments, exitCode: 0, standardOutput: Data(), standardError: "")
+        var stdout = Data()
+        if arguments == ["rev-parse", "--git-common-dir"], let gitCommonDirOutput {
+            stdout = Data(gitCommonDirOutput.utf8)
+        }
+        return GitInvocationResult(arguments: arguments, exitCode: 0, standardOutput: stdout, standardError: "")
     }
 }
 
@@ -91,8 +98,38 @@ final class FakeFileOps: FileOps, @unchecked Sendable {
 
 final class FakeWatcher: FileSystemWatcher, @unchecked Sendable {
     private(set) var isWatching = false
-    func start(paths: [String], debounce: TimeInterval, onChange: @escaping @Sendable ([String]) -> Void) { isWatching = true }
-    func stop() { isWatching = false }
+    private(set) var watchedPaths: [String] = []
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private var handler: (@Sendable ([String]) -> Void)?
+
+    func start(paths: [String], debounce: TimeInterval, onChange: @escaping @Sendable ([String]) -> Void) {
+        isWatching = true
+        watchedPaths = paths
+        startCount += 1
+        handler = onChange
+    }
+
+    func stop() {
+        isWatching = false
+        stopCount += 1
+        handler = nil
+    }
+
+    /// Simulate a coalesced FSEvents change batch.
+    func fire(_ paths: [String]) { handler?(paths) }
+}
+
+/// Hands out and records every `FakeWatcher` the test environment creates, so a test
+/// can grab a specific one (e.g. the repo `.git` watcher) and fire events at it.
+@MainActor
+final class WatcherBox {
+    private(set) var watchers: [FakeWatcher] = []
+    func make() -> FakeWatcher { let watcher = FakeWatcher(); watchers.append(watcher); return watcher }
+    /// The most recently started watcher whose watched paths contain `needle`.
+    func watching(_ needle: String) -> FakeWatcher? {
+        watchers.last { $0.watchedPaths.contains { $0.contains(needle) } }
+    }
 }
 
 // MARK: - Test environment
@@ -103,7 +140,8 @@ func makeTestEnvironment(
     opener: FakeFileOpener = FakeFileOpener(),
     ops: FakeFileOps = FakeFileOps(),
     store: AppStateStore? = nil,
-    monitor: WorktreeActivityMonitor = WorktreeActivityMonitor()
+    monitor: WorktreeActivityMonitor = WorktreeActivityMonitor(),
+    makeWatcher: (@MainActor () -> FileSystemWatcher)? = nil
 ) -> AppEnvironment {
     let storeURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("tb-test-\(UUID().uuidString)")
@@ -114,6 +152,6 @@ func makeTestEnvironment(
         ops: ops,
         store: store ?? AppStateStore(url: storeURL),
         activityMonitor: monitor,
-        makeWatcher: { FakeWatcher() }
+        makeWatcher: makeWatcher ?? { FakeWatcher() }
     )
 }

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -154,6 +154,132 @@ struct SelectorModelTests {
         await selector.refreshWorktreeInfo(now: t.addingTimeInterval(1))
         #expect(selector.info(for: git.worktreesResult[0]).isLive == true)
     }
+
+    @Test("repo watcher watches the repo's .git dir and stops when the selection clears")
+    func repoWatcherLifecycle() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let box = WatcherBox()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, makeWatcher: { box.make() }))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        let repoWatcher = box.watching("/repo/.git")
+        #expect(repoWatcher?.watchedPaths == ["/repo/.git"])
+        #expect(repoWatcher?.isWatching == true)
+
+        selector.clearSelection()
+        #expect(repoWatcher?.isWatching == false)
+    }
+
+    @Test("the watcher follows the git common dir when <repo>/.git is a gitlink")
+    func repoWatcherResolvesGitCommonDir() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/wt-root", branch: "feature", isPrimary: true)]
+        git.gitCommonDirOutput = "/main/.git"   // <repo>/.git is a gitlink → real data lives here
+        let box = WatcherBox()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, makeWatcher: { box.make() }))
+        await selector.selectRepo(Repository(path: "/wt-root"))
+
+        // It watches the resolved common dir, not /wt-root/.git.
+        #expect(box.watching("/main/.git")?.watchedPaths == ["/main/.git"])
+
+        // An add under the common dir's worktrees admin area is detected.
+        git.worktreesResult = [
+            Worktree(path: "/wt-root", branch: "feature", isPrimary: true),
+            Worktree(path: "/wt-2", branch: "feature-2"),
+        ]
+        await selector.handleRepoWatchEvent(["/main/.git/worktrees/wt-2/HEAD"])
+        #expect(selector.worktrees.count == 2)
+    }
+
+    @Test("an external git worktree add is auto-detected via the repo .git watcher")
+    func autoDetectAdd() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let box = WatcherBox()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, makeWatcher: { box.make() }))
+        await selector.selectRepo(Repository(path: "/repo"))
+        #expect(selector.worktrees.count == 1)
+
+        // `git worktree add ../wt feature` lands a new admin dir under .git/worktrees.
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt", branch: "feature"),
+        ]
+        await selector.handleRepoWatchEvent(["/repo/.git/worktrees/wt/HEAD"])
+        #expect(selector.worktrees.map(\.path) == ["/repo", "/wt"])
+    }
+
+    @Test("a non-worktree .git write does not trigger a re-scan")
+    func ignoresNonWorktreeGitWrites() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        // The set changes underneath, but an index write in the primary checkout is
+        // not under .git/worktrees, so the list must stay put.
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt", branch: "feature"),
+        ]
+        await selector.handleRepoWatchEvent(["/repo/.git/index"])
+        #expect(selector.worktrees.count == 1)
+    }
+
+    @Test("refreshWorktrees picks up a new worktree without yanking the selection")
+    func refreshPreservesSelection() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt-a", branch: "feature-a"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+        await selector.selectWorktree(git.worktreesResult[1])   // focus feature-a
+        #expect(selector.selectedWorktree?.path == "/wt-a")
+
+        git.worktreesResult.append(Worktree(path: "/wt-b", branch: "feature-b"))
+        await selector.refreshWorktrees()
+        #expect(selector.worktrees.count == 3)
+        #expect(selector.selectedWorktree?.path == "/wt-a")
+    }
+
+    @Test("refreshWorktrees falls back to primary when the selected worktree disappears")
+    func refreshFallsBackWhenSelectionRemoved() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt-a", branch: "feature-a"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+        await selector.selectWorktree(git.worktreesResult[1])
+        #expect(selector.selectedWorktree?.path == "/wt-a")
+
+        // feature-a is removed externally.
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        await selector.refreshWorktrees()
+        #expect(selector.worktrees.map(\.path) == ["/repo"])
+        #expect(selector.selectedWorktree?.path == "/repo")
+    }
+
+    @Test("a transient discovery failure keeps the existing worktree list")
+    func refreshKeepsListOnError() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/wt-a", branch: "feature-a"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+        #expect(selector.worktrees.count == 2)
+
+        git.worktreesError = .notAGitRepository(path: "/repo")
+        await selector.refreshWorktrees()
+        #expect(selector.worktrees.count == 2)   // unchanged — not blanked
+        #expect(selector.selectedWorktree?.path == "/repo")
+    }
 }
 
 @MainActor

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -73,6 +73,28 @@ struct AppModelTests {
         await app.selector.selectRepo(Repository(path: "/repo"))
         #expect(app.errorMessage == nil)
     }
+
+    @Test("a repo's layout persists, survives unrelated state writes, and reloads")
+    func layoutPersistence() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let env = makeTestEnvironment(git: git)
+        let app = AppModel(environment: env)
+        _ = await app.addRepository(path: "/repo")   // triggers persist()
+
+        let layout = SectionLayout(worktreesOpen: false, changesOpen: true, filesOpen: false, windowHeight: 720)
+        app.saveLayout(layout, forRepo: "/repo")
+
+        // A later persist() (here via floatOnTop) must not clobber the saved layout —
+        // both now mutate one in-memory AppState rather than reloading from disk.
+        app.floatOnTop = true
+        #expect(app.layout(forRepo: "/repo") == layout)
+
+        // And it round-trips through disk to a freshly constructed model.
+        let reopened = AppModel(environment: env)
+        #expect(reopened.layout(forRepo: "/repo") == layout)
+        #expect(reopened.layout(forRepo: "/unknown") == nil)
+    }
 }
 
 @MainActor
@@ -206,6 +228,38 @@ struct WorktreeModelTests {
         await model.confirmPendingMutation()
         #expect(model.pendingMutation == nil)
         #expect(git.discardedWorking == [["a.txt"]])
+    }
+
+    @Test("watcher events coalesce: a burst behind a slow refresh runs one follow-up")
+    func refreshCoalesces() async {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let git = FakeGitClient()
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        #expect(git.statusCallCount == 1)   // initial refresh from load()
+
+        // Gate status so the next refresh blocks until we release it.
+        let gate = Gate()
+        git.statusGate = { await gate.wait() }
+
+        // First watcher event enters status (call #2) and blocks in flight.
+        let inFlight = Task { await model.handleFileSystemEvent(now: Date(timeIntervalSince1970: 1)) }
+        while git.statusCallCount < 2 { await Task.yield() }
+
+        // Five more events while #2 is in flight must collapse into a single queued
+        // follow-up rather than each spawning its own status call.
+        let burst = (0..<5).map { i in
+            Task { await model.handleFileSystemEvent(now: Date(timeIntervalSince1970: Double(2 + i))) }
+        }
+        for _ in 0..<50 { await Task.yield() }
+        #expect(git.statusCallCount == 2)   // still only the in-flight call
+
+        await gate.open()
+        await inFlight.value
+        for task in burst { await task.value }
+
+        // In-flight refresh + exactly one coalesced follow-up == one more status call.
+        #expect(git.statusCallCount == 3)
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -5,28 +5,30 @@
 # Installs teebe.app into /Applications without the Gatekeeper "unverified
 # developer" block. curl-downloaded files carry no com.apple.quarantine flag,
 # so the app opens on first launch with no dialog. Sparkle handles updates after.
+#
+# The download is fetched via https://dl.teebe.io, which records anonymous,
+# aggregate install stats (app version, country, user-agent — never your IP)
+# then redirects to the GitHub release asset. See https://teebe.io/privacy.html.
 set -euo pipefail
 
 REPO="klein-t/teebe"
 APP="teebe.app"
 DEST="/Applications"
 
-echo "Fetching latest teebe release…"
-# Pull the .zip asset URL from the latest release (zip name is versioned).
-ZIP_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep -o '"browser_download_url": *"[^"]*\.zip"' \
-  | head -1 | sed 's/.*"https/https/; s/"$//')
-
-if [ -z "${ZIP_URL}" ]; then
-  echo "error: could not find a .zip asset on the latest release" >&2
-  exit 1
-fi
-
 TMP=$(mktemp -d)
 trap 'rm -rf "${TMP}"' EXIT
 
-echo "Downloading ${ZIP_URL##*/}…"
-curl -fsSL "${ZIP_URL}" -o "${TMP}/teebe.zip"
+echo "Downloading teebe…"
+# Primary: through the download endpoint (counts the install). Falls back to a
+# direct GitHub fetch if the endpoint is unreachable.
+if ! curl -fsSL "https://dl.teebe.io" -o "${TMP}/teebe.zip"; then
+  echo "Download endpoint unavailable, fetching from GitHub…"
+  ZIP_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -o '"browser_download_url": *"[^"]*\.zip"' \
+    | head -1 | sed 's/.*"https/https/; s/"$//')
+  [ -n "${ZIP_URL}" ] || { echo "error: could not find a .zip asset on the latest release" >&2; exit 1; }
+  curl -fsSL "${ZIP_URL}" -o "${TMP}/teebe.zip"
+fi
 
 echo "Unpacking…"
 unzip -q "${TMP}/teebe.zip" -d "${TMP}"

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.3.0}"
+APP_VERSION="${APP_VERSION:-0.3.1}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with


### PR DESCRIPTION
## v0.3.1

Ships the unreleased dev backlog to users via Sparkle:

- Reduce resource use: in-memory state, coalesced refreshes, parallel status
- Audit follow-ups (#45)
- Auto-detect external worktree add/remove (#46)
- Add PRIVACY.md + route install.sh through dl.teebe.io download endpoint (#48)

Version bumped to 0.3.1 (#49). Merge with a **regular merge commit** (not squash), then tag v0.3.1 on main.