### PR TITLE
Show a folder icon for directories in the file tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to teebe are documented here. The format is based on
   height at its current width (filling with the file tree) instead of zooming to cover
   the whole screen. Click it again to restore the previous size.
 
+### Fixed
+- Folders in the file tree now show a folder icon instead of a flat blue square.
+
 ## [0.3.0] - 2026-06-24
 
 ### Changed

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -176,9 +176,10 @@ struct FileRow: View {
     @ViewBuilder
     private var icon: some View {
         if node.isDirectory {
-            RoundedRectangle(cornerRadius: 2)
-                .fill(isSelected ? Color.white.opacity(0.9) : Color(red: 0x5A / 255, green: 0xA7 / 255, blue: 1))
-                .frame(width: 15, height: 12)
+            Image(systemName: "folder.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(isSelected ? Color.white : Color(red: 0x5A / 255, green: 0xA7 / 255, blue: 1))
+                .frame(width: 15)
         } else {
             Image(systemName: node.iconName)
                 .font(.system(size: 12))


### PR DESCRIPTION
Replaces the flat blue square that marked folders in FILES with a proper `folder.fill` icon (same blue, beside the disclosure chevron). Adds a CHANGELOG line under 0.4.0.