### PR TITLE
Add keyboard navigation, multi-select, and bounded section sizing

### DIFF
--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -11,6 +11,12 @@ final class AppModel {
     var floatOnTop: Bool { didSet { persist() } }
     private(set) var errorMessage: String?
 
+    /// Which section the keyboard currently drives — arrows, Enter and Space act on
+    /// it, and its header shows the active accent. Moved by ⌘1/⌘2/⌘3, Tab/⇧Tab, or by
+    /// clicking into a section.
+    enum FocusSection: Equatable { case worktrees, changes, files }
+    var activeSection: FocusSection = .files
+
     /// Auto-dismiss timer for the current error banner, so a transient failure
     /// (e.g. "Not a git repository") never sticks around indefinitely.
     @ObservationIgnored private var errorClearTask: Task<Void, Never>?
@@ -142,6 +148,20 @@ final class AppModel {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(node.path, forType: .string)
     }
+
+    /// ⌘⇧C: copy the FILES selection to the clipboard as Claude-ready `@`-refs, ready
+    /// to paste into whatever terminal/agent is open. No-op unless files are selected.
+    func copySelectedRefs() {
+        let refs = selector.worktree.selectionRefs()
+        guard !refs.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(refs, forType: .string)
+    }
+
+    /// ⌘F: ask the FILES search field to take focus. The view observes this counter
+    /// and focuses on change (a token rather than a bool so repeat presses re-fire).
+    private(set) var searchFocusRequest = 0
+    func focusSearch() { searchFocusRequest += 1 }
 
     func rename(_ node: FileNode) {
         guard let newName = promptForName(title: "Rename", initial: node.name), newName != node.name else { return }

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -217,7 +217,32 @@ final class SelectorModel {
 
     func selectWorktree(_ wt: Worktree) async {
         selectedWorktree = wt
+        highlightedWorktree = wt
         await worktree.load(worktreePath: wt.path, repo: selectedRepo)
         onSelectionChange?()
+    }
+
+    // MARK: - Keyboard navigation (WORKTREES)
+
+    /// The keyboard cursor in the WORKTREES list, distinct from the committed
+    /// `selectedWorktree`: ↑/↓ move it, Enter commits it (switching the worktree).
+    var highlightedWorktree: Worktree?
+
+    /// Seed the cursor on the currently-open worktree (when WORKTREES becomes active).
+    func highlightSelectedWorktree() { highlightedWorktree = selectedWorktree }
+
+    /// Move the keyboard cursor one row (no switch — that happens on commit).
+    func moveWorktreeHighlight(by delta: Int) {
+        guard !worktrees.isEmpty else { return }
+        let base = highlightedWorktree ?? selectedWorktree
+        let index = base.flatMap { b in worktrees.firstIndex { $0.path == b.path } } ?? 0
+        let next = max(0, min(worktrees.count - 1, index + delta))
+        highlightedWorktree = worktrees[next]
+    }
+
+    /// Commit the highlighted worktree (Enter): switch to it unless it's already current.
+    func commitHighlightedWorktree() async {
+        guard let wt = highlightedWorktree, wt.path != selectedWorktree?.path else { return }
+        await selectWorktree(wt)
     }
 }

--- a/Sources/Teebe/ViewModels/WorktreeModel.swift
+++ b/Sources/Teebe/ViewModels/WorktreeModel.swift
@@ -35,6 +35,12 @@ final class WorktreeModel {
     var selectionSource: SelectionSource = .files
     /// Expanded directory paths in the FILES tree.
     var expandedPaths: Set<String> = []
+    /// Multi-selection set for the FILES tree (absolute paths). `selectedPath` is the
+    /// active cursor and is always a member while a file selection exists; batch ops
+    /// (trash, copy-as-refs) act on this set.
+    var selectedPaths: Set<String> = []
+    /// Anchor row for range (⇧) selection; the fixed end as the cursor moves.
+    private var selectionAnchor: String?
     private(set) var worktreePath: String?
     private(set) var errorMessage: String?
     private(set) var pendingMutation: PendingMutation?
@@ -304,11 +310,168 @@ final class WorktreeModel {
         let rows = visibleRows
         guard !rows.isEmpty else { return }
         guard let current = selectedPath, let index = rows.firstIndex(where: { $0.node.path == current }) else {
-            selectedPath = rows.first?.node.path
+            select(rows[0].node.path)
             return
         }
         let next = max(0, min(rows.count - 1, index + delta))
-        selectedPath = rows[next].node.path
+        select(rows[next].node.path)
+    }
+
+    // MARK: - Multi-selection (FILES)
+
+    /// Single-select `path` (plain click / plain arrow): collapses any multi-selection
+    /// to just this row and re-anchors range selection here.
+    func select(_ path: String) {
+        selectionSource = .files
+        selectedPath = path
+        selectedPaths = [path]
+        selectionAnchor = path
+    }
+
+    /// ⌘-click: toggle `path` in/out of the selection, leaving the rest intact.
+    func toggleSelection(_ path: String) {
+        selectionSource = .files
+        if selectedPaths.contains(path) {
+            selectedPaths.remove(path)
+            if selectedPath == path { selectedPath = selectedPaths.first }
+        } else {
+            selectedPaths.insert(path)
+            selectedPath = path
+        }
+        selectionAnchor = path
+    }
+
+    /// ⇧-click / range select: select the contiguous visible run from the anchor to
+    /// `path` inclusive, moving the cursor to `path` (the anchor stays put).
+    func extendSelection(to path: String) {
+        let order = visibleRows.map(\.node.path)
+        guard let anchor = selectionAnchor ?? selectedPath,
+              let a = order.firstIndex(of: anchor),
+              let b = order.firstIndex(of: path) else { select(path); return }
+        selectionSource = .files
+        selectedPaths = Set(order[min(a, b)...max(a, b)])
+        selectedPath = path
+    }
+
+    /// ⇧↑ / ⇧↓: move the cursor one row and extend the range selection to it.
+    func extendSelection(by delta: Int) {
+        let rows = visibleRows
+        guard !rows.isEmpty else { return }
+        guard let current = selectedPath, let index = rows.firstIndex(where: { $0.node.path == current }) else {
+            select(rows[0].node.path); return
+        }
+        if selectionAnchor == nil { selectionAnchor = current }
+        let next = max(0, min(rows.count - 1, index + delta))
+        extendSelection(to: rows[next].node.path)
+    }
+
+    /// ⌘A: select every visible row.
+    func selectAllVisible() {
+        let order = visibleRows.map(\.node.path)
+        guard !order.isEmpty else { return }
+        selectionSource = .files
+        selectedPaths = Set(order)
+        if selectedPath == nil || !selectedPaths.contains(selectedPath!) { selectedPath = order.last }
+    }
+
+    /// Selected paths in visible (top-to-bottom) order.
+    func orderedSelection() -> [String] {
+        visibleRows.map(\.node.path).filter { selectedPaths.contains($0) }
+    }
+
+    /// Selected file nodes (directories excluded), in visible order — used to "open all".
+    func selectedFileNodes() -> [FileNode] {
+        orderedSelection().compactMap { node(atPath: $0) }.filter { !$0.isDirectory }
+    }
+
+    // MARK: - CHANGES list navigation
+
+    /// Move the CHANGES selection by `delta` through the change list (in display
+    /// order), clamping at the ends. Returns the newly selected change so the caller
+    /// can refresh an open diff peek.
+    @discardableResult
+    func moveChangeSelection(by delta: Int) -> FileChange? {
+        guard let worktreePath, !changes.isEmpty else { return nil }
+        selectionSource = .changes
+        let absolute = changes.map { worktreePath + "/" + $0.path }
+        let index = selectedPath.flatMap { absolute.firstIndex(of: $0) }
+        let next = index.map { max(0, min(absolute.count - 1, $0 + delta)) } ?? 0
+        selectedPath = absolute[next]
+        return changes[next]
+    }
+
+    /// Keep the current change selected if it's still valid, else select the first —
+    /// used when the CHANGES section becomes active. Returns the resulting change.
+    @discardableResult
+    func selectCurrentOrFirstChange() -> FileChange? {
+        guard let worktreePath, !changes.isEmpty else { return nil }
+        selectionSource = .changes
+        let absolute = changes.map { worktreePath + "/" + $0.path }
+        if let selectedPath, let index = absolute.firstIndex(of: selectedPath) { return changes[index] }
+        selectedPath = absolute[0]
+        return changes[0]
+    }
+
+    // MARK: - Left/Right arrow tree navigation (VSCode-style)
+
+    /// →: expand a collapsed folder; on an already-expanded folder, step into its
+    /// first child. No-op on a file.
+    func selectExpandOrDescend() {
+        guard let node = selectedNode else {
+            if let first = visibleRows.first { select(first.node.path) }
+            return
+        }
+        guard node.isDirectory else { return }
+        if isExpanded(node) {
+            let rows = visibleRows
+            guard let i = rows.firstIndex(where: { $0.node.path == node.path }) else { return }
+            if i + 1 < rows.count, rows[i + 1].depth > rows[i].depth {
+                select(rows[i + 1].node.path)
+            }
+        } else {
+            toggleExpand(node)
+        }
+    }
+
+    /// ←: collapse an expanded folder; on a collapsed folder or a file, jump up to the
+    /// parent folder.
+    func selectCollapseOrAscend() {
+        guard let node = selectedNode else { return }
+        if node.isDirectory, isExpanded(node) {
+            toggleExpand(node)
+            return
+        }
+        let rows = visibleRows
+        guard let i = rows.firstIndex(where: { $0.node.path == node.path }) else { return }
+        let depth = rows[i].depth
+        guard depth > 0 else { return }
+        for j in stride(from: i - 1, through: 0, by: -1) where rows[j].depth == depth - 1 {
+            select(rows[j].node.path)
+            return
+        }
+    }
+
+    // MARK: - Selection as Claude-ready @-refs (clipboard)
+
+    /// The current FILES selection as a single clipboard string of `@`-prefixed paths
+    /// relative to the worktree root, in visible order, space-joined (each token quoted
+    /// when it contains spaces). Empty when nothing is selected or no worktree is open.
+    func selectionRefs() -> String {
+        guard let worktreePath else { return "" }
+        let root = PathUtil.standardized(worktreePath)
+        let tokens = orderedSelection().map { absolute -> String in
+            let rel = PathUtil.relativePath(of: absolute, under: root)
+            return rel.contains(" ") ? "@\"\(rel)\"" : "@\(rel)"
+        }
+        return tokens.joined(separator: " ")
+    }
+
+    /// Move the current multi-selection to the Trash (guarded; shows the confirm
+    /// dialog). No-op when the selection is empty.
+    func requestTrashSelected(now: Date = Date()) {
+        let paths = orderedSelection()
+        guard !paths.isEmpty else { return }
+        pendingMutation = PendingMutation(kind: .trash, paths: paths, worktreeBusy: isBusy(now))
     }
 
     /// Find a node by absolute path within the currently displayed (and expanded)

--- a/Sources/Teebe/Views/ChangesSection.swift
+++ b/Sources/Teebe/Views/ChangesSection.swift
@@ -10,7 +10,7 @@ struct ChangesSection: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SectionHeader(title: "CHANGES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
+            SectionHeader(title: "CHANGES", isOpen: isOpen, isActive: app.activeSection == .changes, onToggle: { isOpen.toggle() }) {
                 HStack(spacing: 8) {
                     countBadge(worktree.changeCount)
                     if let active = app.selector.selectedWorktree {
@@ -26,11 +26,20 @@ struct ChangesSection: View {
                 // Hug the rows (the window wraps content); cap at the content height
                 // and scroll inside only when the window is dragged too short.
                 VStack(spacing: 0) {
-                    ScrollView {
-                        changeList
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            changeList
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                        .frame(maxHeight: listContentHeight)
+                        // Follow the selection when ↑/↓ moves it past the visible edge.
+                        // Snap, not animate (see FilesSection): an animated scrollTo
+                        // reads as a bounce against the row highlight + relayout.
+                        .onChange(of: worktree.selectedPath) { _, sel in
+                            guard app.activeSection == .changes, let sel else { return }
+                            proxy.scrollTo(sel, anchor: nil)
+                        }
                     }
-                    .scrollBounceBehavior(.basedOnSize)
-                    .frame(maxHeight: listContentHeight)
                 }
                 .padding(.top, 8)
                 .padding(.bottom, 6)
@@ -40,11 +49,18 @@ struct ChangesSection: View {
         .clipped()
     }
 
-    /// Estimated natural height of the change list, used to cap the section so it
-    /// hugs its rows yet can shrink-and-scroll when space is tight.
+    /// Tallest the change list hugs before it scrolls internally. Bounds how much the
+    /// window grows for a worktree with many changes, so browsing between worktrees with
+    /// very different change counts doesn't lurch the window. RootView's
+    /// `changesContentHeight` mirrors this cap so the window math and the view agree.
+    static let maxListHeight: CGFloat = 144   // ~6 rows (24pt each), then scroll
+
+    /// Natural height of the change list (rows are 24pt tall), capped at `maxListHeight`
+    /// so the section hugs its rows up to the cap and scrolls beyond it.
     private var listContentHeight: CGFloat {
         let count = worktree.changeCount
-        return count == 0 ? 24 : CGFloat(count) * 24   // rows are 24pt tall
+        let natural: CGFloat = count == 0 ? 24 : CGFloat(count) * 24
+        return min(natural, Self.maxListHeight)
     }
 
     private var changeList: some View {
@@ -76,7 +92,7 @@ struct ChangesSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(selected ? Palette.accent : .clear)
         .foregroundStyle(selected ? .white : .primary)
-        .animation(.easeInOut(duration: 0.18), value: selected)
+        // Snap, no cross-fade — avoids the trailing highlight when arrowing fast.
         .contentShape(Rectangle())
         .onTapGesture { select(change) }
         .contextMenu {
@@ -87,6 +103,7 @@ struct ChangesSection: View {
             }
             Button("Discard…", role: .destructive) { worktree.requestDiscard(change) }
         }
+        .id(absolutePath(of: change) ?? change.path)   // matches selectedPath for scroll-to
     }
 
     private func absolutePath(of change: FileChange) -> String? {
@@ -94,7 +111,7 @@ struct ChangesSection: View {
     }
 
     private func isSelected(_ change: FileChange) -> Bool {
-        worktree.selectionSource == .changes && worktree.selectedPath == absolutePath(of: change)
+        app.activeSection == .changes && worktree.selectedPath == absolutePath(of: change)
     }
 
     /// Click a change → select it (highlight). Space then peeks its diff. If the
@@ -102,6 +119,7 @@ struct ChangesSection: View {
     private func select(_ change: FileChange) {
         guard let worktreePath = worktree.worktreePath else { return }
         let node = FileNode(path: worktreePath + "/" + change.path, isDirectory: false, change: change)
+        app.activeSection = .changes
         worktree.selectedPath = node.path
         worktree.selectionSource = .changes
         if preview.isVisible {

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -174,6 +174,9 @@ extension View {
 struct SectionHeader<Trailing: View>: View {
     let title: String
     let isOpen: Bool
+    /// Whether this is the section the keyboard is currently driving — tints the title
+    /// in the accent colour so the active section is always visible.
+    var isActive: Bool = false
     let onToggle: () -> Void
     @ViewBuilder var trailing: () -> Trailing
 
@@ -202,7 +205,8 @@ struct SectionHeader<Trailing: View>: View {
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)
-                .foregroundStyle(Palette.headerLabel)
+                .foregroundStyle(isActive ? Palette.accent : Palette.headerLabel)
+                .animation(.easeInOut(duration: 0.18), value: isActive)
                 .fixedSize()
                 .layoutPriority(1)
             Spacer(minLength: 6)

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import TeebeCore
 
 /// FILES accordion section: search + sort + the lazily-expanding file tree.
@@ -7,10 +8,18 @@ struct FilesSection: View {
     @Bindable var worktree: WorktreeModel
     @Bindable var preview: PreviewModel
     @Binding var isOpen: Bool
+    /// Owned by RootView; lets ⌘F focus the search field and ↓/Esc hand focus back.
+    var searchFocused: FocusState<Bool>.Binding
+    /// The reveal area the tree fills below its search box. Fixed (not flexible) while
+    /// browsing so a CHANGES reflow can't momentarily balloon FILES.
+    var revealHeight: CGFloat
+    /// While the window edge is being dragged, FILES becomes the flexible filler so the
+    /// drag resizes it; otherwise it's pinned to `revealHeight`.
+    var liveResizing: Bool
 
     var body: some View {
         VStack(spacing: 0) {
-            SectionHeader(title: "FILES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
+            SectionHeader(title: "FILES", isOpen: isOpen, isActive: app.activeSection == .files, onToggle: { isOpen.toggle() }) {
                 if isOpen {
                     Menu {
                         Picker("Show", selection: $worktree.filter) {
@@ -42,15 +51,54 @@ struct FilesSection: View {
                         .textFieldStyle(.roundedBorder)
                         .font(.system(size: 12))
                         .padding(.horizontal, 11).padding(.vertical, 5)
-                    ScrollView {
-                        FileRowsView(app: app, preview: preview)
+                        .focused(searchFocused)
+                        .onChange(of: app.searchFocusRequest) { _, _ in searchFocused.wrappedValue = true }
+                        // ↓ drops focus into the results so the tree's arrow keys take over.
+                        .onKeyPress(.downArrow) {
+                            searchFocused.wrappedValue = false
+                            if let first = worktree.visibleRows.first,
+                               worktree.selectedPath == nil
+                                || !worktree.visibleRows.contains(where: { $0.node.path == worktree.selectedPath }) {
+                                worktree.select(first.node.path)
+                            }
+                            return .handled
+                        }
+                        // Enter opens the current (or first) result without leaving the field.
+                        .onKeyPress(.return) {
+                            guard let node = worktree.selectedNode ?? worktree.visibleRows.first?.node else { return .ignored }
+                            if node.isDirectory { worktree.toggleExpand(node) } else { app.open(node) }
+                            return .handled
+                        }
+                        // Esc clears the query first, then hands focus back to the tree.
+                        .onKeyPress(.escape) {
+                            if worktree.searchQuery.isEmpty { searchFocused.wrappedValue = false } else { worktree.searchQuery = "" }
+                            return .handled
+                        }
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            FileRowsView(app: app, preview: preview)
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                        // Keep the keyboard cursor on-screen: scroll the minimal amount
+                        // to reveal it when ↑/↓ moves selection past the visible edge.
+                        // Snap, don't animate — an animated scrollTo fights the row's
+                        // highlight animation and SwiftUI's relayout and reads as a
+                        // bounce (the old row flashes before settling). Finder/Xcode
+                        // snap on keyboard nav too.
+                        .onChange(of: worktree.selectedPath) { _, sel in
+                            guard app.activeSection == .files, let sel else { return }
+                            proxy.scrollTo(sel, anchor: nil)
+                        }
                     }
-                    .scrollBounceBehavior(.basedOnSize)
                 }
                 .transition(.opacity)
             }
         }
-        .frame(maxHeight: isOpen ? .infinity : nil)
+        // Open + idle → a fixed reveal pane (the tree scrolls inside it), so a CHANGES
+        // height change can't make FILES balloon for a frame. Open + dragging → the
+        // flexible filler, so the window edge resizes the reveal. Closed → just the header.
+        .frame(height: isOpen && !liveResizing ? revealHeight : nil)
+        .frame(maxHeight: isOpen && liveResizing ? .infinity : nil)
         .clipped()
     }
 }
@@ -86,7 +134,7 @@ struct FileRow: View {
 
     private var worktree: WorktreeModel { app.selector.worktree }
     private var node: FileNode { row.node }
-    private var isSelected: Bool { worktree.selectedPath == node.path }
+    private var isSelected: Bool { app.activeSection == .files && worktree.selectedPaths.contains(node.path) }
     private var isExpanded: Bool { worktree.isExpanded(node) }
 
     var body: some View {
@@ -117,7 +165,8 @@ struct FileRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isSelected ? Palette.accent : .clear)
         .foregroundStyle(isSelected ? .white : .primary)
-        .animation(.easeInOut(duration: 0.18), value: isSelected)
+        // No fade on selection: a 0.18s cross-fade leaves a visible trail of
+        // half-lit rows when arrowing fast. The cursor snaps, like native file lists.
         .contentShape(Rectangle())
         .onTapGesture { select() }
         .simultaneousGesture(TapGesture(count: 2).onEnded { activate() })
@@ -139,9 +188,18 @@ struct FileRow: View {
     }
 
     private func select() {
-        worktree.selectedPath = node.path
-        worktree.selectionSource = .files
-        if node.isDirectory { worktree.toggleExpand(node) }
+        // ⌘-click toggles one row; ⇧-click extends a range; a plain click single-selects
+        // (and toggles a folder's expansion).
+        app.activeSection = .files
+        let mods = NSEvent.modifierFlags
+        if mods.contains(.command) {
+            worktree.toggleSelection(node.path)
+        } else if mods.contains(.shift) {
+            worktree.extendSelection(to: node.path)
+        } else {
+            worktree.select(node.path)
+            if node.isDirectory { worktree.toggleExpand(node) }
+        }
         if preview.isVisible, !node.isDirectory, let wt = worktree.worktreePath {
             Task { await preview.update(for: node, worktreePath: wt) }
         }

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -18,10 +18,18 @@ struct RootView: View {
     /// scrolls; dragging the window's bottom edge while FILES is open updates it, and
     /// it's remembered per repo.
     @State private var filesReveal: CGFloat = 300
+    /// True only while the user is actively dragging the window's edge. FILES is a
+    /// fixed-height pane the rest of the time (so a CHANGES reflow can't make it balloon
+    /// for a frame); during a drag it becomes the flexible filler so the edge resizes it.
+    @State private var isLiveResizing = false
+    /// Focus of the FILES search field, lifted here so ⌘F can drive it and the
+    /// command-key shortcuts can stand down while the user is typing in it.
+    @FocusState private var searchFocused: Bool
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
 
     private var worktree: WorktreeModel { app.selector.worktree }
+    private var selector: SelectorModel { app.selector }
 
     /// Window height when all three sections are collapsed: the compact title row
     /// plus the three stacked headers (with their separators), no slack below.
@@ -49,14 +57,19 @@ struct RootView: View {
             } else {
                 // Pinned-header accordion: every section header stays visible. The
                 // window wraps its content (see targetHeight), so WORKTREES and CHANGES
-                // simply hug their rows; only FILES — whose tree is unbounded — fills
-                // the remaining height and scrolls.
+                // hug their rows (capped, then scroll); FILES is a fixed reveal pane that
+                // becomes the flexible filler only while the window edge is being dragged.
                 VStack(spacing: 0) {
+                    // Higher priority so WORKTREES/CHANGES keep their hugged height and
+                    // FILES yields: while dragging, FILES is the flexible filler and would
+                    // otherwise make the VStack split space evenly and squeeze CHANGES.
                     WorktreesSection(app: app, isOpen: sectionBinding(.worktrees, openWorktrees))
+                        .layoutPriority(1)
                     Divider()
                     ChangesSection(app: app, worktree: worktree, preview: preview, isOpen: sectionBinding(.changes, openChanges))
+                        .layoutPriority(1)
                     Divider()
-                    FilesSection(app: app, worktree: worktree, preview: preview, isOpen: sectionBinding(.files, openFiles))
+                    FilesSection(app: app, worktree: worktree, preview: preview, isOpen: sectionBinding(.files, openFiles), searchFocused: $searchFocused, revealHeight: filesReveal, liveResizing: isLiveResizing)
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
             }
@@ -81,8 +94,8 @@ struct RootView: View {
                 setTrafficLights(visible: false, animated: false, window: resolved)
                 applyLayout(for: app.selector.selectedRepo?.path)
             },
-            onLiveResizeStart: { setHeightLocked(heightPinned, height: targetHeight()) },
-            onLiveResizeEnd: { handleLiveResizeEnd($0) }
+            onLiveResizeStart: { isLiveResizing = true; setHeightLocked(heightPinned, height: targetHeight()) },
+            onLiveResizeEnd: { isLiveResizing = false; handleLiveResizeEnd($0) }
         ))
         .onChange(of: app.selector.selectedRepo?.path) { _, path in applyLayout(for: path) }
         // Keep WORKTREES/CHANGES wrapped to their rows as the lists change (preserving
@@ -95,13 +108,19 @@ struct RootView: View {
             if !allClosed { applyWindowSizing(animated: false) }
         }
         .background(QuickLookBridge(controller: quickLook))
+        .background { commandShortcuts }
         .focusable()
         .focusEffectDisabled()
         .onKeyPress(.space) { handleSpace(); return .handled }
         .onKeyPress(.escape) { preview.close(); dismissWindow(id: "preview"); return .handled }
-        .onKeyPress(.upArrow) { move(-1); return .handled }
-        .onKeyPress(.downArrow) { move(1); return .handled }
+        .onKeyPress(keys: [.upArrow, .downArrow, .leftArrow, .rightArrow]) { handleArrow($0) }
         .onKeyPress(.return) { activateSelected(); return .handled }
+        // Tab / ⇧Tab cycle the active section (stands down while typing in search).
+        .onKeyPress(keys: [.tab]) { press in
+            guard !searchFocused else { return .ignored }
+            cycleSection(forward: !press.modifiers.contains(.shift))
+            return .handled
+        }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {
             Button("Confirm", role: .destructive) { Task { await worktree.confirmPendingMutation() } }
             Button("Cancel", role: .cancel) { worktree.cancelPendingMutation() }
@@ -194,15 +213,18 @@ struct RootView: View {
         applyWindowSizing(animated: false)
     }
 
-    /// `true` only when every section is collapsed: the window then shrinks to the
-    /// three stacked headers and its height is pinned.
-    private var heightPinned: Bool { allClosed }
+    /// `true` whenever FILES is closed: the window then *wraps* its content exactly
+    /// (headers, plus WORKTREES/CHANGES hugged to their capped rows), so its height is
+    /// pinned. Leaving it free in these states let SwiftUI's idealHeight drift the
+    /// window a frame later and open an 18pt "chin" of empty material below the content.
+    /// Only FILES open (the unbounded scroller) makes the window freely resizable.
+    private var heightPinned: Bool { !openFiles }
 
-    /// When the window is pinned (all-collapsed) drive the SwiftUI frame to that exact
+    /// When the window is pinned (FILES closed) drive the SwiftUI frame to that exact
     /// height so `windowResizability` reports the same min/ideal/max we set on the
-    /// `NSWindow`; otherwise SwiftUI's content-min re-clamps the window a frame later
-    /// and leaves an empty "chin" below the last header. `nil` (free height) whenever a
-    /// section is open.
+    /// `NSWindow`; otherwise SwiftUI's idealHeight re-clamps the window a frame later
+    /// and leaves an empty "chin" of material below the content. `nil` (free height)
+    /// only while FILES is open.
     ///
     /// `targetHeight()` is a *window* height; SwiftUI's `.frame` sizes the *content*
     /// (`contentLayoutRect`) and the window is that plus a constant title-bar inset. We
@@ -228,22 +250,23 @@ struct RootView: View {
         (window?.screen ?? NSScreen.main)?.visibleFrame.height ?? 900
     }
 
-    /// Estimated natural height of the open worktree list (mirrors WorktreesSection);
+    /// Height of the open worktree list (mirrors WorktreesSection, including its cap);
     /// 0 when closed.
     private var worktreesContentHeight: CGFloat {
         guard openWorktrees else { return 0 }
         let s = app.selector
         let repoRow: CGFloat = s.selectedRepo != nil ? 25 : 0
         let rows: CGFloat = s.worktrees.isEmpty ? 26 : CGFloat(s.worktrees.count) * 26
-        return 8 + repoRow + rows
+        return min(8 + repoRow + rows, WorktreesSection.maxListHeight)
     }
 
-    /// Estimated natural height of the open change list (mirrors ChangesSection); 0
-    /// when closed.
+    /// Height of the open change list (mirrors ChangesSection, including its cap); 0
+    /// when closed. The +14 is the section's top/bottom padding around the list.
     private var changesContentHeight: CGFloat {
         guard openChanges else { return 0 }
         let count = app.selector.worktree.changeCount
-        return 14 + (count == 0 ? 24 : CGFloat(count) * 24)
+        let natural: CGFloat = count == 0 ? 24 : CGFloat(count) * 24
+        return 14 + min(natural, ChangesSection.maxListHeight)
     }
 
     /// Size the window to the current state, anchored at the top so it grows and
@@ -310,21 +333,170 @@ struct RootView: View {
 
     // MARK: - Keyboard
 
-    private func move(_ delta: Int) {
+    /// Arrow-key navigation, dispatched to whichever section is active. WORKTREES:
+    /// move the keyboard cursor (Enter commits). CHANGES: move the selection and track
+    /// the open diff peek. FILES: move/extend the cursor and ←/→ collapse-expand.
+    private func handleArrow(_ press: KeyPress) -> KeyPress.Result {
+        let result: KeyPress.Result
+        switch app.activeSection {
+        case .worktrees: result = handleWorktreeArrow(press)
+        case .changes:   result = handleChangesArrow(press)
+        case .files:     result = handleFilesArrow(press)
+        }
+        return result
+    }
+
+    /// WORKTREES: ↑/↓ move the keyboard cursor (no switch — Enter commits).
+    private func handleWorktreeArrow(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .upArrow:   selector.moveWorktreeHighlight(by: -1)
+        case .downArrow: selector.moveWorktreeHighlight(by: 1)
+        default:         return .ignored
+        }
+        return .handled
+    }
+
+    /// CHANGES: ↑/↓ move the selection and follow the open diff peek.
+    private func handleChangesArrow(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .upArrow:   moveChange(by: -1)
+        case .downArrow: moveChange(by: 1)
+        default:         return .ignored
+        }
+        return .handled
+    }
+
+    /// FILES: ↑/↓ move/extend the cursor; ←/→ collapse-expand or jump parent/child.
+    private func handleFilesArrow(_ press: KeyPress) -> KeyPress.Result {
         worktree.selectionSource = .files
-        delta < 0 ? worktree.selectPrevious() : worktree.selectNext()
-        if preview.isVisible, let node = worktree.selectedNode, !node.isDirectory,
-           let wt = worktree.worktreePath {
-            Task { await preview.update(for: node, worktreePath: wt) }
+        let shift = press.modifiers.contains(.shift)
+        switch press.key {
+        case .upArrow:
+            if shift { worktree.extendSelection(by: -1) } else { worktree.selectPrevious() }
+        case .downArrow:
+            if shift { worktree.extendSelection(by: 1) } else { worktree.selectNext() }
+        case .leftArrow:  worktree.selectCollapseOrAscend()
+        case .rightArrow: worktree.selectExpandOrDescend()
+        default:          return .ignored
+        }
+        syncPreviewToSelection()
+        return .handled
+    }
+
+    /// Move the CHANGES selection and, if the diff peek is open, swap its content to
+    /// the newly selected file in place (the preview window itself does not move).
+    private func moveChange(by delta: Int) {
+        guard let change = worktree.moveChangeSelection(by: delta),
+              preview.isVisible, let wt = worktree.worktreePath else { return }
+        let node = FileNode(path: wt + "/" + change.path, isDirectory: false, change: change)
+        Task { await preview.update(for: node, worktreePath: wt) }
+    }
+
+    // MARK: - Section focus (⌘1/2/3, Tab)
+
+    /// ⌘1/⌘2/⌘3: if the section is already active, toggle it open/closed; otherwise
+    /// make it active (opening it and moving the selection in).
+    private func focusOrToggle(_ section: AppModel.FocusSection) {
+        if app.activeSection == section {
+            setOpen(rootSection(section), !sectionIsOpen(section))
+        } else {
+            activate(section)
         }
     }
 
-    /// Spacebar previews the current selection: the native Quick Look panel for a
-    /// FILES row, or the in-app diff peek for a CHANGES row.
+    /// Tab / ⇧Tab: move the active section forward/back through WORKTREES→CHANGES→FILES.
+    private func cycleSection(forward: Bool) {
+        let order: [AppModel.FocusSection] = [.worktrees, .changes, .files]
+        let index = order.firstIndex(of: app.activeSection) ?? 2
+        activate(order[(index + (forward ? 1 : order.count - 1)) % order.count])
+    }
+
+    /// Make `section` the active one: open it if collapsed, and seat the selection
+    /// (the open worktree for WORKTREES, the current/first change, or a file cursor).
+    private func activate(_ section: AppModel.FocusSection) {
+        app.activeSection = section
+        if !sectionIsOpen(section) { setOpen(rootSection(section), true) }
+        switch section {
+        case .worktrees:
+            selector.highlightSelectedWorktree()
+        case .changes:
+            if let change = worktree.selectCurrentOrFirstChange(), preview.isVisible, let wt = worktree.worktreePath {
+                let node = FileNode(path: wt + "/" + change.path, isDirectory: false, change: change)
+                Task { await preview.update(for: node, worktreePath: wt) }
+            }
+        case .files:
+            worktree.selectionSource = .files
+            let hasValidCursor = worktree.selectedPath.map { sel in worktree.visibleRows.contains { $0.node.path == sel } } ?? false
+            if !hasValidCursor, let first = worktree.visibleRows.first { worktree.select(first.node.path) }
+        }
+    }
+
+    private func rootSection(_ s: AppModel.FocusSection) -> Section {
+        switch s {
+        case .worktrees: .worktrees
+        case .changes:   .changes
+        case .files:     .files
+        }
+    }
+
+    private func sectionIsOpen(_ s: AppModel.FocusSection) -> Bool {
+        switch s {
+        case .worktrees: openWorktrees
+        case .changes:   openChanges
+        case .files:     openFiles
+        }
+    }
+
+    /// Keep the live preview tracking the cursor as it moves over files.
+    private func syncPreviewToSelection() {
+        guard preview.isVisible, let node = worktree.selectedNode, !node.isDirectory,
+              let wt = worktree.worktreePath else { return }
+        Task { await preview.update(for: node, worktreePath: wt) }
+    }
+
+    /// Hidden buttons that register the command-key shortcuts window-wide. Disabled
+    /// while the search field is focused so ⌘A / ⌘⌫ keep editing the query text there.
+    private var commandShortcuts: some View {
+        Group {
+            Button("") { focusOrToggle(.worktrees) }.keyboardShortcut("1", modifiers: .command)
+            Button("") { focusOrToggle(.changes) }.keyboardShortcut("2", modifiers: .command)
+            Button("") { focusOrToggle(.files) }.keyboardShortcut("3", modifiers: .command)
+            Button("") { focusSearch() }.keyboardShortcut("f", modifiers: .command)
+            Button("") { if app.activeSection == .files { worktree.selectAllVisible() } }.keyboardShortcut("a", modifiers: .command)
+            Button("") { copyRefs() }.keyboardShortcut("c", modifiers: [.command, .shift])
+            Button("") { trashSelection() }.keyboardShortcut(.delete, modifiers: .command)
+        }
+        .opacity(0)
+        .frame(width: 0, height: 0)
+        .accessibilityHidden(true)
+        .disabled(searchFocused)
+    }
+
+    /// ⌘F: open FILES if needed and hand focus to its search field.
+    private func focusSearch() {
+        if !openFiles { setOpen(.files, true) }
+        app.focusSearch()
+    }
+
+    /// ⌘⇧C: copy the FILES selection to the clipboard as Claude-ready `@`-refs.
+    private func copyRefs() {
+        guard app.activeSection == .files else { return }
+        app.copySelectedRefs()
+    }
+
+    /// ⌘⌫: move the FILES selection to the Trash (guarded by the confirm dialog).
+    private func trashSelection() {
+        guard app.activeSection == .files else { return }
+        worktree.requestTrashSelected()
+    }
+
+    /// Spacebar previews the active section's selection: the native Quick Look panel
+    /// for a FILES row, the in-app diff peek for a CHANGES row, nothing for WORKTREES.
     private func handleSpace() {
-        switch worktree.selectionSource {
-        case .changes: toggleDiffPeek()
-        case .files: presentQuickLook()
+        switch app.activeSection {
+        case .changes:   toggleDiffPeek()
+        case .files:     presentQuickLook()
+        case .worktrees: break
         }
     }
 
@@ -346,6 +518,18 @@ struct RootView: View {
         Task {
             await preview.toggle(for: node, worktreePath: wt)
             openWindow(id: "preview")
+            await reclaimKeyFocus()
+        }
+    }
+
+    /// The freshly-opened peek scene becomes the key window and would swallow ↑/↓, so
+    /// the CHANGES/FILES list couldn't drive it. Hand key status back to the main
+    /// window (the peek stays visible — it floats above and only its content updates).
+    /// Retried across a few runloops because the scene becomes key asynchronously.
+    private func reclaimKeyFocus() async {
+        for _ in 0..<3 {
+            try? await Task.sleep(for: .milliseconds(80))
+            window?.makeKey()
         }
     }
 
@@ -360,9 +544,23 @@ struct RootView: View {
         quickLook.toggle(urls: urls, startIndex: start)
     }
 
+    /// Enter, dispatched by active section: WORKTREES commits the highlighted worktree
+    /// (the switch); CHANGES opens the changed file; FILES opens the file(s) or toggles
+    /// a folder.
     private func activateSelected() {
-        guard let node = worktree.selectedNode else { return }
-        if node.isDirectory { worktree.toggleExpand(node) } else { app.open(node) }
+        switch app.activeSection {
+        case .worktrees:
+            Task { await selector.commitHighlightedWorktree() }
+        case .changes:
+            guard let wt = worktree.worktreePath, let change = selectedChange else { return }
+            app.open(FileNode(path: wt + "/" + change.path, isDirectory: false, change: change))
+        case .files:
+            guard let node = worktree.selectedNode else { return }
+            if node.isDirectory { worktree.toggleExpand(node); return }
+            // With several files selected, Enter opens them all; otherwise just the cursor.
+            let files = worktree.selectedFileNodes()
+            if files.count > 1 { files.forEach { app.open($0) } } else { app.open(node) }
+        }
     }
 
     // MARK: - Guarded mutation confirmation

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -11,7 +11,7 @@ struct WorktreesSection: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SectionHeader(title: "WORKTREES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
+            SectionHeader(title: "WORKTREES", isOpen: isOpen, isActive: app.activeSection == .worktrees, onToggle: { isOpen.toggle() }) {
                 if isOpen {
                     HStack(spacing: 2) {
                         Button { app.presentAddRepositoryPanel() } label: {
@@ -57,21 +57,34 @@ struct WorktreesSection: View {
                 // Hug the rows (the window wraps content), but cap at the content
                 // height and scroll inside when the window is dragged too short — the
                 // other headers must never get pushed off-screen.
-                ScrollView { worktreeListBody }
-                    .scrollBounceBehavior(.basedOnSize)
-                    .frame(maxHeight: listContentHeight)
-                    .transition(.opacity)
+                ScrollViewReader { proxy in
+                    ScrollView { worktreeListBody }
+                        .scrollBounceBehavior(.basedOnSize)
+                        .frame(maxHeight: listContentHeight)
+                        // Keep the keyboard cursor visible as ↑/↓ move it. Snap, not
+                        // animate (see FilesSection) — avoids the bounce-then-settle.
+                        .onChange(of: selector.highlightedWorktree?.path) { _, path in
+                            guard app.activeSection == .worktrees, let path else { return }
+                            proxy.scrollTo(path, anchor: nil)
+                        }
+                }
+                .transition(.opacity)
             }
         }
         .clipped()
     }
 
-    /// Estimated natural height of the worktree list, used to cap the section so it
-    /// hugs its rows yet can shrink-and-scroll when space is tight.
+    /// Tallest the worktree list hugs before it scrolls internally (repo row + ~6
+    /// worktrees). Keeps the window from ballooning on a repo with many worktrees;
+    /// RootView's `worktreesContentHeight` mirrors this cap.
+    static let maxListHeight: CGFloat = 200
+
+    /// Natural height of the worktree list, capped at `maxListHeight` so the section
+    /// hugs its rows up to the cap and scrolls beyond it.
     private var listContentHeight: CGFloat {
         let repoRow: CGFloat = selector.selectedRepo != nil ? 25 : 0
         let rows: CGFloat = selector.worktrees.isEmpty ? 26 : CGFloat(selector.worktrees.count) * 26
-        return 8 + repoRow + rows   // 8 = worktreeListBody vertical padding
+        return min(8 + repoRow + rows, Self.maxListHeight)   // 8 = worktreeListBody vertical padding
     }
 
     private var worktreeListBody: some View {
@@ -109,6 +122,9 @@ struct WorktreesSection: View {
     private func worktreeRow(_ worktree: Worktree) -> some View {
         let info = selector.info(for: worktree)
         let isActive = selector.selectedWorktree?.path == worktree.path
+        // The keyboard cursor (only while WORKTREES is the active section): an outline,
+        // distinct from the filled accent of the committed worktree. Enter commits it.
+        let isHighlighted = app.activeSection == .worktrees && selector.highlightedWorktree?.path == worktree.path
         return HStack(spacing: 7) {
             LiveDot(active: info.isLive)
             Image(systemName: "point.3.connected.trianglepath.dotted")
@@ -127,9 +143,18 @@ struct WorktreesSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isActive ? Palette.accent : .clear)
         .foregroundStyle(isActive ? .white : .primary)
+        .overlay {
+            if isHighlighted, !isActive {
+                RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.accent, lineWidth: 1.5)
+            }
+        }
         .animation(.easeInOut(duration: 0.18), value: isActive)
         .contentShape(Rectangle())
-        .onTapGesture { Task { await selector.selectWorktree(worktree) } }
+        .onTapGesture {
+            app.activeSection = .worktrees
+            selector.highlightedWorktree = worktree
+            Task { await selector.selectWorktree(worktree) }
+        }
         .contextMenu {
             Button("Open in Finder") { app.revealPath(worktree.path) }
             Button("Open in Terminal") { app.openTerminal(at: worktree.path) }
@@ -137,5 +162,6 @@ struct WorktreesSection: View {
                 Button("Remove Worktree…", role: .destructive) { app.removeWorktree(worktree) }
             }
         }
+        .id(worktree.path)   // scroll-to target for keyboard highlight
     }
 }

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -117,6 +117,31 @@ struct SelectorModelTests {
         #expect(selector.worktree.worktreePath == "/repo")
     }
 
+    @Test("WORKTREES keyboard cursor moves and clamps; Enter commits the switch")
+    func worktreeHighlightNav() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-a", branch: "feat/a"),
+            Worktree(path: "/repo-b", branch: "feat/b"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        // Activating WORKTREES seats the cursor on the currently-open worktree.
+        selector.highlightSelectedWorktree()
+        #expect(selector.highlightedWorktree?.path == "/repo")
+
+        selector.moveWorktreeHighlight(by: 1)
+        #expect(selector.highlightedWorktree?.path == "/repo-a")
+        selector.moveWorktreeHighlight(by: 5)   // clamps at the last row
+        #expect(selector.highlightedWorktree?.path == "/repo-b")
+        #expect(selector.selectedWorktree?.path == "/repo")   // not switched until commit
+
+        await selector.commitHighlightedWorktree()
+        #expect(selector.selectedWorktree?.path == "/repo-b")
+    }
+
     @Test("live dot lights for a worktree written to within the window, off after it")
     func liveDotWindow() async {
         let git = FakeGitClient()
@@ -442,6 +467,137 @@ struct WorktreeNavigationTests {
         #expect(model.visibleRows.map(\.node.name) == ["b.txt"])
     }
 
+    // MARK: - Left/Right arrow tree navigation
+
+    @Test("→ expands a collapsed folder, then descends into its first child")
+    func rightArrowExpandsThenDescends() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let src = try #require(model.visibleRows.first { $0.node.name == "src" }).node
+        model.select(src.path)
+
+        model.selectExpandOrDescend()
+        #expect(model.isExpanded(src))
+        #expect(model.selectedPath == src.path)   // cursor stays on the folder
+
+        model.selectExpandOrDescend()
+        #expect(model.selectedNode?.name == "b.txt")   // now steps into the child
+    }
+
+    @Test("← collapses an expanded folder; from a child it jumps to the parent")
+    func leftArrowCollapsesAndAscends() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let src = try #require(model.visibleRows.first { $0.node.name == "src" }).node
+        model.select(src.path)
+        model.selectExpandOrDescend()   // expand
+        let b = try #require(model.visibleRows.first { $0.node.name == "b.txt" }).node
+        model.select(b.path)
+
+        model.selectCollapseOrAscend()   // file → jump to parent
+        #expect(model.selectedNode?.name == "src")
+        #expect(model.isExpanded(src))   // parent stays expanded
+
+        model.selectCollapseOrAscend()   // expanded folder → collapse
+        #expect(model.isExpanded(src) == false)
+    }
+
+    // MARK: - Multi-selection
+
+    @Test("⌘-toggle and ⇧-range build and collapse the multi-selection")
+    func multiSelectToggleAndRange() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let rows = model.visibleRows.map(\.node.path)
+        let (first, second) = (rows[0], rows[1])
+
+        model.select(first)
+        model.toggleSelection(second)
+        #expect(model.selectedPaths == [first, second])
+        model.toggleSelection(second)
+        #expect(model.selectedPaths == [first])
+
+        model.select(first)
+        model.extendSelection(to: second)
+        #expect(model.selectedPaths == [first, second])
+        #expect(model.orderedSelection() == [first, second])   // visible (top-down) order
+
+        model.selectAllVisible()
+        #expect(model.selectedPaths.count == rows.count)
+
+        // A plain arrow collapses any multi-selection back to a single cursor.
+        model.selectPrevious()
+        #expect(model.selectedPaths.count == 1)
+    }
+
+    @Test("⇧↓ extends the selection by one row")
+    func shiftArrowExtends() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.select(model.visibleRows[0].node.path)
+        model.extendSelection(by: 1)
+        #expect(model.selectedPaths.count == 2)
+    }
+
+    @Test("selectedFileNodes excludes directories")
+    func selectedFileNodesExcludesDirs() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.selectAllVisible()   // src (dir) + a.txt
+        let files = model.selectedFileNodes()
+        #expect(files.allSatisfy { !$0.isDirectory })
+        #expect(files.contains { $0.name == "a.txt" })
+    }
+
+    @Test("requestTrashSelected stages a trash mutation for the whole selection")
+    func trashSelected() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.selectAllVisible()
+        model.requestTrashSelected(now: Date())
+        #expect(model.pendingMutation?.kind == .trash)
+        #expect(Set(model.pendingMutation?.paths ?? []) == model.selectedPaths)
+    }
+
+    // MARK: - Selection as @-refs
+
+    @Test("selectionRefs emits @-prefixed worktree-relative paths in visible order")
+    func selectionRefsFormat() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let src = try #require(model.visibleRows.first { $0.node.name == "src" }).node
+        model.select(src.path)
+        model.selectExpandOrDescend()   // expand so src/b.txt is visible
+        let b = try #require(model.visibleRows.first { $0.node.name == "b.txt" }).node
+        let a = try #require(model.visibleRows.first { $0.node.name == "a.txt" }).node
+        model.select(a.path)
+        model.toggleSelection(b.path)
+
+        // Visible order is src/b.txt (depth 1, under src) then a.txt.
+        #expect(model.selectionRefs() == "@src/b.txt @a.txt")
+    }
+
+    @Test("selectionRefs quotes a path containing spaces")
+    func selectionRefsQuotesSpaces() async throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("tb-refs-\(UUID().uuidString)")
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? "x".write(to: dir.appendingPathComponent("my file.txt"), atomically: true, encoding: .utf8)
+        defer { try? fm.removeItem(at: dir) }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir.path, repo: Repository(path: dir.path))
+        let file = try #require(model.visibleRows.first { $0.node.name == "my file.txt" }).node
+        model.select(file.path)
+        #expect(model.selectionRefs() == "@\"my file.txt\"")
+    }
+
     @Test("changeGroups groups changes by folder")
     func changeGroups() async {
         let (dir, cleanup) = tempTree(); defer { cleanup() }
@@ -456,6 +612,28 @@ struct WorktreeNavigationTests {
         let folders = model.changeGroups.map(\.folder)
         #expect(folders.contains("src"))
         #expect(folders.contains(""))
+    }
+
+    @Test("CHANGES selection moves through the list and clamps at the ends")
+    func changeNavigation() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let git = FakeGitClient()
+        git.statusResult = StatusResult(changes: [
+            FileChange(path: "a.txt", worktreeStatus: .modified),
+            FileChange(path: "src/b.txt", worktreeStatus: .modified),
+        ])
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+
+        let first = try? #require(model.selectCurrentOrFirstChange())
+        #expect(model.selectionSource == .changes)
+        #expect(model.selectedPath == dir + "/" + model.changes[0].path)
+        #expect(first?.path == model.changes[0].path)
+
+        #expect(model.moveChangeSelection(by: 1)?.path == model.changes[1].path)
+        #expect(model.selectedPath == dir + "/" + model.changes[1].path)
+        #expect(model.moveChangeSelection(by: 1)?.path == model.changes[1].path)   // clamp at end
+        #expect(model.moveChangeSelection(by: -5)?.path == model.changes[0].path)  // clamp at start
     }
 
     @Test("commitPending stages and commits, then clears the message")


### PR DESCRIPTION
## Summary

Full VSCode-style keyboard control of the WORKTREES / CHANGES / FILES accordion, plus multi-select, clipboard refs, and a reworked section-sizing model that keeps the window visually stable while browsing.

### Keyboard navigation
- Arrows drive the **active section**; ←/→ collapse/expand or jump parent↔child in FILES, ↑/↓ move the cursor in WORKTREES and CHANGES.
- **⌘1/⌘2/⌘3** focus a section (or toggle it open/closed when already active); **Tab / ⇧Tab** cycle the active section, shown by an accent header.
- **⌘F** jumps to the FILES search box (↓/Enter/Esc to navigate results); **Enter** opens; **Space** peeks (Quick Look for files, in-app diff for changes). The peek/preview follows the cursor in place.

### Multi-select & actions
- Multi-select files (⌘/⇧-click, ⇧↑/↓, ⌘A).
- **⌘⌫** moves the selection to the Trash (guarded by the confirm dialog).
- **⌘⇧C** copies the selection as Claude-ready `@`-refs to the clipboard.

### Bounded section sizing (fixes browse-time resize jank)
- WORKTREES/CHANGES hug their rows only up to a cap, then scroll internally → switching between worktrees with very different change counts no longer lurches the window (**~450px swing → ~120px**).
- FILES is a fixed reveal pane while browsing, flexible filler only while dragging the edge → no mid-switch balloon, never starved below its floor.
- Window pinned to wrap content whenever FILES is closed → removes an 18px empty "chin".

Verified numerically across all 8 open/close combinations and browsing 0/4/21-change worktrees: window == computed target everywhere, FILES never deviates from its two legitimate heights.

## Testing
- `swift build`, `swift test` (141 tests, 31 suites), portable `swiftlint lint` (0 errors) all green.
- Resize behavior vetted via the `teebe-fe-verify` instrument-and-self-drive methodology (all temporary instrumentation stripped before commit).