### PR TITLE
Keyboard Shortcuts cheat sheet, chip-styled keys, and vertical zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to teebe are documented here. The format is based on
 - **Bounded section sizing.** The Worktrees and Changes lists now scroll inside their
   own area once they get tall, instead of growing without limit. The window stays a
   stable size as you switch between worktrees.
+- **Vertical maximize.** The green window button now grows teebe to the full screen
+  height at its current width (filling with the file tree) instead of zooming to cover
+  the whole screen. Click it again to restore the previous size.
 
 ## [0.3.0] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,29 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.0] - 2026-06-30
 
 ### Added
-- Worktrees added or removed **outside** teebe (e.g. `git worktree add` / `remove`
-  in a terminal) are now detected automatically and appear in the WORKTREES list
-  without a manual action. The Refresh button forces a full re-scan.
-- A **What's New** window that shows this changelog inside the app — opened
-  automatically the first time you launch a new version, and any time from
-  Help → What's New.
+- **Keyboard navigation.** Drive the whole window without the mouse. Arrow keys move
+  through Worktrees, Changes and Files. `⌘1` / `⌘2` / `⌘3` focus a section (press again
+  to collapse), and `Tab` cycles between them. `Return` opens a file or switches
+  worktree, and `Space` Quick Looks a file or peeks a diff.
+- **Multi-select and send to your agent.** Select several files with `⌘`- or `⇧`-click,
+  `⇧↑` / `⇧↓`, or `⌘A`. Copy them as AI-agent-ready `@`-refs with `⌘⇧C`, or move them to
+  the Trash with `⌘⌫`.
+- **Automatic worktree detection.** Worktrees you add or remove outside teebe (for
+  example with `git worktree add` in a terminal) now appear on their own, with no
+  manual action. The Refresh button forces a full re-scan.
+- **Keyboard Shortcuts cheat sheet.** Press `?` (or open Help → Keyboard Shortcuts) for
+  the full list.
+- **Jump to search** with `⌘F`.
+- **What's New window.** Shows this changelog inside the app: automatically on the
+  first launch after an update, and any time from Help → What's New.
+
+### Changed
+- **Bounded section sizing.** The Worktrees and Changes lists now scroll inside their
+  own area once they get tall, instead of growing without limit. The window stays a
+  stable size as you switch between worktrees.
 
 ## [0.3.0] - 2026-06-24
 

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -51,6 +51,9 @@ struct TeebeApp: App {
                 .sheet(isPresented: $whatsNew.isPresented) {
                     WhatsNewView(model: whatsNew)
                 }
+                .sheet(isPresented: $app.showKeyboardShortcuts) {
+                    KeyboardShortcutsView()
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
@@ -60,6 +63,8 @@ struct TeebeApp: App {
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
                 Button("What's New in \(Brand.name)") { whatsNew.present() }
+                Button("Keyboard Shortcuts") { app.showKeyboardShortcuts = true }
+                    .keyboardShortcut("/", modifiers: .command)
             }
         }
 

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -17,6 +17,10 @@ final class AppModel {
     enum FocusSection: Equatable { case worktrees, changes, files }
     var activeSection: FocusSection = .files
 
+    /// Drives the Keyboard Shortcuts cheat sheet. Toggled by the `?` key, the Help
+    /// menu item (⌘/), and dismissed from the sheet. Not persisted — purely transient UI.
+    var showKeyboardShortcuts = false
+
     /// Auto-dismiss timer for the current error banner, so a transient failure
     /// (e.g. "Not a git repository") never sticks around indefinitely.
     @ObservationIgnored private var errorClearTask: Task<Void, Never>?

--- a/Sources/Teebe/Views/KeyboardShortcutsView.swift
+++ b/Sources/Teebe/Views/KeyboardShortcutsView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// The Keyboard Shortcuts cheat sheet: every shortcut grouped by what it acts on.
+/// Opened with `?` (or Help → Keyboard Shortcuts, ⌘/) and dismissed with Esc/Close.
+/// Its content comes from `ShortcutsCatalog`, the single source of truth.
+struct KeyboardShortcutsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    ForEach(ShortcutsCatalog.groups) { group in
+                        groupView(group)
+                    }
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 460, height: 560)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            if let logo = Brand.logo {
+                Image(nsImage: logo).resizable().interpolation(.high).scaledToFit()
+                    .frame(width: 44, height: 44)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Keyboard Shortcuts")
+                    .font(.system(size: 16, weight: .semibold))
+                Text("Drive \(Brand.name) without the mouse")
+                    .font(.system(size: 12)).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20).padding(.vertical, 16)
+    }
+
+    private func groupView(_ group: ShortcutGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(group.title.uppercased())
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(Palette.accent)
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(group.items) { item in
+                    row(item)
+                }
+            }
+        }
+    }
+
+    private func row(_ item: ShortcutItem) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            keyChips(item.keys)
+                .frame(width: 150, alignment: .leading)
+            Text(item.action)
+                .font(.system(size: 12.5))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Render a row's `keys` string as rounded keycap chips: split alternatives on
+    /// " / " (joined by a dim slash), and for gestures like "⌘-click" chip the modifier
+    /// and keep "-click" as plain text. Matches the chip style in the What's New window.
+    private func keyChips(_ keys: String) -> some View {
+        let segments = keys.components(separatedBy: " / ")
+        return HStack(alignment: .firstTextBaseline, spacing: 4) {
+            ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
+                if index > 0 {
+                    Text("/").font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
+                }
+                if let dash = segment.range(of: "-click") {
+                    HStack(alignment: .firstTextBaseline, spacing: 2) {
+                        chip(String(segment[segment.startIndex..<dash.lowerBound]))
+                        Text("-click").font(.system(size: 11.5)).foregroundStyle(.secondary)
+                    }
+                } else {
+                    chip(segment)
+                }
+            }
+        }
+    }
+
+    private func chip(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 5).padding(.vertical, 1.5)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(0.08))
+            )
+    }
+
+    private var footer: some View {
+        HStack {
+            Text("Open anytime with ?")
+                .font(.system(size: 11)).foregroundStyle(.secondary)
+            Spacer()
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -22,6 +22,9 @@ struct RootView: View {
     /// fixed-height pane the rest of the time (so a CHANGES reflow can't make it balloon
     /// for a frame); during a drag it becomes the flexible filler so the edge resizes it.
     @State private var isLiveResizing = false
+    /// Layout to restore when the green zoom is toggled off — set while the window is
+    /// "vertically maximized" (full height), nil otherwise.
+    @State private var zoomRestore: ZoomRestore?
     /// Focus of the FILES search field, lifted here so ⌘F can drive it and the
     /// command-key shortcuts can stand down while the user is typing in it.
     @FocusState private var searchFocused: Bool
@@ -45,6 +48,10 @@ struct RootView: View {
     private let minFilesReveal: CGFloat = 140
 
     private enum Section { case worktrees, changes, files }
+
+    /// Snapshot taken when the green zoom maximizes the window vertically, restored on
+    /// the next zoom toggle.
+    private struct ZoomRestore { let frame: NSRect; let openFiles: Bool; let reveal: CGFloat }
 
     private var allClosed: Bool { !openWorktrees && !openChanges && !openFiles }
 
@@ -95,7 +102,8 @@ struct RootView: View {
                 applyLayout(for: app.selector.selectedRepo?.path)
             },
             onLiveResizeStart: { isLiveResizing = true; setHeightLocked(heightPinned, height: targetHeight()) },
-            onLiveResizeEnd: { isLiveResizing = false; handleLiveResizeEnd($0) }
+            onLiveResizeEnd: { isLiveResizing = false; handleLiveResizeEnd($0) },
+            onZoom: { toggleVerticalZoom() }
         ))
         .onChange(of: app.selector.selectedRepo?.path) { _, path in applyLayout(for: path) }
         // Keep WORKTREES/CHANGES wrapped to their rows as the lists change (preserving
@@ -285,9 +293,39 @@ struct RootView: View {
         setWindowHeight(target, animated: animated && !shrinking)
     }
 
+    /// Green zoom: toggle a *vertical* maximize. Grow to the full visible screen height
+    /// at the current width and x (never wider), opening FILES so it fills the new room;
+    /// a second click restores the previous size and section layout. Unlike AppKit's
+    /// default zoom (fill the whole screen, both dimensions), this keeps teebe a column.
+    private func toggleVerticalZoom() {
+        guard let window else { return }
+        let visible = (window.screen ?? NSScreen.main)?.visibleFrame ?? window.frame
+        if let restore = zoomRestore {
+            zoomRestore = nil
+            openFiles = restore.openFiles
+            filesReveal = restore.reveal
+            setHeightLocked(heightPinned, height: targetHeight())
+            window.setFrame(restore.frame, display: true, animate: false)
+            persistLayout()
+            return
+        }
+        zoomRestore = ZoomRestore(frame: window.frame, openFiles: openFiles, reveal: filesReveal)
+        openFiles = true
+        let nonFiles = collapsedHeight + worktreesContentHeight + changesContentHeight
+        filesReveal = max(minFilesReveal, visible.height - nonFiles)
+        setHeightLocked(false, height: targetHeight())   // FILES open → resizable up to the screen
+        var frame = window.frame
+        frame.size.height = visible.height               // width and x untouched → no widening
+        frame.origin.y = visible.minY
+        window.setFrame(frame, display: true, animate: false)
+        persistLayout()
+    }
+
     /// User finished dragging the window edge. Height is derived from content (wrap),
     /// so there's nothing to remember — just persist the open/closed flags.
     private func handleLiveResizeEnd(_ height: CGFloat) {
+        // A manual resize means we're no longer in the zoomed state.
+        zoomRestore = nil
         // Dragging the edge resizes the FILES area (the only thing that can grow past
         // its content); record it so the reveal persists. With FILES closed the window
         // already wraps WORKTREES/CHANGES, so there's nothing to remember.

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -121,6 +121,12 @@ struct RootView: View {
             cycleSection(forward: !press.modifiers.contains(.shift))
             return .handled
         }
+        // ? opens the keyboard cheat sheet (but let it type into the search field).
+        .onKeyPress("?") {
+            guard !searchFocused else { return .ignored }
+            app.showKeyboardShortcuts = true
+            return .handled
+        }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {
             Button("Confirm", role: .destructive) { Task { await worktree.confirmPendingMutation() } }
             Button("Cancel", role: .cancel) { worktree.cancelPendingMutation() }

--- a/Sources/Teebe/Views/ShortcutsCatalog.swift
+++ b/Sources/Teebe/Views/ShortcutsCatalog.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One row in the Keyboard Shortcuts cheat sheet: the key combo and what it does.
+struct ShortcutItem: Identifiable {
+    let keys: String
+    let action: String
+    var id: String { keys + "\u{1}" + action }
+}
+
+/// A titled group of related shortcuts (a section of the cheat sheet).
+struct ShortcutGroup: Identifiable {
+    let title: String
+    let items: [ShortcutItem]
+    var id: String { title }
+}
+
+/// The single source of truth for the cheat sheet. Mirror this whenever a shortcut
+/// changes in `RootView`/`FilesSection` so the sheet stays accurate.
+enum ShortcutsCatalog {
+    static let groups: [ShortcutGroup] = [
+        ShortcutGroup(title: "Sections", items: [
+            ShortcutItem(keys: "⌘1 / ⌘2 / ⌘3", action: "Focus Worktrees / Changes / Files (again to collapse)"),
+            ShortcutItem(keys: "Tab / ⇧Tab", action: "Cycle the active section")
+        ]),
+        ShortcutGroup(title: "Navigate", items: [
+            ShortcutItem(keys: "↑ / ↓", action: "Move selection in the active section"),
+            ShortcutItem(keys: "→", action: "Expand folder / go to first child"),
+            ShortcutItem(keys: "←", action: "Collapse folder / go to parent"),
+            ShortcutItem(keys: "Return", action: "Open file · switch worktree · open change"),
+            ShortcutItem(keys: "Space", action: "Quick Look a file / peek a change's diff")
+        ]),
+        ShortcutGroup(title: "Select files", items: [
+            ShortcutItem(keys: "⇧↑ / ⇧↓", action: "Extend the selection"),
+            ShortcutItem(keys: "⌘A", action: "Select all files"),
+            ShortcutItem(keys: "⌘-click", action: "Add or remove one file"),
+            ShortcutItem(keys: "⇧-click", action: "Select a range")
+        ]),
+        ShortcutGroup(title: "Files actions", items: [
+            ShortcutItem(keys: "⌘F", action: "Jump to search"),
+            ShortcutItem(keys: "⌘⇧C", action: "Copy selection as @-refs"),
+            ShortcutItem(keys: "⌘⌫", action: "Move selection to Trash")
+        ]),
+        ShortcutGroup(title: "Search", items: [
+            ShortcutItem(keys: "↓", action: "Drop from the search box into results"),
+            ShortcutItem(keys: "Esc", action: "Clear the query, then return to the tree")
+        ])
+    ]
+}

--- a/Sources/Teebe/Views/WhatsNewView.swift
+++ b/Sources/Teebe/Views/WhatsNewView.swift
@@ -73,17 +73,49 @@ struct WhatsNewView: View {
     private func bullet(_ item: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 7) {
             Text("•").foregroundStyle(Palette.secondaryText)
-            Text(attributed(item))
-                .font(.system(size: 12.5))
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
+            ChipFlow(spacing: 3, lineSpacing: 6) {
+                ForEach(Array(tokens(for: item).enumerated()), id: \.offset) { _, token in
+                    switch token {
+                    case let .word(text, bold):
+                        Text(text)
+                            .font(.system(size: 12.5, weight: bold ? .semibold : .regular))
+                            .foregroundStyle(.primary)
+                    case let .chip(text):
+                        Text(text)
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.primary)
+                            .padding(.horizontal, 5).padding(.vertical, 1.5)
+                            .background(
+                                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                    .fill(Color.primary.opacity(0.08))
+                            )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
-    /// Render inline markdown (bold, code, links) for a bullet, falling back to plain
-    /// text if it can't be parsed.
-    private func attributed(_ item: String) -> AttributedString {
-        (try? AttributedString(markdown: item)) ?? AttributedString(item)
+    /// Split a bullet's inline markdown into flow tokens: plain words (optionally bold)
+    /// and `code` spans. Working word-by-word (instead of one `Text`) lets the code
+    /// spans render as real rounded chip views that wrap inline with the prose.
+    private func tokens(for item: String) -> [BulletToken] {
+        guard let parsed = try? AttributedString(markdown: item) else {
+            return item.split(separator: " ").map { .word(String($0), bold: false) }
+        }
+        var out: [BulletToken] = []
+        for run in parsed.runs {
+            let text = String(parsed[run.range].characters)
+            if run.inlinePresentationIntent?.contains(.code) == true {
+                out.append(.chip(text.trimmingCharacters(in: .whitespaces)))
+            } else {
+                let bold = run.inlinePresentationIntent?.contains(.stronglyEmphasized) == true
+                for word in text.split(separator: " ", omittingEmptySubsequences: true) {
+                    out.append(.word(String(word), bold: bold))
+                }
+            }
+        }
+        return out
     }
 
     private var footer: some View {
@@ -93,5 +125,87 @@ struct WhatsNewView: View {
                 .keyboardShortcut(.defaultAction)
         }
         .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}
+
+/// A flow token: a plain (optionally bold) word, or a `code` span shown as a chip.
+private enum BulletToken {
+    case word(String, bold: Bool)
+    case chip(String)
+}
+
+/// A left-to-right wrapping layout that aligns every item on the text baseline, so the
+/// rounded chip views sit inline with the prose and wrap to new lines cleanly (no
+/// trailing slivers, unlike an inline-text background).
+private struct ChipFlow: Layout {
+    var spacing: CGFloat = 3
+    var lineSpacing: CGFloat = 6
+
+    private struct Metric { let size: CGSize; let baseline: CGFloat }
+
+    private func metric(_ subview: LayoutSubview) -> Metric {
+        let dim = subview.dimensions(in: .unspecified)
+        return Metric(size: CGSize(width: dim.width, height: dim.height),
+                      baseline: dim[VerticalAlignment.firstTextBaseline] ?? dim.height)
+    }
+
+    /// Group subview indices into rows that each fit within `maxWidth`.
+    private func rows(_ subviews: Subviews, maxWidth: CGFloat) -> [[Int]] {
+        var rows: [[Int]] = []
+        var row: [Int] = []
+        var x: CGFloat = 0
+        for index in subviews.indices {
+            let width = metric(subviews[index]).size.width
+            if !row.isEmpty, x + width > maxWidth {
+                rows.append(row); row = []; x = 0
+            }
+            row.append(index)
+            x += width + spacing
+        }
+        if !row.isEmpty { rows.append(row) }
+        return rows
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = rows(subviews, maxWidth: maxWidth)
+        var height: CGFloat = 0
+        var width: CGFloat = 0
+        for (i, row) in rows.enumerated() {
+            let metrics = row.map { metric(subviews[$0]) }
+            let ascent = metrics.map(\.baseline).max() ?? 0
+            let descent = metrics.map { $0.size.height - $0.baseline }.max() ?? 0
+            height += ascent + descent + (i < rows.count - 1 ? lineSpacing : 0)
+            let rowWidth = metrics.reduce(0) { $0 + $1.size.width + spacing } - spacing
+            width = max(width, rowWidth)
+        }
+        return CGSize(width: maxWidth.isFinite ? maxWidth : max(width, 0), height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = rows(subviews, maxWidth: bounds.width)
+        var y = bounds.minY
+        for row in rows {
+            let metrics = row.map { metric(subviews[$0]) }
+            let ascent = metrics.map(\.baseline).max() ?? 0
+            let descent = metrics.map { $0.size.height - $0.baseline }.max() ?? 0
+            var x = bounds.minX
+            for (offset, index) in row.enumerated() {
+                let m = metrics[offset]
+                subviews[index].place(at: CGPoint(x: x, y: y + ascent - m.baseline),
+                                      proposal: ProposedViewSize(m.size))
+                x += m.size.width + spacing
+            }
+            y += ascent + descent + lineSpacing
+        }
+    }
+
+    /// Report the first row's baseline so an enclosing `firstTextBaseline` HStack (the
+    /// bullet dot) lines up with the first line of text.
+    func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect,
+                           proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+        guard guide == .firstTextBaseline,
+              let first = rows(subviews, maxWidth: bounds.width).first else { return nil }
+        return first.map { metric(subviews[$0]).baseline }.max()
     }
 }

--- a/Sources/Teebe/Views/WindowAccessor.swift
+++ b/Sources/Teebe/Views/WindowAccessor.swift
@@ -26,6 +26,10 @@ struct WindowController: NSViewRepresentable {
     var onResolve: (NSWindow) -> Void
     var onLiveResizeStart: () -> Void
     var onLiveResizeEnd: (CGFloat) -> Void
+    /// Green "zoom" button (and double-click on the title bar is left to AppKit). We
+    /// override it to grow the window to full height at the same width instead of the
+    /// default fill-the-screen zoom.
+    var onZoom: () -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -46,22 +50,26 @@ struct WindowController: NSViewRepresentable {
         }
     }
 
-    final class Coordinator {
+    final class Coordinator: NSObject {
         private(set) weak var window: NSWindow?
         private var observers: [NSObjectProtocol] = []
         private var floatOnTop = false
         private var onLiveResizeStart: (() -> Void)?
         private var onLiveResizeEnd: ((CGFloat) -> Void)?
+        private var onZoom: (() -> Void)?
 
         /// Per-update, no allocation: refresh the callbacks and float level only.
         func refresh(parent: WindowController) {
             onLiveResizeStart = parent.onLiveResizeStart
             onLiveResizeEnd = parent.onLiveResizeEnd
+            onZoom = parent.onZoom
             if floatOnTop != parent.floatOnTop {
                 floatOnTop = parent.floatOnTop
                 window?.level = floatOnTop ? .floating : .normal
             }
         }
+
+        @objc private func zoomClicked() { onZoom?() }
 
         /// One-time: bind to the window and install the live-resize observers.
         func attach(_ window: NSWindow?, parent: WindowController) {
@@ -70,6 +78,11 @@ struct WindowController: NSViewRepresentable {
             floatOnTop = parent.floatOnTop
             window.level = floatOnTop ? .floating : .normal
             parent.onResolve(window)
+            // Take over the green zoom button so it grows to full height, not full screen.
+            if let zoomButton = window.standardWindowButton(.zoomButton) {
+                zoomButton.target = self
+                zoomButton.action = #selector(zoomClicked)
+            }
             // Re-assert the height clamp the instant a drag begins (SwiftUI's
             // windowResizability keeps re-enabling free resize otherwise)…
             observers.append(NotificationCenter.default.addObserver(

--- a/Tests/TeebeTests/ShortcutsCatalogTests.swift
+++ b/Tests/TeebeTests/ShortcutsCatalogTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import Teebe
+
+@Suite("ShortcutsCatalog")
+struct ShortcutsCatalogTests {
+    @Test("has the expected groups in order")
+    func groupTitles() {
+        let titles = ShortcutsCatalog.groups.map(\.title)
+        #expect(titles == ["Sections", "Navigate", "Select files", "Files actions", "Search"])
+    }
+
+    @Test("every row has non-empty keys and an action")
+    func rowsAreWellFormed() {
+        let items = ShortcutsCatalog.groups.flatMap(\.items)
+        #expect(!items.isEmpty)
+        for item in items {
+            #expect(!item.keys.trimmingCharacters(in: .whitespaces).isEmpty)
+            #expect(!item.action.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+    }
+
+    @Test("row identifiers are unique")
+    func idsAreUnique() {
+        let ids = ShortcutsCatalog.groups.flatMap(\.items).map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("documents the headline shortcuts")
+    func coversKeyShortcuts() {
+        let keys = ShortcutsCatalog.groups.flatMap(\.items).map(\.keys)
+        // Spot-check that the marquee bindings are listed so the sheet can't silently
+        // drift from RootView/FilesSection.
+        #expect(keys.contains { $0.contains("⌘⇧C") })   // copy @-refs
+        #expect(keys.contains { $0.contains("⌘⌫") })    // trash
+        #expect(keys.contains { $0.contains("⌘F") })    // search
+        #expect(keys.contains { $0.contains("⌘1") })    // section focus
+    }
+}


### PR DESCRIPTION
## Summary

Discoverability + window polish for the v0.4.0 keyboard release.

- **Keyboard Shortcuts cheat sheet** — opened with `?` or Help → Keyboard Shortcuts (⌘/). Lists every shortcut grouped by section, from a single `ShortcutsCatalog` (covered by tests) so it can't drift from the real bindings.
- **Chip-styled key combos** — key combos render as rounded keycap chips in both the cheat sheet and the What's New window. The What's New bullets use a baseline-aligned wrapping flow layout so chips sit inline with the prose and wrap cleanly (no line-spacing change, no slivers).
- **Vertical maximize** — the green window button now grows teebe to full screen height at the same width (opening FILES to fill), and back, instead of AppKit's fill-the-whole-screen zoom that left the column floating in empty material.
- **v0.4.0 release notes** drafted in `CHANGELOG.md` (surfaced by the in-app What's New window built in #47).

## Testing
- `swift build`, `swift test` (158 tests), portable `swiftlint` (0 errors) all green.
- Cheat sheet, chips, and What's New previewed in the packaged `.app`; vertical-zoom verified by hand (full-height, same width, fills, restores).