### PR TITLE
Make What's New and Keyboard Shortcuts movable windows

### DIFF
--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -43,28 +43,17 @@ struct TeebeApp: App {
 
     var body: some Scene {
         WindowGroup(Brand.name) {
-            RootView(app: app, preview: preview)
-                .task {
-                    await app.bootstrap()
-                    whatsNew.presentIfUpdated()   // greet once after an update
-                }
-                .sheet(isPresented: $whatsNew.isPresented) {
-                    WhatsNewView(model: whatsNew)
-                }
-                .sheet(isPresented: $app.showKeyboardShortcuts) {
-                    KeyboardShortcutsView()
-                }
+            RootWindowContent(app: app, preview: preview, whatsNew: whatsNew)
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
         .commands {
-            // "Check for Updates…" and "What's New" in the app menu next to About.
+            // "Check for Updates…", "What's New", and "Keyboard Shortcuts" next to About.
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
-                Button("What's New in \(Brand.name)") { whatsNew.present() }
-                Button("Keyboard Shortcuts") { app.showKeyboardShortcuts = true }
-                    .keyboardShortcut("/", modifiers: .command)
+                WhatsNewMenuCommand()
+                KeyboardShortcutsMenuCommand()
             }
         }
 
@@ -73,5 +62,47 @@ struct TeebeApp: App {
             PreviewPanel(preview: preview, app: app)
         }
         .windowResizability(.contentSize)
+
+        // "What's New" and the Keyboard Shortcuts cheat sheet are real, movable
+        // windows rather than sheets (macOS pins sheets to the parent and won't let
+        // you drag them). Chrome-less to match their in-content header; closed via the
+        // footer button, Esc, or ⌘W.
+        Window("What's New in \(Brand.name)", id: WindowID.whatsNew) {
+            WhatsNewView(model: whatsNew)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+
+        Window("Keyboard Shortcuts", id: WindowID.shortcuts) {
+            KeyboardShortcutsView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+    }
+}
+
+/// Stable identifiers for the secondary windows opened via `openWindow(id:)`.
+enum WindowID {
+    static let whatsNew = "whatsNew"
+    static let shortcuts = "shortcuts"
+}
+
+/// Hosts the main window's content and, on the first launch after an update, opens
+/// the What's New window. This lives in a `View` (not the `App` scene builder) so it
+/// can read `openWindow` from the environment.
+private struct RootWindowContent: View {
+    let app: AppModel
+    let preview: PreviewModel
+    let whatsNew: WhatsNewModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        RootView(app: app, preview: preview)
+            .task {
+                await app.bootstrap()
+                if whatsNew.presentIfUpdated() {   // greet once after an update
+                    openWindow(id: WindowID.whatsNew)
+                }
+            }
     }
 }

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -17,10 +17,6 @@ final class AppModel {
     enum FocusSection: Equatable { case worktrees, changes, files }
     var activeSection: FocusSection = .files
 
-    /// Drives the Keyboard Shortcuts cheat sheet. Toggled by the `?` key, the Help
-    /// menu item (⌘/), and dismissed from the sheet. Not persisted — purely transient UI.
-    var showKeyboardShortcuts = false
-
     /// Auto-dismiss timer for the current error banner, so a transient failure
     /// (e.g. "Not a git repository") never sticks around indefinitely.
     @ObservationIgnored private var errorClearTask: Task<Void, Never>?

--- a/Sources/Teebe/ViewModels/WhatsNewModel.swift
+++ b/Sources/Teebe/ViewModels/WhatsNewModel.swift
@@ -9,7 +9,6 @@ import TeebeCore
 @Observable
 final class WhatsNewModel {
     private(set) var entries: [ChangelogEntry]
-    var isPresented = false
     /// User-facing app version (`CFBundleShortVersionString`), or `nil` when unknown
     /// (e.g. running via `swift run`, which has no Info.plist).
     let version: String?
@@ -24,24 +23,19 @@ final class WhatsNewModel {
 
     var hasContent: Bool { !entries.isEmpty }
 
-    /// Auto-present once after an update: when the running version is newer than the
-    /// version we last showed. A fresh install (no record) is *not* greeted with the
-    /// changelog — it's just recorded as seen. A dev build (no version) never
-    /// auto-presents. Either way the current version is marked seen so it won't
-    /// re-trigger.
-    func presentIfUpdated() {
-        guard let version else { return }
+    /// Decide whether to greet with the changelog on the first launch after an update,
+    /// and record the running version as seen. Returns `true` only when the running
+    /// version is newer than the one we last greeted for; a fresh install (no record)
+    /// or a dev build (no version) is recorded/ignored but never greeted. The caller
+    /// opens the What's New window — this model stays presentation-agnostic.
+    @discardableResult
+    func presentIfUpdated() -> Bool {
+        guard let version else { return false }
         let lastSeen = store.load().lastSeenVersion
-        if let lastSeen, SemVer.isGreater(version, than: lastSeen) {
-            isPresented = true
-        }
+        let shouldGreet = lastSeen.map { SemVer.isGreater(version, than: $0) } ?? false
         markSeen(version)
+        return shouldGreet
     }
-
-    /// Manual open (Help → What's New).
-    func present() { isPresented = true }
-
-    func dismiss() { isPresented = false }
 
     private func markSeen(_ version: String) {
         var state = store.load()

--- a/Sources/Teebe/Views/KeyboardShortcutsView.swift
+++ b/Sources/Teebe/Views/KeyboardShortcutsView.swift
@@ -23,6 +23,7 @@ struct KeyboardShortcutsView: View {
             footer
         }
         .frame(width: 460, height: 560)
+        .onExitCommand { dismiss() }   // Esc closes the window
     }
 
     private var header: some View {
@@ -109,5 +110,14 @@ struct KeyboardShortcutsView: View {
                 .keyboardShortcut(.defaultAction)
         }
         .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}
+
+/// Menu command (next to About) that opens the Keyboard Shortcuts window; ⌘/.
+struct KeyboardShortcutsMenuCommand: View {
+    @Environment(\.openWindow) private var openWindow
+    var body: some View {
+        Button("Keyboard Shortcuts") { openWindow(id: WindowID.shortcuts) }
+            .keyboardShortcut("/", modifiers: .command)
     }
 }

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -132,7 +132,7 @@ struct RootView: View {
         // ? opens the keyboard cheat sheet (but let it type into the search field).
         .onKeyPress("?") {
             guard !searchFocused else { return .ignored }
-            app.showKeyboardShortcuts = true
+            openWindow(id: WindowID.shortcuts)
             return .handled
         }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {

--- a/Sources/Teebe/Views/WhatsNewView.swift
+++ b/Sources/Teebe/Views/WhatsNewView.swift
@@ -31,6 +31,7 @@ struct WhatsNewView: View {
             footer
         }
         .frame(width: 440, height: 520)
+        .onExitCommand { dismiss() }   // Esc closes the window
     }
 
     private var header: some View {
@@ -207,5 +208,13 @@ private struct ChipFlow: Layout {
         guard guide == .firstTextBaseline,
               let first = rows(subviews, maxWidth: bounds.width).first else { return nil }
         return first.map { metric(subviews[$0]).baseline }.max()
+    }
+}
+
+/// Menu command (next to About) that opens the What's New window.
+struct WhatsNewMenuCommand: View {
+    @Environment(\.openWindow) private var openWindow
+    var body: some View {
+        Button("What's New in \(Brand.name)") { openWindow(id: WindowID.whatsNew) }
     }
 }

--- a/Tests/TeebeTests/WhatsNewModelTests.swift
+++ b/Tests/TeebeTests/WhatsNewModelTests.swift
@@ -34,46 +34,33 @@ struct WhatsNewModelTests {
     func freshInstall() {
         let store = makeStore()
         let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == false)
+        #expect(model.presentIfUpdated() == false)
         #expect(store.load().lastSeenVersion == "0.3.0")
     }
 
-    @Test("auto-presents once after an update, then records the new version")
+    @Test("greets once after an update, then records the new version")
     func presentsOnUpdate() {
         let store = makeStore()
         try? store.save(AppState(lastSeenVersion: "0.2.2"))
         let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == true)
+        #expect(model.presentIfUpdated() == true)
         #expect(store.load().lastSeenVersion == "0.3.0")
     }
 
-    @Test("does not re-present for the same version")
+    @Test("does not greet again for the same version")
     func sameVersion() {
         let store = makeStore()
         try? store.save(AppState(lastSeenVersion: "0.3.0"))
         let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == false)
+        #expect(model.presentIfUpdated() == false)
     }
 
-    @Test("a dev build with no version never auto-presents and doesn't crash")
+    @Test("a dev build with no version never greets and doesn't crash")
     func devBuild() {
         let store = makeStore()
         let model = WhatsNewModel(version: nil, changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == false)
+        #expect(model.presentIfUpdated() == false)
         #expect(store.load().lastSeenVersion == nil)
         #expect(model.displayVersion == "dev build")
-    }
-
-    @Test("manual present opens it regardless of seen state")
-    func manualPresent() {
-        let store = makeStore()
-        try? store.save(AppState(lastSeenVersion: "0.3.0"))
-        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.present()
-        #expect(model.isPresented == true)
     }
 }


### PR DESCRIPTION
The "What's New" and Keyboard Shortcuts cheat sheet were presented as `.sheet`s, which macOS pins to the parent window — so they couldn't be moved. This converts both to standalone `Window` scenes opened via `openWindow` (mirroring the existing Quick Look window), so they're draggable and can sit alongside the main window.

- Chrome-less (`.hiddenTitleBar`) to keep their in-content header; close via the footer button, Esc, or ⌘W.
- `?` and the menu items (incl. ⌘/) now call `openWindow` instead of toggling a bool.
- `WhatsNewModel.presentIfUpdated()` returns whether to greet so presentation lives at the scene layer; `AppModel.showKeyboardShortcuts` and the model's `isPresented`/`present`/`dismiss` are removed. Tests updated.

Verified: `swift build` clean, 157 tests pass, app launches without crash.