### PR TITLE
Release v0.4.0

### DIFF
--- a/.github/workflows/publish-appcast.yml
+++ b/.github/workflows/publish-appcast.yml
@@ -32,6 +32,17 @@ jobs:
           echo "Downloaded appcast.xml for $TAG:"
           cat appcast.xml
 
+      - name: Fetch CHANGELOG.md at the released tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Mirror the changelog onto the site so the changelog page can read it
+          # same-origin. CHANGELOG.md in the app repo stays the single source.
+          gh api "repos/$GITHUB_REPOSITORY/contents/CHANGELOG.md?ref=$TAG" \
+            -H "Accept: application/vnd.github.raw" > CHANGELOG.md || true
+          head -5 CHANGELOG.md || true
+
       - name: Check out teebe-site
         uses: actions/checkout@v7
         with:
@@ -39,18 +50,19 @@ jobs:
           ssh-key: ${{ secrets.SITE_DEPLOY_KEY }}
           path: site
 
-      - name: Commit appcast if changed
+      - name: Commit appcast + changelog if changed
         env:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           cp appcast.xml site/appcast.xml
+          [ -s CHANGELOG.md ] && cp CHANGELOG.md site/CHANGELOG.md
           cd site
-          if git diff --quiet -- appcast.xml; then
-            echo "appcast.xml unchanged; nothing to publish."
+          if git diff --quiet -- appcast.xml CHANGELOG.md; then
+            echo "appcast.xml and CHANGELOG.md unchanged; nothing to publish."
             exit 0
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add appcast.xml
-          git commit -m "Publish Sparkle appcast for ${TAG}"
+          git add appcast.xml CHANGELOG.md
+          git commit -m "Publish appcast + changelog for ${TAG}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,24 @@ jobs:
           # increase per release or Sparkle never sees a newer version.
           APP_VERSION="${GITHUB_REF_NAME#v}" ./scripts/make-app.sh release
 
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          # Single source of truth: the tag's CHANGELOG.md section feeds both the
+          # GitHub release body and the Sparkle appcast notes below.
+          VER="${GITHUB_REF_NAME#v}"
+          ./scripts/changelog-section.sh "$VER" > RELEASE_NOTES.md || true
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::warning::No CHANGELOG.md section for $VER — notes fall back to auto-generated."
+            printf '_No changelog entry for %s._\n' "$VER" > RELEASE_NOTES.md
+          fi
+          echo "----- release notes -----"; cat RELEASE_NOTES.md
+
       - name: Stage update archive
         run: |
           mkdir -p sparkle-updates
           ditto -c -k --keepParent teebe.app "sparkle-updates/teebe-${GITHUB_REF_NAME}.zip"
+          # Same-basename .md → generate_appcast attaches it as this item's notes.
+          cp RELEASE_NOTES.md "sparkle-updates/teebe-${GITHUB_REF_NAME}.md"
 
       - name: Generate & sign Sparkle appcast
         env:
@@ -47,6 +61,7 @@ jobs:
           # and point download URLs at this release's assets.
           printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$GEN" \
             --ed-key-file - \
+            --embed-release-notes \
             --download-url-prefix "https://github.com/klein-t/teebe/releases/download/${GITHUB_REF_NAME}/" \
             sparkle-updates
           cp sparkle-updates/teebe-*.zip .
@@ -75,5 +90,8 @@ jobs:
             teebe-*.zip
             teebe-macos.dmg
             appcast.xml
+          # Curated notes from CHANGELOG.md, with the auto-generated commit/PR list
+          # appended below them.
+          body_path: RELEASE_NOTES.md
           generate_release_notes: true
           draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to teebe are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Worktrees added or removed **outside** teebe (e.g. `git worktree add` / `remove`
+  in a terminal) are now detected automatically and appear in the WORKTREES list
+  without a manual action. The Refresh button forces a full re-scan.
+- A **What's New** window that shows this changelog inside the app — opened
+  automatically the first time you launch a new version, and any time from
+  Help → What's New.
+
+## [0.3.0] - 2026-06-24
+
+### Changed
+- Window resizing reworked into a coherent content-wrap model — no more
+  bounce / jump / gap on resize.
+
+### Added
+- Branded `.dmg` download for the website, with centered teebe / Applications icons.
+- The Sparkle appcast is now hosted on teebe.io; releases also ship a stable
+  `teebe-macos.zip` asset.
+
+### Fixed
+- Dock icon rendering, updater start-up, and a sticky error banner.
+
+## [0.2.2] - 2026-06-23
+
+### Fixed
+- **Packaged-app launch crash.** v0.2.0 / v0.2.1 release builds crashed on launch
+  ("could not load resource bundle") because the resource bundle wasn't resolvable
+  in a code-signed `.app`. The app now resolves it from `Contents/Resources`.
+
+## [0.2.1] - 2026-06-23
+
+### Changed
+- The CHANGES section now hugs its rows like WORKTREES instead of taking the
+  flexible vertical space — FILES is the sole space-filling section, and the
+  window resizes as the change count changes.
+
+## [0.2.0] - 2026-06-23
+
+### Added
+- Sparkle in-app auto-updates.
+
+### Fixed
+- Section-toggle bounce; refined sidebar chrome.
+
+## [0.1.0] - 2026-06-23
+
+### Added
+- Initial release: browse a git repository's worktrees, changes, and files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,32 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.0] - 2026-06-30
 
 ### Added
-- Worktrees added or removed **outside** teebe (e.g. `git worktree add` / `remove`
-  in a terminal) are now detected automatically and appear in the WORKTREES list
-  without a manual action. The Refresh button forces a full re-scan.
-- A **What's New** window that shows this changelog inside the app — opened
-  automatically the first time you launch a new version, and any time from
-  Help → What's New.
+- **Keyboard navigation.** Drive the whole window without the mouse. Arrow keys move
+  through Worktrees, Changes and Files. `⌘1` / `⌘2` / `⌘3` focus a section (press again
+  to collapse), and `Tab` cycles between them. `Return` opens a file or switches
+  worktree, and `Space` Quick Looks a file or peeks a diff.
+- **Multi-select and send to your agent.** Select several files with `⌘`- or `⇧`-click,
+  `⇧↑` / `⇧↓`, or `⌘A`. Copy them as AI-agent-ready `@`-refs with `⌘⇧C`, or move them to
+  the Trash with `⌘⌫`.
+- **Automatic worktree detection.** Worktrees you add or remove outside teebe (for
+  example with `git worktree add` in a terminal) now appear on their own, with no
+  manual action. The Refresh button forces a full re-scan.
+- **Keyboard Shortcuts cheat sheet.** Press `?` (or open Help → Keyboard Shortcuts) for
+  the full list.
+- **Jump to search** with `⌘F`.
+- **What's New window.** Shows this changelog inside the app: automatically on the
+  first launch after an update, and any time from Help → What's New.
+
+### Changed
+- **Bounded section sizing.** The Worktrees and Changes lists now scroll inside their
+  own area once they get tall, instead of growing without limit. The window stays a
+  stable size as you switch between worktrees.
+- **Vertical maximize.** The green window button now grows teebe to the full screen
+  height at its current width (filling with the file tree) instead of zooming to cover
+  the whole screen. Click it again to restore the previous size.
 
 ## [0.3.0] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to teebe are documented here. The format is based on
   height at its current width (filling with the file tree) instead of zooming to cover
   the whole screen. Click it again to restore the previous size.
 
+### Fixed
+- Folders in the file tree now show a folder icon instead of a flat blue square.
+
 ## [0.3.0] - 2026-06-24
 
 ### Changed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,8 +1,9 @@
 # Privacy
 
-teebe is a local macOS app. Short version: we count downloads in aggregate so we
-know roughly how many people use teebe, and that's it. No accounts, no personal
-data, no tracking of what you do inside the app.
+teebe is a local macOS app. Short version: we count downloads and website page
+views in aggregate so we know roughly how many people are interested in teebe,
+and that's it. No accounts, no personal data, no tracking of what you do inside
+the app.
 
 The canonical, always-current version of this notice lives at
 **https://teebe.io/privacy.html**.
@@ -16,8 +17,14 @@ records one anonymous, aggregate event:
 - your **country** (derived at the edge, not stored as a precise location), and
 - the **user-agent** string your downloader sends.
 
-We use this only to gauge interest and adoption. It is not tied to your identity
-and is not sold or shared.
+When you open a page on `teebe.io`, a small script records one anonymous,
+aggregate page-view event: the **page** you viewed, the **referring site** (if
+any), and your **country**. To tell a fresh visit from a page-to-page click we
+keep a single per-tab flag in your browser's `sessionStorage` — it holds no
+identifier and is gone when you close the tab.
+
+We use all of this only to gauge interest and adoption. It is not tied to your
+identity and is not sold or shared.
 
 ## What we don't collect
 

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -26,6 +26,7 @@ struct TeebeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var app: AppModel
     @State private var preview: PreviewModel
+    @State private var whatsNew: WhatsNewModel
     @StateObject private var updater = UpdaterController()
 
     init() {
@@ -33,20 +34,32 @@ struct TeebeApp: App {
         let environment = AppEnvironment.live()
         _app = State(initialValue: AppModel(environment: environment))
         _preview = State(initialValue: PreviewModel(environment: environment))
+        _whatsNew = State(initialValue: WhatsNewModel(
+            version: Brand.appVersion,
+            changelogMarkdown: Brand.changelogMarkdown,
+            store: environment.store
+        ))
     }
 
     var body: some Scene {
         WindowGroup(Brand.name) {
             RootView(app: app, preview: preview)
-                .task { await app.bootstrap() }
+                .task {
+                    await app.bootstrap()
+                    whatsNew.presentIfUpdated()   // greet once after an update
+                }
+                .sheet(isPresented: $whatsNew.isPresented) {
+                    WhatsNewView(model: whatsNew)
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
         .commands {
-            // Standard "Check for Updates…" item, placed in the app menu next to About.
+            // "Check for Updates…" and "What's New" in the app menu next to About.
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
+                Button("What's New in \(Brand.name)") { whatsNew.present() }
             }
         }
 

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -51,6 +51,9 @@ struct TeebeApp: App {
                 .sheet(isPresented: $whatsNew.isPresented) {
                     WhatsNewView(model: whatsNew)
                 }
+                .sheet(isPresented: $app.showKeyboardShortcuts) {
+                    KeyboardShortcutsView()
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
@@ -60,6 +63,8 @@ struct TeebeApp: App {
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
                 Button("What's New in \(Brand.name)") { whatsNew.present() }
+                Button("Keyboard Shortcuts") { app.showKeyboardShortcuts = true }
+                    .keyboardShortcut("/", modifiers: .command)
             }
         }
 

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -43,28 +43,17 @@ struct TeebeApp: App {
 
     var body: some Scene {
         WindowGroup(Brand.name) {
-            RootView(app: app, preview: preview)
-                .task {
-                    await app.bootstrap()
-                    whatsNew.presentIfUpdated()   // greet once after an update
-                }
-                .sheet(isPresented: $whatsNew.isPresented) {
-                    WhatsNewView(model: whatsNew)
-                }
-                .sheet(isPresented: $app.showKeyboardShortcuts) {
-                    KeyboardShortcutsView()
-                }
+            RootWindowContent(app: app, preview: preview, whatsNew: whatsNew)
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
         .commands {
-            // "Check for Updates…" and "What's New" in the app menu next to About.
+            // "Check for Updates…", "What's New", and "Keyboard Shortcuts" next to About.
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
-                Button("What's New in \(Brand.name)") { whatsNew.present() }
-                Button("Keyboard Shortcuts") { app.showKeyboardShortcuts = true }
-                    .keyboardShortcut("/", modifiers: .command)
+                WhatsNewMenuCommand()
+                KeyboardShortcutsMenuCommand()
             }
         }
 
@@ -73,5 +62,47 @@ struct TeebeApp: App {
             PreviewPanel(preview: preview, app: app)
         }
         .windowResizability(.contentSize)
+
+        // "What's New" and the Keyboard Shortcuts cheat sheet are real, movable
+        // windows rather than sheets (macOS pins sheets to the parent and won't let
+        // you drag them). Chrome-less to match their in-content header; closed via the
+        // footer button, Esc, or ⌘W.
+        Window("What's New in \(Brand.name)", id: WindowID.whatsNew) {
+            WhatsNewView(model: whatsNew)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+
+        Window("Keyboard Shortcuts", id: WindowID.shortcuts) {
+            KeyboardShortcutsView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+    }
+}
+
+/// Stable identifiers for the secondary windows opened via `openWindow(id:)`.
+enum WindowID {
+    static let whatsNew = "whatsNew"
+    static let shortcuts = "shortcuts"
+}
+
+/// Hosts the main window's content and, on the first launch after an update, opens
+/// the What's New window. This lives in a `View` (not the `App` scene builder) so it
+/// can read `openWindow` from the environment.
+private struct RootWindowContent: View {
+    let app: AppModel
+    let preview: PreviewModel
+    let whatsNew: WhatsNewModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        RootView(app: app, preview: preview)
+            .task {
+                await app.bootstrap()
+                if whatsNew.presentIfUpdated() {   // greet once after an update
+                    openWindow(id: WindowID.whatsNew)
+                }
+            }
     }
 }

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -11,6 +11,12 @@ final class AppModel {
     var floatOnTop: Bool { didSet { persist() } }
     private(set) var errorMessage: String?
 
+    /// Which section the keyboard currently drives — arrows, Enter and Space act on
+    /// it, and its header shows the active accent. Moved by ⌘1/⌘2/⌘3, Tab/⇧Tab, or by
+    /// clicking into a section.
+    enum FocusSection: Equatable { case worktrees, changes, files }
+    var activeSection: FocusSection = .files
+
     /// Auto-dismiss timer for the current error banner, so a transient failure
     /// (e.g. "Not a git repository") never sticks around indefinitely.
     @ObservationIgnored private var errorClearTask: Task<Void, Never>?
@@ -142,6 +148,20 @@ final class AppModel {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(node.path, forType: .string)
     }
+
+    /// ⌘⇧C: copy the FILES selection to the clipboard as Claude-ready `@`-refs, ready
+    /// to paste into whatever terminal/agent is open. No-op unless files are selected.
+    func copySelectedRefs() {
+        let refs = selector.worktree.selectionRefs()
+        guard !refs.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(refs, forType: .string)
+    }
+
+    /// ⌘F: ask the FILES search field to take focus. The view observes this counter
+    /// and focuses on change (a token rather than a bool so repeat presses re-fire).
+    private(set) var searchFocusRequest = 0
+    func focusSearch() { searchFocusRequest += 1 }
 
     func rename(_ node: FileNode) {
         guard let newName = promptForName(title: "Rename", initial: node.name), newName != node.name else { return }

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -17,10 +17,6 @@ final class AppModel {
     enum FocusSection: Equatable { case worktrees, changes, files }
     var activeSection: FocusSection = .files
 
-    /// Drives the Keyboard Shortcuts cheat sheet. Toggled by the `?` key, the Help
-    /// menu item (⌘/), and dismissed from the sheet. Not persisted — purely transient UI.
-    var showKeyboardShortcuts = false
-
     /// Auto-dismiss timer for the current error banner, so a transient failure
     /// (e.g. "Not a git repository") never sticks around indefinitely.
     @ObservationIgnored private var errorClearTask: Task<Void, Never>?

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -17,6 +17,10 @@ final class AppModel {
     enum FocusSection: Equatable { case worktrees, changes, files }
     var activeSection: FocusSection = .files
 
+    /// Drives the Keyboard Shortcuts cheat sheet. Toggled by the `?` key, the Help
+    /// menu item (⌘/), and dismissed from the sheet. Not persisted — purely transient UI.
+    var showKeyboardShortcuts = false
+
     /// Auto-dismiss timer for the current error banner, so a transient failure
     /// (e.g. "Not a git repository") never sticks around indefinitely.
     @ObservationIgnored private var errorClearTask: Task<Void, Never>?

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -217,7 +217,32 @@ final class SelectorModel {
 
     func selectWorktree(_ wt: Worktree) async {
         selectedWorktree = wt
+        highlightedWorktree = wt
         await worktree.load(worktreePath: wt.path, repo: selectedRepo)
         onSelectionChange?()
+    }
+
+    // MARK: - Keyboard navigation (WORKTREES)
+
+    /// The keyboard cursor in the WORKTREES list, distinct from the committed
+    /// `selectedWorktree`: ↑/↓ move it, Enter commits it (switching the worktree).
+    var highlightedWorktree: Worktree?
+
+    /// Seed the cursor on the currently-open worktree (when WORKTREES becomes active).
+    func highlightSelectedWorktree() { highlightedWorktree = selectedWorktree }
+
+    /// Move the keyboard cursor one row (no switch — that happens on commit).
+    func moveWorktreeHighlight(by delta: Int) {
+        guard !worktrees.isEmpty else { return }
+        let base = highlightedWorktree ?? selectedWorktree
+        let index = base.flatMap { b in worktrees.firstIndex { $0.path == b.path } } ?? 0
+        let next = max(0, min(worktrees.count - 1, index + delta))
+        highlightedWorktree = worktrees[next]
+    }
+
+    /// Commit the highlighted worktree (Enter): switch to it unless it's already current.
+    func commitHighlightedWorktree() async {
+        guard let wt = highlightedWorktree, wt.path != selectedWorktree?.path else { return }
+        await selectWorktree(wt)
     }
 }

--- a/Sources/Teebe/ViewModels/WhatsNewModel.swift
+++ b/Sources/Teebe/ViewModels/WhatsNewModel.swift
@@ -9,7 +9,6 @@ import TeebeCore
 @Observable
 final class WhatsNewModel {
     private(set) var entries: [ChangelogEntry]
-    var isPresented = false
     /// User-facing app version (`CFBundleShortVersionString`), or `nil` when unknown
     /// (e.g. running via `swift run`, which has no Info.plist).
     let version: String?
@@ -24,24 +23,19 @@ final class WhatsNewModel {
 
     var hasContent: Bool { !entries.isEmpty }
 
-    /// Auto-present once after an update: when the running version is newer than the
-    /// version we last showed. A fresh install (no record) is *not* greeted with the
-    /// changelog — it's just recorded as seen. A dev build (no version) never
-    /// auto-presents. Either way the current version is marked seen so it won't
-    /// re-trigger.
-    func presentIfUpdated() {
-        guard let version else { return }
+    /// Decide whether to greet with the changelog on the first launch after an update,
+    /// and record the running version as seen. Returns `true` only when the running
+    /// version is newer than the one we last greeted for; a fresh install (no record)
+    /// or a dev build (no version) is recorded/ignored but never greeted. The caller
+    /// opens the What's New window — this model stays presentation-agnostic.
+    @discardableResult
+    func presentIfUpdated() -> Bool {
+        guard let version else { return false }
         let lastSeen = store.load().lastSeenVersion
-        if let lastSeen, SemVer.isGreater(version, than: lastSeen) {
-            isPresented = true
-        }
+        let shouldGreet = lastSeen.map { SemVer.isGreater(version, than: $0) } ?? false
         markSeen(version)
+        return shouldGreet
     }
-
-    /// Manual open (Help → What's New).
-    func present() { isPresented = true }
-
-    func dismiss() { isPresented = false }
 
     private func markSeen(_ version: String) {
         var state = store.load()

--- a/Sources/Teebe/ViewModels/WhatsNewModel.swift
+++ b/Sources/Teebe/ViewModels/WhatsNewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Observation
+import TeebeCore
+
+/// Drives the "What's New" window: the parsed changelog plus the once-per-version
+/// auto-present logic. Pure enough to unit-test by injecting the version, markdown,
+/// and store.
+@MainActor
+@Observable
+final class WhatsNewModel {
+    private(set) var entries: [ChangelogEntry]
+    var isPresented = false
+    /// User-facing app version (`CFBundleShortVersionString`), or `nil` when unknown
+    /// (e.g. running via `swift run`, which has no Info.plist).
+    let version: String?
+
+    private let store: AppStateStore
+
+    init(version: String?, changelogMarkdown: String?, store: AppStateStore) {
+        self.version = version
+        self.entries = changelogMarkdown.map(ChangelogParser.parse) ?? []
+        self.store = store
+    }
+
+    var hasContent: Bool { !entries.isEmpty }
+
+    /// Auto-present once after an update: when the running version is newer than the
+    /// version we last showed. A fresh install (no record) is *not* greeted with the
+    /// changelog — it's just recorded as seen. A dev build (no version) never
+    /// auto-presents. Either way the current version is marked seen so it won't
+    /// re-trigger.
+    func presentIfUpdated() {
+        guard let version else { return }
+        let lastSeen = store.load().lastSeenVersion
+        if let lastSeen, SemVer.isGreater(version, than: lastSeen) {
+            isPresented = true
+        }
+        markSeen(version)
+    }
+
+    /// Manual open (Help → What's New).
+    func present() { isPresented = true }
+
+    func dismiss() { isPresented = false }
+
+    private func markSeen(_ version: String) {
+        var state = store.load()
+        guard state.lastSeenVersion != version else { return }
+        state.lastSeenVersion = version
+        try? store.save(state)
+    }
+
+    /// The app version read from the bundle, formatted for display ("v0.3.0"), or a
+    /// dev placeholder when unknown.
+    var displayVersion: String { version.map { "v\($0)" } ?? "dev build" }
+}

--- a/Sources/Teebe/ViewModels/WorktreeModel.swift
+++ b/Sources/Teebe/ViewModels/WorktreeModel.swift
@@ -35,6 +35,12 @@ final class WorktreeModel {
     var selectionSource: SelectionSource = .files
     /// Expanded directory paths in the FILES tree.
     var expandedPaths: Set<String> = []
+    /// Multi-selection set for the FILES tree (absolute paths). `selectedPath` is the
+    /// active cursor and is always a member while a file selection exists; batch ops
+    /// (trash, copy-as-refs) act on this set.
+    var selectedPaths: Set<String> = []
+    /// Anchor row for range (⇧) selection; the fixed end as the cursor moves.
+    private var selectionAnchor: String?
     private(set) var worktreePath: String?
     private(set) var errorMessage: String?
     private(set) var pendingMutation: PendingMutation?
@@ -304,11 +310,168 @@ final class WorktreeModel {
         let rows = visibleRows
         guard !rows.isEmpty else { return }
         guard let current = selectedPath, let index = rows.firstIndex(where: { $0.node.path == current }) else {
-            selectedPath = rows.first?.node.path
+            select(rows[0].node.path)
             return
         }
         let next = max(0, min(rows.count - 1, index + delta))
-        selectedPath = rows[next].node.path
+        select(rows[next].node.path)
+    }
+
+    // MARK: - Multi-selection (FILES)
+
+    /// Single-select `path` (plain click / plain arrow): collapses any multi-selection
+    /// to just this row and re-anchors range selection here.
+    func select(_ path: String) {
+        selectionSource = .files
+        selectedPath = path
+        selectedPaths = [path]
+        selectionAnchor = path
+    }
+
+    /// ⌘-click: toggle `path` in/out of the selection, leaving the rest intact.
+    func toggleSelection(_ path: String) {
+        selectionSource = .files
+        if selectedPaths.contains(path) {
+            selectedPaths.remove(path)
+            if selectedPath == path { selectedPath = selectedPaths.first }
+        } else {
+            selectedPaths.insert(path)
+            selectedPath = path
+        }
+        selectionAnchor = path
+    }
+
+    /// ⇧-click / range select: select the contiguous visible run from the anchor to
+    /// `path` inclusive, moving the cursor to `path` (the anchor stays put).
+    func extendSelection(to path: String) {
+        let order = visibleRows.map(\.node.path)
+        guard let anchor = selectionAnchor ?? selectedPath,
+              let a = order.firstIndex(of: anchor),
+              let b = order.firstIndex(of: path) else { select(path); return }
+        selectionSource = .files
+        selectedPaths = Set(order[min(a, b)...max(a, b)])
+        selectedPath = path
+    }
+
+    /// ⇧↑ / ⇧↓: move the cursor one row and extend the range selection to it.
+    func extendSelection(by delta: Int) {
+        let rows = visibleRows
+        guard !rows.isEmpty else { return }
+        guard let current = selectedPath, let index = rows.firstIndex(where: { $0.node.path == current }) else {
+            select(rows[0].node.path); return
+        }
+        if selectionAnchor == nil { selectionAnchor = current }
+        let next = max(0, min(rows.count - 1, index + delta))
+        extendSelection(to: rows[next].node.path)
+    }
+
+    /// ⌘A: select every visible row.
+    func selectAllVisible() {
+        let order = visibleRows.map(\.node.path)
+        guard !order.isEmpty else { return }
+        selectionSource = .files
+        selectedPaths = Set(order)
+        if selectedPath == nil || !selectedPaths.contains(selectedPath!) { selectedPath = order.last }
+    }
+
+    /// Selected paths in visible (top-to-bottom) order.
+    func orderedSelection() -> [String] {
+        visibleRows.map(\.node.path).filter { selectedPaths.contains($0) }
+    }
+
+    /// Selected file nodes (directories excluded), in visible order — used to "open all".
+    func selectedFileNodes() -> [FileNode] {
+        orderedSelection().compactMap { node(atPath: $0) }.filter { !$0.isDirectory }
+    }
+
+    // MARK: - CHANGES list navigation
+
+    /// Move the CHANGES selection by `delta` through the change list (in display
+    /// order), clamping at the ends. Returns the newly selected change so the caller
+    /// can refresh an open diff peek.
+    @discardableResult
+    func moveChangeSelection(by delta: Int) -> FileChange? {
+        guard let worktreePath, !changes.isEmpty else { return nil }
+        selectionSource = .changes
+        let absolute = changes.map { worktreePath + "/" + $0.path }
+        let index = selectedPath.flatMap { absolute.firstIndex(of: $0) }
+        let next = index.map { max(0, min(absolute.count - 1, $0 + delta)) } ?? 0
+        selectedPath = absolute[next]
+        return changes[next]
+    }
+
+    /// Keep the current change selected if it's still valid, else select the first —
+    /// used when the CHANGES section becomes active. Returns the resulting change.
+    @discardableResult
+    func selectCurrentOrFirstChange() -> FileChange? {
+        guard let worktreePath, !changes.isEmpty else { return nil }
+        selectionSource = .changes
+        let absolute = changes.map { worktreePath + "/" + $0.path }
+        if let selectedPath, let index = absolute.firstIndex(of: selectedPath) { return changes[index] }
+        selectedPath = absolute[0]
+        return changes[0]
+    }
+
+    // MARK: - Left/Right arrow tree navigation (VSCode-style)
+
+    /// →: expand a collapsed folder; on an already-expanded folder, step into its
+    /// first child. No-op on a file.
+    func selectExpandOrDescend() {
+        guard let node = selectedNode else {
+            if let first = visibleRows.first { select(first.node.path) }
+            return
+        }
+        guard node.isDirectory else { return }
+        if isExpanded(node) {
+            let rows = visibleRows
+            guard let i = rows.firstIndex(where: { $0.node.path == node.path }) else { return }
+            if i + 1 < rows.count, rows[i + 1].depth > rows[i].depth {
+                select(rows[i + 1].node.path)
+            }
+        } else {
+            toggleExpand(node)
+        }
+    }
+
+    /// ←: collapse an expanded folder; on a collapsed folder or a file, jump up to the
+    /// parent folder.
+    func selectCollapseOrAscend() {
+        guard let node = selectedNode else { return }
+        if node.isDirectory, isExpanded(node) {
+            toggleExpand(node)
+            return
+        }
+        let rows = visibleRows
+        guard let i = rows.firstIndex(where: { $0.node.path == node.path }) else { return }
+        let depth = rows[i].depth
+        guard depth > 0 else { return }
+        for j in stride(from: i - 1, through: 0, by: -1) where rows[j].depth == depth - 1 {
+            select(rows[j].node.path)
+            return
+        }
+    }
+
+    // MARK: - Selection as Claude-ready @-refs (clipboard)
+
+    /// The current FILES selection as a single clipboard string of `@`-prefixed paths
+    /// relative to the worktree root, in visible order, space-joined (each token quoted
+    /// when it contains spaces). Empty when nothing is selected or no worktree is open.
+    func selectionRefs() -> String {
+        guard let worktreePath else { return "" }
+        let root = PathUtil.standardized(worktreePath)
+        let tokens = orderedSelection().map { absolute -> String in
+            let rel = PathUtil.relativePath(of: absolute, under: root)
+            return rel.contains(" ") ? "@\"\(rel)\"" : "@\(rel)"
+        }
+        return tokens.joined(separator: " ")
+    }
+
+    /// Move the current multi-selection to the Trash (guarded; shows the confirm
+    /// dialog). No-op when the selection is empty.
+    func requestTrashSelected(now: Date = Date()) {
+        let paths = orderedSelection()
+        guard !paths.isEmpty else { return }
+        pendingMutation = PendingMutation(kind: .trash, paths: paths, worktreeBusy: isBusy(now))
     }
 
     /// Find a node by absolute path within the currently displayed (and expanded)

--- a/Sources/Teebe/Views/ChangesSection.swift
+++ b/Sources/Teebe/Views/ChangesSection.swift
@@ -10,7 +10,7 @@ struct ChangesSection: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SectionHeader(title: "CHANGES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
+            SectionHeader(title: "CHANGES", isOpen: isOpen, isActive: app.activeSection == .changes, onToggle: { isOpen.toggle() }) {
                 HStack(spacing: 8) {
                     countBadge(worktree.changeCount)
                     if let active = app.selector.selectedWorktree {
@@ -26,11 +26,20 @@ struct ChangesSection: View {
                 // Hug the rows (the window wraps content); cap at the content height
                 // and scroll inside only when the window is dragged too short.
                 VStack(spacing: 0) {
-                    ScrollView {
-                        changeList
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            changeList
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                        .frame(maxHeight: listContentHeight)
+                        // Follow the selection when ↑/↓ moves it past the visible edge.
+                        // Snap, not animate (see FilesSection): an animated scrollTo
+                        // reads as a bounce against the row highlight + relayout.
+                        .onChange(of: worktree.selectedPath) { _, sel in
+                            guard app.activeSection == .changes, let sel else { return }
+                            proxy.scrollTo(sel, anchor: nil)
+                        }
                     }
-                    .scrollBounceBehavior(.basedOnSize)
-                    .frame(maxHeight: listContentHeight)
                 }
                 .padding(.top, 8)
                 .padding(.bottom, 6)
@@ -40,11 +49,18 @@ struct ChangesSection: View {
         .clipped()
     }
 
-    /// Estimated natural height of the change list, used to cap the section so it
-    /// hugs its rows yet can shrink-and-scroll when space is tight.
+    /// Tallest the change list hugs before it scrolls internally. Bounds how much the
+    /// window grows for a worktree with many changes, so browsing between worktrees with
+    /// very different change counts doesn't lurch the window. RootView's
+    /// `changesContentHeight` mirrors this cap so the window math and the view agree.
+    static let maxListHeight: CGFloat = 144   // ~6 rows (24pt each), then scroll
+
+    /// Natural height of the change list (rows are 24pt tall), capped at `maxListHeight`
+    /// so the section hugs its rows up to the cap and scrolls beyond it.
     private var listContentHeight: CGFloat {
         let count = worktree.changeCount
-        return count == 0 ? 24 : CGFloat(count) * 24   // rows are 24pt tall
+        let natural: CGFloat = count == 0 ? 24 : CGFloat(count) * 24
+        return min(natural, Self.maxListHeight)
     }
 
     private var changeList: some View {
@@ -76,7 +92,7 @@ struct ChangesSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(selected ? Palette.accent : .clear)
         .foregroundStyle(selected ? .white : .primary)
-        .animation(.easeInOut(duration: 0.18), value: selected)
+        // Snap, no cross-fade — avoids the trailing highlight when arrowing fast.
         .contentShape(Rectangle())
         .onTapGesture { select(change) }
         .contextMenu {
@@ -87,6 +103,7 @@ struct ChangesSection: View {
             }
             Button("Discard…", role: .destructive) { worktree.requestDiscard(change) }
         }
+        .id(absolutePath(of: change) ?? change.path)   // matches selectedPath for scroll-to
     }
 
     private func absolutePath(of change: FileChange) -> String? {
@@ -94,7 +111,7 @@ struct ChangesSection: View {
     }
 
     private func isSelected(_ change: FileChange) -> Bool {
-        worktree.selectionSource == .changes && worktree.selectedPath == absolutePath(of: change)
+        app.activeSection == .changes && worktree.selectedPath == absolutePath(of: change)
     }
 
     /// Click a change → select it (highlight). Space then peeks its diff. If the
@@ -102,6 +119,7 @@ struct ChangesSection: View {
     private func select(_ change: FileChange) {
         guard let worktreePath = worktree.worktreePath else { return }
         let node = FileNode(path: worktreePath + "/" + change.path, isDirectory: false, change: change)
+        app.activeSection = .changes
         worktree.selectedPath = node.path
         worktree.selectionSource = .changes
         if preview.isVisible {

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -12,6 +12,29 @@ enum Brand {
         .url(forResource: "teebe-logo", withExtension: "png")
         .flatMap(NSImage.init(contentsOf:))
 
+    /// The packaged `CHANGELOG.md`, drives the "What's New" window. In a release the
+    /// `.app` carries it in `Contents/Resources/` (copied by `make-app.sh`); under
+    /// `swift run`/tests there's no bundle copy, so fall back to walking up from the
+    /// executable to the repo-root `CHANGELOG.md` so the window still works in dev.
+    static let changelogMarkdown: String? = {
+        if let url = Bundle.main.url(forResource: "CHANGELOG", withExtension: "md"),
+           let text = try? String(contentsOf: url, encoding: .utf8) {
+            return text
+        }
+        var dir = URL(fileURLWithPath: Bundle.main.bundlePath)
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent("CHANGELOG.md")
+            if let text = try? String(contentsOf: candidate, encoding: .utf8) { return text }
+            dir.deleteLastPathComponent()
+        }
+        return nil
+    }()
+
+    /// User-facing version string from the bundle's `Info.plist`, or `nil` in dev.
+    static var appVersion: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
     /// Locate the SwiftPM resource bundle (`Teebe_Teebe.bundle`) across run modes.
     /// We deliberately avoid `Bundle.module`: its generated accessor only checks
     /// the app *root* (`Bundle.main.bundleURL/Teebe_Teebe.bundle`) plus a hardcoded

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -174,6 +174,9 @@ extension View {
 struct SectionHeader<Trailing: View>: View {
     let title: String
     let isOpen: Bool
+    /// Whether this is the section the keyboard is currently driving — tints the title
+    /// in the accent colour so the active section is always visible.
+    var isActive: Bool = false
     let onToggle: () -> Void
     @ViewBuilder var trailing: () -> Trailing
 
@@ -202,7 +205,8 @@ struct SectionHeader<Trailing: View>: View {
             Text(title)
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.5)
-                .foregroundStyle(Palette.headerLabel)
+                .foregroundStyle(isActive ? Palette.accent : Palette.headerLabel)
+                .animation(.easeInOut(duration: 0.18), value: isActive)
                 .fixedSize()
                 .layoutPriority(1)
             Spacer(minLength: 6)

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import TeebeCore
 
 /// FILES accordion section: search + sort + the lazily-expanding file tree.
@@ -7,10 +8,18 @@ struct FilesSection: View {
     @Bindable var worktree: WorktreeModel
     @Bindable var preview: PreviewModel
     @Binding var isOpen: Bool
+    /// Owned by RootView; lets ⌘F focus the search field and ↓/Esc hand focus back.
+    var searchFocused: FocusState<Bool>.Binding
+    /// The reveal area the tree fills below its search box. Fixed (not flexible) while
+    /// browsing so a CHANGES reflow can't momentarily balloon FILES.
+    var revealHeight: CGFloat
+    /// While the window edge is being dragged, FILES becomes the flexible filler so the
+    /// drag resizes it; otherwise it's pinned to `revealHeight`.
+    var liveResizing: Bool
 
     var body: some View {
         VStack(spacing: 0) {
-            SectionHeader(title: "FILES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
+            SectionHeader(title: "FILES", isOpen: isOpen, isActive: app.activeSection == .files, onToggle: { isOpen.toggle() }) {
                 if isOpen {
                     Menu {
                         Picker("Show", selection: $worktree.filter) {
@@ -42,15 +51,54 @@ struct FilesSection: View {
                         .textFieldStyle(.roundedBorder)
                         .font(.system(size: 12))
                         .padding(.horizontal, 11).padding(.vertical, 5)
-                    ScrollView {
-                        FileRowsView(app: app, preview: preview)
+                        .focused(searchFocused)
+                        .onChange(of: app.searchFocusRequest) { _, _ in searchFocused.wrappedValue = true }
+                        // ↓ drops focus into the results so the tree's arrow keys take over.
+                        .onKeyPress(.downArrow) {
+                            searchFocused.wrappedValue = false
+                            if let first = worktree.visibleRows.first,
+                               worktree.selectedPath == nil
+                                || !worktree.visibleRows.contains(where: { $0.node.path == worktree.selectedPath }) {
+                                worktree.select(first.node.path)
+                            }
+                            return .handled
+                        }
+                        // Enter opens the current (or first) result without leaving the field.
+                        .onKeyPress(.return) {
+                            guard let node = worktree.selectedNode ?? worktree.visibleRows.first?.node else { return .ignored }
+                            if node.isDirectory { worktree.toggleExpand(node) } else { app.open(node) }
+                            return .handled
+                        }
+                        // Esc clears the query first, then hands focus back to the tree.
+                        .onKeyPress(.escape) {
+                            if worktree.searchQuery.isEmpty { searchFocused.wrappedValue = false } else { worktree.searchQuery = "" }
+                            return .handled
+                        }
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            FileRowsView(app: app, preview: preview)
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                        // Keep the keyboard cursor on-screen: scroll the minimal amount
+                        // to reveal it when ↑/↓ moves selection past the visible edge.
+                        // Snap, don't animate — an animated scrollTo fights the row's
+                        // highlight animation and SwiftUI's relayout and reads as a
+                        // bounce (the old row flashes before settling). Finder/Xcode
+                        // snap on keyboard nav too.
+                        .onChange(of: worktree.selectedPath) { _, sel in
+                            guard app.activeSection == .files, let sel else { return }
+                            proxy.scrollTo(sel, anchor: nil)
+                        }
                     }
-                    .scrollBounceBehavior(.basedOnSize)
                 }
                 .transition(.opacity)
             }
         }
-        .frame(maxHeight: isOpen ? .infinity : nil)
+        // Open + idle → a fixed reveal pane (the tree scrolls inside it), so a CHANGES
+        // height change can't make FILES balloon for a frame. Open + dragging → the
+        // flexible filler, so the window edge resizes the reveal. Closed → just the header.
+        .frame(height: isOpen && !liveResizing ? revealHeight : nil)
+        .frame(maxHeight: isOpen && liveResizing ? .infinity : nil)
         .clipped()
     }
 }
@@ -86,7 +134,7 @@ struct FileRow: View {
 
     private var worktree: WorktreeModel { app.selector.worktree }
     private var node: FileNode { row.node }
-    private var isSelected: Bool { worktree.selectedPath == node.path }
+    private var isSelected: Bool { app.activeSection == .files && worktree.selectedPaths.contains(node.path) }
     private var isExpanded: Bool { worktree.isExpanded(node) }
 
     var body: some View {
@@ -117,7 +165,8 @@ struct FileRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isSelected ? Palette.accent : .clear)
         .foregroundStyle(isSelected ? .white : .primary)
-        .animation(.easeInOut(duration: 0.18), value: isSelected)
+        // No fade on selection: a 0.18s cross-fade leaves a visible trail of
+        // half-lit rows when arrowing fast. The cursor snaps, like native file lists.
         .contentShape(Rectangle())
         .onTapGesture { select() }
         .simultaneousGesture(TapGesture(count: 2).onEnded { activate() })
@@ -139,9 +188,18 @@ struct FileRow: View {
     }
 
     private func select() {
-        worktree.selectedPath = node.path
-        worktree.selectionSource = .files
-        if node.isDirectory { worktree.toggleExpand(node) }
+        // ⌘-click toggles one row; ⇧-click extends a range; a plain click single-selects
+        // (and toggles a folder's expansion).
+        app.activeSection = .files
+        let mods = NSEvent.modifierFlags
+        if mods.contains(.command) {
+            worktree.toggleSelection(node.path)
+        } else if mods.contains(.shift) {
+            worktree.extendSelection(to: node.path)
+        } else {
+            worktree.select(node.path)
+            if node.isDirectory { worktree.toggleExpand(node) }
+        }
         if preview.isVisible, !node.isDirectory, let wt = worktree.worktreePath {
             Task { await preview.update(for: node, worktreePath: wt) }
         }

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -176,9 +176,10 @@ struct FileRow: View {
     @ViewBuilder
     private var icon: some View {
         if node.isDirectory {
-            RoundedRectangle(cornerRadius: 2)
-                .fill(isSelected ? Color.white.opacity(0.9) : Color(red: 0x5A / 255, green: 0xA7 / 255, blue: 1))
-                .frame(width: 15, height: 12)
+            Image(systemName: "folder.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(isSelected ? Color.white : Color(red: 0x5A / 255, green: 0xA7 / 255, blue: 1))
+                .frame(width: 15)
         } else {
             Image(systemName: node.iconName)
                 .font(.system(size: 12))

--- a/Sources/Teebe/Views/KeyboardShortcutsView.swift
+++ b/Sources/Teebe/Views/KeyboardShortcutsView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// The Keyboard Shortcuts cheat sheet: every shortcut grouped by what it acts on.
+/// Opened with `?` (or Help → Keyboard Shortcuts, ⌘/) and dismissed with Esc/Close.
+/// Its content comes from `ShortcutsCatalog`, the single source of truth.
+struct KeyboardShortcutsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    ForEach(ShortcutsCatalog.groups) { group in
+                        groupView(group)
+                    }
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 460, height: 560)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            if let logo = Brand.logo {
+                Image(nsImage: logo).resizable().interpolation(.high).scaledToFit()
+                    .frame(width: 44, height: 44)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Keyboard Shortcuts")
+                    .font(.system(size: 16, weight: .semibold))
+                Text("Drive \(Brand.name) without the mouse")
+                    .font(.system(size: 12)).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20).padding(.vertical, 16)
+    }
+
+    private func groupView(_ group: ShortcutGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(group.title.uppercased())
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(Palette.accent)
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(group.items) { item in
+                    row(item)
+                }
+            }
+        }
+    }
+
+    private func row(_ item: ShortcutItem) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            keyChips(item.keys)
+                .frame(width: 150, alignment: .leading)
+            Text(item.action)
+                .font(.system(size: 12.5))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Render a row's `keys` string as rounded keycap chips: split alternatives on
+    /// " / " (joined by a dim slash), and for gestures like "⌘-click" chip the modifier
+    /// and keep "-click" as plain text. Matches the chip style in the What's New window.
+    private func keyChips(_ keys: String) -> some View {
+        let segments = keys.components(separatedBy: " / ")
+        return HStack(alignment: .firstTextBaseline, spacing: 4) {
+            ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
+                if index > 0 {
+                    Text("/").font(.system(size: 11)).foregroundStyle(Palette.secondaryText)
+                }
+                if let dash = segment.range(of: "-click") {
+                    HStack(alignment: .firstTextBaseline, spacing: 2) {
+                        chip(String(segment[segment.startIndex..<dash.lowerBound]))
+                        Text("-click").font(.system(size: 11.5)).foregroundStyle(.secondary)
+                    }
+                } else {
+                    chip(segment)
+                }
+            }
+        }
+    }
+
+    private func chip(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 5).padding(.vertical, 1.5)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(0.08))
+            )
+    }
+
+    private var footer: some View {
+        HStack {
+            Text("Open anytime with ?")
+                .font(.system(size: 11)).foregroundStyle(.secondary)
+            Spacer()
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}

--- a/Sources/Teebe/Views/KeyboardShortcutsView.swift
+++ b/Sources/Teebe/Views/KeyboardShortcutsView.swift
@@ -23,6 +23,7 @@ struct KeyboardShortcutsView: View {
             footer
         }
         .frame(width: 460, height: 560)
+        .onExitCommand { dismiss() }   // Esc closes the window
     }
 
     private var header: some View {
@@ -109,5 +110,14 @@ struct KeyboardShortcutsView: View {
                 .keyboardShortcut(.defaultAction)
         }
         .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}
+
+/// Menu command (next to About) that opens the Keyboard Shortcuts window; ⌘/.
+struct KeyboardShortcutsMenuCommand: View {
+    @Environment(\.openWindow) private var openWindow
+    var body: some View {
+        Button("Keyboard Shortcuts") { openWindow(id: WindowID.shortcuts) }
+            .keyboardShortcut("/", modifiers: .command)
     }
 }

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -18,10 +18,18 @@ struct RootView: View {
     /// scrolls; dragging the window's bottom edge while FILES is open updates it, and
     /// it's remembered per repo.
     @State private var filesReveal: CGFloat = 300
+    /// True only while the user is actively dragging the window's edge. FILES is a
+    /// fixed-height pane the rest of the time (so a CHANGES reflow can't make it balloon
+    /// for a frame); during a drag it becomes the flexible filler so the edge resizes it.
+    @State private var isLiveResizing = false
+    /// Focus of the FILES search field, lifted here so ⌘F can drive it and the
+    /// command-key shortcuts can stand down while the user is typing in it.
+    @FocusState private var searchFocused: Bool
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
 
     private var worktree: WorktreeModel { app.selector.worktree }
+    private var selector: SelectorModel { app.selector }
 
     /// Window height when all three sections are collapsed: the compact title row
     /// plus the three stacked headers (with their separators), no slack below.
@@ -49,14 +57,19 @@ struct RootView: View {
             } else {
                 // Pinned-header accordion: every section header stays visible. The
                 // window wraps its content (see targetHeight), so WORKTREES and CHANGES
-                // simply hug their rows; only FILES — whose tree is unbounded — fills
-                // the remaining height and scrolls.
+                // hug their rows (capped, then scroll); FILES is a fixed reveal pane that
+                // becomes the flexible filler only while the window edge is being dragged.
                 VStack(spacing: 0) {
+                    // Higher priority so WORKTREES/CHANGES keep their hugged height and
+                    // FILES yields: while dragging, FILES is the flexible filler and would
+                    // otherwise make the VStack split space evenly and squeeze CHANGES.
                     WorktreesSection(app: app, isOpen: sectionBinding(.worktrees, openWorktrees))
+                        .layoutPriority(1)
                     Divider()
                     ChangesSection(app: app, worktree: worktree, preview: preview, isOpen: sectionBinding(.changes, openChanges))
+                        .layoutPriority(1)
                     Divider()
-                    FilesSection(app: app, worktree: worktree, preview: preview, isOpen: sectionBinding(.files, openFiles))
+                    FilesSection(app: app, worktree: worktree, preview: preview, isOpen: sectionBinding(.files, openFiles), searchFocused: $searchFocused, revealHeight: filesReveal, liveResizing: isLiveResizing)
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
             }
@@ -81,8 +94,8 @@ struct RootView: View {
                 setTrafficLights(visible: false, animated: false, window: resolved)
                 applyLayout(for: app.selector.selectedRepo?.path)
             },
-            onLiveResizeStart: { setHeightLocked(heightPinned, height: targetHeight()) },
-            onLiveResizeEnd: { handleLiveResizeEnd($0) }
+            onLiveResizeStart: { isLiveResizing = true; setHeightLocked(heightPinned, height: targetHeight()) },
+            onLiveResizeEnd: { isLiveResizing = false; handleLiveResizeEnd($0) }
         ))
         .onChange(of: app.selector.selectedRepo?.path) { _, path in applyLayout(for: path) }
         // Keep WORKTREES/CHANGES wrapped to their rows as the lists change (preserving
@@ -95,13 +108,19 @@ struct RootView: View {
             if !allClosed { applyWindowSizing(animated: false) }
         }
         .background(QuickLookBridge(controller: quickLook))
+        .background { commandShortcuts }
         .focusable()
         .focusEffectDisabled()
         .onKeyPress(.space) { handleSpace(); return .handled }
         .onKeyPress(.escape) { preview.close(); dismissWindow(id: "preview"); return .handled }
-        .onKeyPress(.upArrow) { move(-1); return .handled }
-        .onKeyPress(.downArrow) { move(1); return .handled }
+        .onKeyPress(keys: [.upArrow, .downArrow, .leftArrow, .rightArrow]) { handleArrow($0) }
         .onKeyPress(.return) { activateSelected(); return .handled }
+        // Tab / ⇧Tab cycle the active section (stands down while typing in search).
+        .onKeyPress(keys: [.tab]) { press in
+            guard !searchFocused else { return .ignored }
+            cycleSection(forward: !press.modifiers.contains(.shift))
+            return .handled
+        }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {
             Button("Confirm", role: .destructive) { Task { await worktree.confirmPendingMutation() } }
             Button("Cancel", role: .cancel) { worktree.cancelPendingMutation() }
@@ -194,15 +213,18 @@ struct RootView: View {
         applyWindowSizing(animated: false)
     }
 
-    /// `true` only when every section is collapsed: the window then shrinks to the
-    /// three stacked headers and its height is pinned.
-    private var heightPinned: Bool { allClosed }
+    /// `true` whenever FILES is closed: the window then *wraps* its content exactly
+    /// (headers, plus WORKTREES/CHANGES hugged to their capped rows), so its height is
+    /// pinned. Leaving it free in these states let SwiftUI's idealHeight drift the
+    /// window a frame later and open an 18pt "chin" of empty material below the content.
+    /// Only FILES open (the unbounded scroller) makes the window freely resizable.
+    private var heightPinned: Bool { !openFiles }
 
-    /// When the window is pinned (all-collapsed) drive the SwiftUI frame to that exact
+    /// When the window is pinned (FILES closed) drive the SwiftUI frame to that exact
     /// height so `windowResizability` reports the same min/ideal/max we set on the
-    /// `NSWindow`; otherwise SwiftUI's content-min re-clamps the window a frame later
-    /// and leaves an empty "chin" below the last header. `nil` (free height) whenever a
-    /// section is open.
+    /// `NSWindow`; otherwise SwiftUI's idealHeight re-clamps the window a frame later
+    /// and leaves an empty "chin" of material below the content. `nil` (free height)
+    /// only while FILES is open.
     ///
     /// `targetHeight()` is a *window* height; SwiftUI's `.frame` sizes the *content*
     /// (`contentLayoutRect`) and the window is that plus a constant title-bar inset. We
@@ -228,22 +250,23 @@ struct RootView: View {
         (window?.screen ?? NSScreen.main)?.visibleFrame.height ?? 900
     }
 
-    /// Estimated natural height of the open worktree list (mirrors WorktreesSection);
+    /// Height of the open worktree list (mirrors WorktreesSection, including its cap);
     /// 0 when closed.
     private var worktreesContentHeight: CGFloat {
         guard openWorktrees else { return 0 }
         let s = app.selector
         let repoRow: CGFloat = s.selectedRepo != nil ? 25 : 0
         let rows: CGFloat = s.worktrees.isEmpty ? 26 : CGFloat(s.worktrees.count) * 26
-        return 8 + repoRow + rows
+        return min(8 + repoRow + rows, WorktreesSection.maxListHeight)
     }
 
-    /// Estimated natural height of the open change list (mirrors ChangesSection); 0
-    /// when closed.
+    /// Height of the open change list (mirrors ChangesSection, including its cap); 0
+    /// when closed. The +14 is the section's top/bottom padding around the list.
     private var changesContentHeight: CGFloat {
         guard openChanges else { return 0 }
         let count = app.selector.worktree.changeCount
-        return 14 + (count == 0 ? 24 : CGFloat(count) * 24)
+        let natural: CGFloat = count == 0 ? 24 : CGFloat(count) * 24
+        return 14 + min(natural, ChangesSection.maxListHeight)
     }
 
     /// Size the window to the current state, anchored at the top so it grows and
@@ -310,21 +333,170 @@ struct RootView: View {
 
     // MARK: - Keyboard
 
-    private func move(_ delta: Int) {
+    /// Arrow-key navigation, dispatched to whichever section is active. WORKTREES:
+    /// move the keyboard cursor (Enter commits). CHANGES: move the selection and track
+    /// the open diff peek. FILES: move/extend the cursor and ←/→ collapse-expand.
+    private func handleArrow(_ press: KeyPress) -> KeyPress.Result {
+        let result: KeyPress.Result
+        switch app.activeSection {
+        case .worktrees: result = handleWorktreeArrow(press)
+        case .changes:   result = handleChangesArrow(press)
+        case .files:     result = handleFilesArrow(press)
+        }
+        return result
+    }
+
+    /// WORKTREES: ↑/↓ move the keyboard cursor (no switch — Enter commits).
+    private func handleWorktreeArrow(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .upArrow:   selector.moveWorktreeHighlight(by: -1)
+        case .downArrow: selector.moveWorktreeHighlight(by: 1)
+        default:         return .ignored
+        }
+        return .handled
+    }
+
+    /// CHANGES: ↑/↓ move the selection and follow the open diff peek.
+    private func handleChangesArrow(_ press: KeyPress) -> KeyPress.Result {
+        switch press.key {
+        case .upArrow:   moveChange(by: -1)
+        case .downArrow: moveChange(by: 1)
+        default:         return .ignored
+        }
+        return .handled
+    }
+
+    /// FILES: ↑/↓ move/extend the cursor; ←/→ collapse-expand or jump parent/child.
+    private func handleFilesArrow(_ press: KeyPress) -> KeyPress.Result {
         worktree.selectionSource = .files
-        delta < 0 ? worktree.selectPrevious() : worktree.selectNext()
-        if preview.isVisible, let node = worktree.selectedNode, !node.isDirectory,
-           let wt = worktree.worktreePath {
-            Task { await preview.update(for: node, worktreePath: wt) }
+        let shift = press.modifiers.contains(.shift)
+        switch press.key {
+        case .upArrow:
+            if shift { worktree.extendSelection(by: -1) } else { worktree.selectPrevious() }
+        case .downArrow:
+            if shift { worktree.extendSelection(by: 1) } else { worktree.selectNext() }
+        case .leftArrow:  worktree.selectCollapseOrAscend()
+        case .rightArrow: worktree.selectExpandOrDescend()
+        default:          return .ignored
+        }
+        syncPreviewToSelection()
+        return .handled
+    }
+
+    /// Move the CHANGES selection and, if the diff peek is open, swap its content to
+    /// the newly selected file in place (the preview window itself does not move).
+    private func moveChange(by delta: Int) {
+        guard let change = worktree.moveChangeSelection(by: delta),
+              preview.isVisible, let wt = worktree.worktreePath else { return }
+        let node = FileNode(path: wt + "/" + change.path, isDirectory: false, change: change)
+        Task { await preview.update(for: node, worktreePath: wt) }
+    }
+
+    // MARK: - Section focus (⌘1/2/3, Tab)
+
+    /// ⌘1/⌘2/⌘3: if the section is already active, toggle it open/closed; otherwise
+    /// make it active (opening it and moving the selection in).
+    private func focusOrToggle(_ section: AppModel.FocusSection) {
+        if app.activeSection == section {
+            setOpen(rootSection(section), !sectionIsOpen(section))
+        } else {
+            activate(section)
         }
     }
 
-    /// Spacebar previews the current selection: the native Quick Look panel for a
-    /// FILES row, or the in-app diff peek for a CHANGES row.
+    /// Tab / ⇧Tab: move the active section forward/back through WORKTREES→CHANGES→FILES.
+    private func cycleSection(forward: Bool) {
+        let order: [AppModel.FocusSection] = [.worktrees, .changes, .files]
+        let index = order.firstIndex(of: app.activeSection) ?? 2
+        activate(order[(index + (forward ? 1 : order.count - 1)) % order.count])
+    }
+
+    /// Make `section` the active one: open it if collapsed, and seat the selection
+    /// (the open worktree for WORKTREES, the current/first change, or a file cursor).
+    private func activate(_ section: AppModel.FocusSection) {
+        app.activeSection = section
+        if !sectionIsOpen(section) { setOpen(rootSection(section), true) }
+        switch section {
+        case .worktrees:
+            selector.highlightSelectedWorktree()
+        case .changes:
+            if let change = worktree.selectCurrentOrFirstChange(), preview.isVisible, let wt = worktree.worktreePath {
+                let node = FileNode(path: wt + "/" + change.path, isDirectory: false, change: change)
+                Task { await preview.update(for: node, worktreePath: wt) }
+            }
+        case .files:
+            worktree.selectionSource = .files
+            let hasValidCursor = worktree.selectedPath.map { sel in worktree.visibleRows.contains { $0.node.path == sel } } ?? false
+            if !hasValidCursor, let first = worktree.visibleRows.first { worktree.select(first.node.path) }
+        }
+    }
+
+    private func rootSection(_ s: AppModel.FocusSection) -> Section {
+        switch s {
+        case .worktrees: .worktrees
+        case .changes:   .changes
+        case .files:     .files
+        }
+    }
+
+    private func sectionIsOpen(_ s: AppModel.FocusSection) -> Bool {
+        switch s {
+        case .worktrees: openWorktrees
+        case .changes:   openChanges
+        case .files:     openFiles
+        }
+    }
+
+    /// Keep the live preview tracking the cursor as it moves over files.
+    private func syncPreviewToSelection() {
+        guard preview.isVisible, let node = worktree.selectedNode, !node.isDirectory,
+              let wt = worktree.worktreePath else { return }
+        Task { await preview.update(for: node, worktreePath: wt) }
+    }
+
+    /// Hidden buttons that register the command-key shortcuts window-wide. Disabled
+    /// while the search field is focused so ⌘A / ⌘⌫ keep editing the query text there.
+    private var commandShortcuts: some View {
+        Group {
+            Button("") { focusOrToggle(.worktrees) }.keyboardShortcut("1", modifiers: .command)
+            Button("") { focusOrToggle(.changes) }.keyboardShortcut("2", modifiers: .command)
+            Button("") { focusOrToggle(.files) }.keyboardShortcut("3", modifiers: .command)
+            Button("") { focusSearch() }.keyboardShortcut("f", modifiers: .command)
+            Button("") { if app.activeSection == .files { worktree.selectAllVisible() } }.keyboardShortcut("a", modifiers: .command)
+            Button("") { copyRefs() }.keyboardShortcut("c", modifiers: [.command, .shift])
+            Button("") { trashSelection() }.keyboardShortcut(.delete, modifiers: .command)
+        }
+        .opacity(0)
+        .frame(width: 0, height: 0)
+        .accessibilityHidden(true)
+        .disabled(searchFocused)
+    }
+
+    /// ⌘F: open FILES if needed and hand focus to its search field.
+    private func focusSearch() {
+        if !openFiles { setOpen(.files, true) }
+        app.focusSearch()
+    }
+
+    /// ⌘⇧C: copy the FILES selection to the clipboard as Claude-ready `@`-refs.
+    private func copyRefs() {
+        guard app.activeSection == .files else { return }
+        app.copySelectedRefs()
+    }
+
+    /// ⌘⌫: move the FILES selection to the Trash (guarded by the confirm dialog).
+    private func trashSelection() {
+        guard app.activeSection == .files else { return }
+        worktree.requestTrashSelected()
+    }
+
+    /// Spacebar previews the active section's selection: the native Quick Look panel
+    /// for a FILES row, the in-app diff peek for a CHANGES row, nothing for WORKTREES.
     private func handleSpace() {
-        switch worktree.selectionSource {
-        case .changes: toggleDiffPeek()
-        case .files: presentQuickLook()
+        switch app.activeSection {
+        case .changes:   toggleDiffPeek()
+        case .files:     presentQuickLook()
+        case .worktrees: break
         }
     }
 
@@ -346,6 +518,18 @@ struct RootView: View {
         Task {
             await preview.toggle(for: node, worktreePath: wt)
             openWindow(id: "preview")
+            await reclaimKeyFocus()
+        }
+    }
+
+    /// The freshly-opened peek scene becomes the key window and would swallow ↑/↓, so
+    /// the CHANGES/FILES list couldn't drive it. Hand key status back to the main
+    /// window (the peek stays visible — it floats above and only its content updates).
+    /// Retried across a few runloops because the scene becomes key asynchronously.
+    private func reclaimKeyFocus() async {
+        for _ in 0..<3 {
+            try? await Task.sleep(for: .milliseconds(80))
+            window?.makeKey()
         }
     }
 
@@ -360,9 +544,23 @@ struct RootView: View {
         quickLook.toggle(urls: urls, startIndex: start)
     }
 
+    /// Enter, dispatched by active section: WORKTREES commits the highlighted worktree
+    /// (the switch); CHANGES opens the changed file; FILES opens the file(s) or toggles
+    /// a folder.
     private func activateSelected() {
-        guard let node = worktree.selectedNode else { return }
-        if node.isDirectory { worktree.toggleExpand(node) } else { app.open(node) }
+        switch app.activeSection {
+        case .worktrees:
+            Task { await selector.commitHighlightedWorktree() }
+        case .changes:
+            guard let wt = worktree.worktreePath, let change = selectedChange else { return }
+            app.open(FileNode(path: wt + "/" + change.path, isDirectory: false, change: change))
+        case .files:
+            guard let node = worktree.selectedNode else { return }
+            if node.isDirectory { worktree.toggleExpand(node); return }
+            // With several files selected, Enter opens them all; otherwise just the cursor.
+            let files = worktree.selectedFileNodes()
+            if files.count > 1 { files.forEach { app.open($0) } } else { app.open(node) }
+        }
     }
 
     // MARK: - Guarded mutation confirmation

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -132,7 +132,7 @@ struct RootView: View {
         // ? opens the keyboard cheat sheet (but let it type into the search field).
         .onKeyPress("?") {
             guard !searchFocused else { return .ignored }
-            app.showKeyboardShortcuts = true
+            openWindow(id: WindowID.shortcuts)
             return .handled
         }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -22,6 +22,9 @@ struct RootView: View {
     /// fixed-height pane the rest of the time (so a CHANGES reflow can't make it balloon
     /// for a frame); during a drag it becomes the flexible filler so the edge resizes it.
     @State private var isLiveResizing = false
+    /// Layout to restore when the green zoom is toggled off — set while the window is
+    /// "vertically maximized" (full height), nil otherwise.
+    @State private var zoomRestore: ZoomRestore?
     /// Focus of the FILES search field, lifted here so ⌘F can drive it and the
     /// command-key shortcuts can stand down while the user is typing in it.
     @FocusState private var searchFocused: Bool
@@ -45,6 +48,10 @@ struct RootView: View {
     private let minFilesReveal: CGFloat = 140
 
     private enum Section { case worktrees, changes, files }
+
+    /// Snapshot taken when the green zoom maximizes the window vertically, restored on
+    /// the next zoom toggle.
+    private struct ZoomRestore { let frame: NSRect; let openFiles: Bool; let reveal: CGFloat }
 
     private var allClosed: Bool { !openWorktrees && !openChanges && !openFiles }
 
@@ -95,7 +102,8 @@ struct RootView: View {
                 applyLayout(for: app.selector.selectedRepo?.path)
             },
             onLiveResizeStart: { isLiveResizing = true; setHeightLocked(heightPinned, height: targetHeight()) },
-            onLiveResizeEnd: { isLiveResizing = false; handleLiveResizeEnd($0) }
+            onLiveResizeEnd: { isLiveResizing = false; handleLiveResizeEnd($0) },
+            onZoom: { toggleVerticalZoom() }
         ))
         .onChange(of: app.selector.selectedRepo?.path) { _, path in applyLayout(for: path) }
         // Keep WORKTREES/CHANGES wrapped to their rows as the lists change (preserving
@@ -119,6 +127,12 @@ struct RootView: View {
         .onKeyPress(keys: [.tab]) { press in
             guard !searchFocused else { return .ignored }
             cycleSection(forward: !press.modifiers.contains(.shift))
+            return .handled
+        }
+        // ? opens the keyboard cheat sheet (but let it type into the search field).
+        .onKeyPress("?") {
+            guard !searchFocused else { return .ignored }
+            app.showKeyboardShortcuts = true
             return .handled
         }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {
@@ -279,9 +293,39 @@ struct RootView: View {
         setWindowHeight(target, animated: animated && !shrinking)
     }
 
+    /// Green zoom: toggle a *vertical* maximize. Grow to the full visible screen height
+    /// at the current width and x (never wider), opening FILES so it fills the new room;
+    /// a second click restores the previous size and section layout. Unlike AppKit's
+    /// default zoom (fill the whole screen, both dimensions), this keeps teebe a column.
+    private func toggleVerticalZoom() {
+        guard let window else { return }
+        let visible = (window.screen ?? NSScreen.main)?.visibleFrame ?? window.frame
+        if let restore = zoomRestore {
+            zoomRestore = nil
+            openFiles = restore.openFiles
+            filesReveal = restore.reveal
+            setHeightLocked(heightPinned, height: targetHeight())
+            window.setFrame(restore.frame, display: true, animate: false)
+            persistLayout()
+            return
+        }
+        zoomRestore = ZoomRestore(frame: window.frame, openFiles: openFiles, reveal: filesReveal)
+        openFiles = true
+        let nonFiles = collapsedHeight + worktreesContentHeight + changesContentHeight
+        filesReveal = max(minFilesReveal, visible.height - nonFiles)
+        setHeightLocked(false, height: targetHeight())   // FILES open → resizable up to the screen
+        var frame = window.frame
+        frame.size.height = visible.height               // width and x untouched → no widening
+        frame.origin.y = visible.minY
+        window.setFrame(frame, display: true, animate: false)
+        persistLayout()
+    }
+
     /// User finished dragging the window edge. Height is derived from content (wrap),
     /// so there's nothing to remember — just persist the open/closed flags.
     private func handleLiveResizeEnd(_ height: CGFloat) {
+        // A manual resize means we're no longer in the zoomed state.
+        zoomRestore = nil
         // Dragging the edge resizes the FILES area (the only thing that can grow past
         // its content); record it so the reveal persists. With FILES closed the window
         // already wraps WORKTREES/CHANGES, so there's nothing to remember.

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -615,6 +615,12 @@ private struct EmptyStateView: View {
             .controlSize(.large)
             .buttonStyle(.borderedProminent)
             .modifier(StaggeredReveal(revealed: revealed, step: 3))
+            if let version = Brand.appVersion {
+                Text("\(Brand.name) v\(version)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Palette.secondaryText)
+                    .modifier(StaggeredReveal(revealed: revealed, step: 4))
+            }
         }
         .frame(maxWidth: .infinity, minHeight: 300)
         .padding(40)

--- a/Sources/Teebe/Views/ShortcutsCatalog.swift
+++ b/Sources/Teebe/Views/ShortcutsCatalog.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One row in the Keyboard Shortcuts cheat sheet: the key combo and what it does.
+struct ShortcutItem: Identifiable {
+    let keys: String
+    let action: String
+    var id: String { keys + "\u{1}" + action }
+}
+
+/// A titled group of related shortcuts (a section of the cheat sheet).
+struct ShortcutGroup: Identifiable {
+    let title: String
+    let items: [ShortcutItem]
+    var id: String { title }
+}
+
+/// The single source of truth for the cheat sheet. Mirror this whenever a shortcut
+/// changes in `RootView`/`FilesSection` so the sheet stays accurate.
+enum ShortcutsCatalog {
+    static let groups: [ShortcutGroup] = [
+        ShortcutGroup(title: "Sections", items: [
+            ShortcutItem(keys: "⌘1 / ⌘2 / ⌘3", action: "Focus Worktrees / Changes / Files (again to collapse)"),
+            ShortcutItem(keys: "Tab / ⇧Tab", action: "Cycle the active section")
+        ]),
+        ShortcutGroup(title: "Navigate", items: [
+            ShortcutItem(keys: "↑ / ↓", action: "Move selection in the active section"),
+            ShortcutItem(keys: "→", action: "Expand folder / go to first child"),
+            ShortcutItem(keys: "←", action: "Collapse folder / go to parent"),
+            ShortcutItem(keys: "Return", action: "Open file · switch worktree · open change"),
+            ShortcutItem(keys: "Space", action: "Quick Look a file / peek a change's diff")
+        ]),
+        ShortcutGroup(title: "Select files", items: [
+            ShortcutItem(keys: "⇧↑ / ⇧↓", action: "Extend the selection"),
+            ShortcutItem(keys: "⌘A", action: "Select all files"),
+            ShortcutItem(keys: "⌘-click", action: "Add or remove one file"),
+            ShortcutItem(keys: "⇧-click", action: "Select a range")
+        ]),
+        ShortcutGroup(title: "Files actions", items: [
+            ShortcutItem(keys: "⌘F", action: "Jump to search"),
+            ShortcutItem(keys: "⌘⇧C", action: "Copy selection as @-refs"),
+            ShortcutItem(keys: "⌘⌫", action: "Move selection to Trash")
+        ]),
+        ShortcutGroup(title: "Search", items: [
+            ShortcutItem(keys: "↓", action: "Drop from the search box into results"),
+            ShortcutItem(keys: "Esc", action: "Clear the query, then return to the tree")
+        ])
+    ]
+}

--- a/Sources/Teebe/Views/WhatsNewView.swift
+++ b/Sources/Teebe/Views/WhatsNewView.swift
@@ -31,6 +31,7 @@ struct WhatsNewView: View {
             footer
         }
         .frame(width: 440, height: 520)
+        .onExitCommand { dismiss() }   // Esc closes the window
     }
 
     private var header: some View {
@@ -207,5 +208,13 @@ private struct ChipFlow: Layout {
         guard guide == .firstTextBaseline,
               let first = rows(subviews, maxWidth: bounds.width).first else { return nil }
         return first.map { metric(subviews[$0]).baseline }.max()
+    }
+}
+
+/// Menu command (next to About) that opens the What's New window.
+struct WhatsNewMenuCommand: View {
+    @Environment(\.openWindow) private var openWindow
+    var body: some View {
+        Button("What's New in \(Brand.name)") { openWindow(id: WindowID.whatsNew) }
     }
 }

--- a/Sources/Teebe/Views/WhatsNewView.swift
+++ b/Sources/Teebe/Views/WhatsNewView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import TeebeCore
+
+/// The "What's New" window: the app logo + version, then the changelog rendered as
+/// grouped, bulleted release notes. Shown automatically the first launch after an
+/// update, and on demand from Help → What's New.
+struct WhatsNewView: View {
+    @Bindable var model: WhatsNewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if model.hasContent {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 22) {
+                        ForEach(model.entries) { entry in
+                            entryView(entry)
+                        }
+                    }
+                    .padding(20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            } else {
+                Text("No release notes available.")
+                    .font(.callout).foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 440, height: 520)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            if let logo = Brand.logo {
+                Image(nsImage: logo).resizable().interpolation(.high).scaledToFit()
+                    .frame(width: 44, height: 44)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text("What's New in \(Brand.name)")
+                    .font(.system(size: 16, weight: .semibold))
+                Text(model.displayVersion)
+                    .font(.system(size: 12)).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20).padding(.vertical, 16)
+    }
+
+    private func entryView(_ entry: ChangelogEntry) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(entry.isUnreleased ? "Unreleased" : "Version \(entry.version)")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Palette.accent)
+                if let date = entry.date {
+                    Text(date).font(.system(size: 11)).foregroundStyle(.secondary)
+                }
+            }
+            // Flat bullet list per version — the Added/Changed/Fixed groupings live
+            // in CHANGELOG.md for authoring, but users just see what changed.
+            VStack(alignment: .leading, spacing: 5) {
+                ForEach(entry.groups.flatMap(\.items), id: \.self) { item in
+                    bullet(item)
+                }
+            }
+        }
+    }
+
+    private func bullet(_ item: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Text("•").foregroundStyle(Palette.secondaryText)
+            Text(attributed(item))
+                .font(.system(size: 12.5))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Render inline markdown (bold, code, links) for a bullet, falling back to plain
+    /// text if it can't be parsed.
+    private func attributed(_ item: String) -> AttributedString {
+        (try? AttributedString(markdown: item)) ?? AttributedString(item)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}

--- a/Sources/Teebe/Views/WhatsNewView.swift
+++ b/Sources/Teebe/Views/WhatsNewView.swift
@@ -73,17 +73,49 @@ struct WhatsNewView: View {
     private func bullet(_ item: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 7) {
             Text("•").foregroundStyle(Palette.secondaryText)
-            Text(attributed(item))
-                .font(.system(size: 12.5))
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
+            ChipFlow(spacing: 3, lineSpacing: 6) {
+                ForEach(Array(tokens(for: item).enumerated()), id: \.offset) { _, token in
+                    switch token {
+                    case let .word(text, bold):
+                        Text(text)
+                            .font(.system(size: 12.5, weight: bold ? .semibold : .regular))
+                            .foregroundStyle(.primary)
+                    case let .chip(text):
+                        Text(text)
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.primary)
+                            .padding(.horizontal, 5).padding(.vertical, 1.5)
+                            .background(
+                                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                    .fill(Color.primary.opacity(0.08))
+                            )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
-    /// Render inline markdown (bold, code, links) for a bullet, falling back to plain
-    /// text if it can't be parsed.
-    private func attributed(_ item: String) -> AttributedString {
-        (try? AttributedString(markdown: item)) ?? AttributedString(item)
+    /// Split a bullet's inline markdown into flow tokens: plain words (optionally bold)
+    /// and `code` spans. Working word-by-word (instead of one `Text`) lets the code
+    /// spans render as real rounded chip views that wrap inline with the prose.
+    private func tokens(for item: String) -> [BulletToken] {
+        guard let parsed = try? AttributedString(markdown: item) else {
+            return item.split(separator: " ").map { .word(String($0), bold: false) }
+        }
+        var out: [BulletToken] = []
+        for run in parsed.runs {
+            let text = String(parsed[run.range].characters)
+            if run.inlinePresentationIntent?.contains(.code) == true {
+                out.append(.chip(text.trimmingCharacters(in: .whitespaces)))
+            } else {
+                let bold = run.inlinePresentationIntent?.contains(.stronglyEmphasized) == true
+                for word in text.split(separator: " ", omittingEmptySubsequences: true) {
+                    out.append(.word(String(word), bold: bold))
+                }
+            }
+        }
+        return out
     }
 
     private var footer: some View {
@@ -93,5 +125,87 @@ struct WhatsNewView: View {
                 .keyboardShortcut(.defaultAction)
         }
         .padding(.horizontal, 20).padding(.vertical, 12)
+    }
+}
+
+/// A flow token: a plain (optionally bold) word, or a `code` span shown as a chip.
+private enum BulletToken {
+    case word(String, bold: Bool)
+    case chip(String)
+}
+
+/// A left-to-right wrapping layout that aligns every item on the text baseline, so the
+/// rounded chip views sit inline with the prose and wrap to new lines cleanly (no
+/// trailing slivers, unlike an inline-text background).
+private struct ChipFlow: Layout {
+    var spacing: CGFloat = 3
+    var lineSpacing: CGFloat = 6
+
+    private struct Metric { let size: CGSize; let baseline: CGFloat }
+
+    private func metric(_ subview: LayoutSubview) -> Metric {
+        let dim = subview.dimensions(in: .unspecified)
+        return Metric(size: CGSize(width: dim.width, height: dim.height),
+                      baseline: dim[VerticalAlignment.firstTextBaseline] ?? dim.height)
+    }
+
+    /// Group subview indices into rows that each fit within `maxWidth`.
+    private func rows(_ subviews: Subviews, maxWidth: CGFloat) -> [[Int]] {
+        var rows: [[Int]] = []
+        var row: [Int] = []
+        var x: CGFloat = 0
+        for index in subviews.indices {
+            let width = metric(subviews[index]).size.width
+            if !row.isEmpty, x + width > maxWidth {
+                rows.append(row); row = []; x = 0
+            }
+            row.append(index)
+            x += width + spacing
+        }
+        if !row.isEmpty { rows.append(row) }
+        return rows
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = rows(subviews, maxWidth: maxWidth)
+        var height: CGFloat = 0
+        var width: CGFloat = 0
+        for (i, row) in rows.enumerated() {
+            let metrics = row.map { metric(subviews[$0]) }
+            let ascent = metrics.map(\.baseline).max() ?? 0
+            let descent = metrics.map { $0.size.height - $0.baseline }.max() ?? 0
+            height += ascent + descent + (i < rows.count - 1 ? lineSpacing : 0)
+            let rowWidth = metrics.reduce(0) { $0 + $1.size.width + spacing } - spacing
+            width = max(width, rowWidth)
+        }
+        return CGSize(width: maxWidth.isFinite ? maxWidth : max(width, 0), height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = rows(subviews, maxWidth: bounds.width)
+        var y = bounds.minY
+        for row in rows {
+            let metrics = row.map { metric(subviews[$0]) }
+            let ascent = metrics.map(\.baseline).max() ?? 0
+            let descent = metrics.map { $0.size.height - $0.baseline }.max() ?? 0
+            var x = bounds.minX
+            for (offset, index) in row.enumerated() {
+                let m = metrics[offset]
+                subviews[index].place(at: CGPoint(x: x, y: y + ascent - m.baseline),
+                                      proposal: ProposedViewSize(m.size))
+                x += m.size.width + spacing
+            }
+            y += ascent + descent + lineSpacing
+        }
+    }
+
+    /// Report the first row's baseline so an enclosing `firstTextBaseline` HStack (the
+    /// bullet dot) lines up with the first line of text.
+    func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect,
+                           proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+        guard guide == .firstTextBaseline,
+              let first = rows(subviews, maxWidth: bounds.width).first else { return nil }
+        return first.map { metric(subviews[$0]).baseline }.max()
     }
 }

--- a/Sources/Teebe/Views/WindowAccessor.swift
+++ b/Sources/Teebe/Views/WindowAccessor.swift
@@ -26,6 +26,10 @@ struct WindowController: NSViewRepresentable {
     var onResolve: (NSWindow) -> Void
     var onLiveResizeStart: () -> Void
     var onLiveResizeEnd: (CGFloat) -> Void
+    /// Green "zoom" button (and double-click on the title bar is left to AppKit). We
+    /// override it to grow the window to full height at the same width instead of the
+    /// default fill-the-screen zoom.
+    var onZoom: () -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -46,22 +50,26 @@ struct WindowController: NSViewRepresentable {
         }
     }
 
-    final class Coordinator {
+    final class Coordinator: NSObject {
         private(set) weak var window: NSWindow?
         private var observers: [NSObjectProtocol] = []
         private var floatOnTop = false
         private var onLiveResizeStart: (() -> Void)?
         private var onLiveResizeEnd: ((CGFloat) -> Void)?
+        private var onZoom: (() -> Void)?
 
         /// Per-update, no allocation: refresh the callbacks and float level only.
         func refresh(parent: WindowController) {
             onLiveResizeStart = parent.onLiveResizeStart
             onLiveResizeEnd = parent.onLiveResizeEnd
+            onZoom = parent.onZoom
             if floatOnTop != parent.floatOnTop {
                 floatOnTop = parent.floatOnTop
                 window?.level = floatOnTop ? .floating : .normal
             }
         }
+
+        @objc private func zoomClicked() { onZoom?() }
 
         /// One-time: bind to the window and install the live-resize observers.
         func attach(_ window: NSWindow?, parent: WindowController) {
@@ -70,6 +78,11 @@ struct WindowController: NSViewRepresentable {
             floatOnTop = parent.floatOnTop
             window.level = floatOnTop ? .floating : .normal
             parent.onResolve(window)
+            // Take over the green zoom button so it grows to full height, not full screen.
+            if let zoomButton = window.standardWindowButton(.zoomButton) {
+                zoomButton.target = self
+                zoomButton.action = #selector(zoomClicked)
+            }
             // Re-assert the height clamp the instant a drag begins (SwiftUI's
             // windowResizability keeps re-enabling free resize otherwise)…
             observers.append(NotificationCenter.default.addObserver(

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -11,7 +11,7 @@ struct WorktreesSection: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SectionHeader(title: "WORKTREES", isOpen: isOpen, onToggle: { isOpen.toggle() }) {
+            SectionHeader(title: "WORKTREES", isOpen: isOpen, isActive: app.activeSection == .worktrees, onToggle: { isOpen.toggle() }) {
                 if isOpen {
                     HStack(spacing: 2) {
                         Button { app.presentAddRepositoryPanel() } label: {
@@ -57,21 +57,34 @@ struct WorktreesSection: View {
                 // Hug the rows (the window wraps content), but cap at the content
                 // height and scroll inside when the window is dragged too short — the
                 // other headers must never get pushed off-screen.
-                ScrollView { worktreeListBody }
-                    .scrollBounceBehavior(.basedOnSize)
-                    .frame(maxHeight: listContentHeight)
-                    .transition(.opacity)
+                ScrollViewReader { proxy in
+                    ScrollView { worktreeListBody }
+                        .scrollBounceBehavior(.basedOnSize)
+                        .frame(maxHeight: listContentHeight)
+                        // Keep the keyboard cursor visible as ↑/↓ move it. Snap, not
+                        // animate (see FilesSection) — avoids the bounce-then-settle.
+                        .onChange(of: selector.highlightedWorktree?.path) { _, path in
+                            guard app.activeSection == .worktrees, let path else { return }
+                            proxy.scrollTo(path, anchor: nil)
+                        }
+                }
+                .transition(.opacity)
             }
         }
         .clipped()
     }
 
-    /// Estimated natural height of the worktree list, used to cap the section so it
-    /// hugs its rows yet can shrink-and-scroll when space is tight.
+    /// Tallest the worktree list hugs before it scrolls internally (repo row + ~6
+    /// worktrees). Keeps the window from ballooning on a repo with many worktrees;
+    /// RootView's `worktreesContentHeight` mirrors this cap.
+    static let maxListHeight: CGFloat = 200
+
+    /// Natural height of the worktree list, capped at `maxListHeight` so the section
+    /// hugs its rows up to the cap and scrolls beyond it.
     private var listContentHeight: CGFloat {
         let repoRow: CGFloat = selector.selectedRepo != nil ? 25 : 0
         let rows: CGFloat = selector.worktrees.isEmpty ? 26 : CGFloat(selector.worktrees.count) * 26
-        return 8 + repoRow + rows   // 8 = worktreeListBody vertical padding
+        return min(8 + repoRow + rows, Self.maxListHeight)   // 8 = worktreeListBody vertical padding
     }
 
     private var worktreeListBody: some View {
@@ -109,6 +122,9 @@ struct WorktreesSection: View {
     private func worktreeRow(_ worktree: Worktree) -> some View {
         let info = selector.info(for: worktree)
         let isActive = selector.selectedWorktree?.path == worktree.path
+        // The keyboard cursor (only while WORKTREES is the active section): an outline,
+        // distinct from the filled accent of the committed worktree. Enter commits it.
+        let isHighlighted = app.activeSection == .worktrees && selector.highlightedWorktree?.path == worktree.path
         return HStack(spacing: 7) {
             LiveDot(active: info.isLive)
             Image(systemName: "point.3.connected.trianglepath.dotted")
@@ -127,9 +143,18 @@ struct WorktreesSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isActive ? Palette.accent : .clear)
         .foregroundStyle(isActive ? .white : .primary)
+        .overlay {
+            if isHighlighted, !isActive {
+                RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.accent, lineWidth: 1.5)
+            }
+        }
         .animation(.easeInOut(duration: 0.18), value: isActive)
         .contentShape(Rectangle())
-        .onTapGesture { Task { await selector.selectWorktree(worktree) } }
+        .onTapGesture {
+            app.activeSection = .worktrees
+            selector.highlightedWorktree = worktree
+            Task { await selector.selectWorktree(worktree) }
+        }
         .contextMenu {
             Button("Open in Finder") { app.revealPath(worktree.path) }
             Button("Open in Terminal") { app.openTerminal(at: worktree.path) }
@@ -137,5 +162,6 @@ struct WorktreesSection: View {
                 Button("Remove Worktree…", role: .destructive) { app.removeWorktree(worktree) }
             }
         }
+        .id(worktree.path)   // scroll-to target for keyboard highlight
     }
 }

--- a/Sources/TeebeCore/AppStateStore.swift
+++ b/Sources/TeebeCore/AppStateStore.swift
@@ -42,6 +42,9 @@ public struct AppState: Codable, Equatable, Sendable {
     /// Accordion layout keyed by repository path. Optional so older state files
     /// (without this key) still decode instead of resetting everything.
     public var layoutByRepo: [String: SectionLayout]?
+    /// The app version we last showed the "What's New" window for. Optional so older
+    /// state files decode; `nil` means "never shown" (treated as a fresh install).
+    public var lastSeenVersion: String?
 
     public init(
         repositories: [PersistedRepository] = [],
@@ -50,7 +53,8 @@ public struct AppState: Codable, Equatable, Sendable {
         floatOnTop: Bool = false,
         lastSelectedRepoPath: String? = nil,
         lastSelectedWorktreePath: String? = nil,
-        layoutByRepo: [String: SectionLayout]? = nil
+        layoutByRepo: [String: SectionLayout]? = nil,
+        lastSeenVersion: String? = nil
     ) {
         self.repositories = repositories
         self.showChangedOnly = showChangedOnly
@@ -59,6 +63,7 @@ public struct AppState: Codable, Equatable, Sendable {
         self.lastSelectedRepoPath = lastSelectedRepoPath
         self.lastSelectedWorktreePath = lastSelectedWorktreePath
         self.layoutByRepo = layoutByRepo
+        self.lastSeenVersion = lastSeenVersion
     }
 }
 

--- a/Sources/TeebeCore/Changelog.swift
+++ b/Sources/TeebeCore/Changelog.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// One version's worth of a parsed changelog: a version label, an optional date,
+/// and its grouped bullet items. Pure value types so the parser is fully testable
+/// without any UI.
+public struct ChangelogEntry: Equatable, Sendable, Identifiable {
+    /// Version label, e.g. `"0.3.0"` or `"Unreleased"`.
+    public var version: String
+    /// Raw date string from the header (e.g. `"2026-06-24"`), when present.
+    public var date: String?
+    public var groups: [ChangelogGroup]
+
+    public var id: String { version }
+    public var isUnreleased: Bool { version.lowercased() == "unreleased" }
+
+    public init(version: String, date: String? = nil, groups: [ChangelogGroup] = []) {
+        self.version = version
+        self.date = date
+        self.groups = groups
+    }
+}
+
+/// A titled group of bullet items within an entry (e.g. `### Added`). `title` is
+/// `nil` for bullets that appear before any `###` subheading.
+public struct ChangelogGroup: Equatable, Sendable, Identifiable {
+    public var title: String?
+    public var items: [String]
+
+    public var id: String { title ?? "—" }
+
+    public init(title: String? = nil, items: [String] = []) {
+        self.title = title
+        self.items = items
+    }
+}
+
+/// Parses [Keep a Changelog](https://keepachangelog.com/) markdown into entries.
+///
+/// Grammar (everything else is ignored): `## [version] - date` starts an entry,
+/// `### Group` starts a group, and `- ` / `* ` lines are bullets. Bullet text that
+/// wraps onto continuation lines is rejoined. Item text keeps its inline markdown
+/// so the view can render emphasis/code.
+public enum ChangelogParser {
+    public static func parse(_ markdown: String) -> [ChangelogEntry] {
+        var entries: [ChangelogEntry] = []
+        var groups: [ChangelogGroup] = []
+        var currentGroup: ChangelogGroup?
+        var version: String?
+        var date: String?
+
+        func flushGroup() {
+            if let group = currentGroup, !group.items.isEmpty { groups.append(group) }
+            currentGroup = nil
+        }
+        func flushEntry() {
+            flushGroup()
+            if let version { entries.append(ChangelogEntry(version: version, date: date, groups: groups)) }
+            version = nil
+            date = nil
+            groups = []
+        }
+        func appendContinuation(_ text: String) {
+            guard version != nil, currentGroup != nil,
+                  let last = currentGroup?.items.indices.last else { return }
+            currentGroup?.items[last] += " " + text
+        }
+
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("## ") {
+                flushEntry()
+                (version, date) = parseHeader(String(line.dropFirst(3)))
+            } else if line.hasPrefix("### ") {
+                flushGroup()
+                let title = String(line.dropFirst(4)).trimmingCharacters(in: .whitespaces)
+                currentGroup = ChangelogGroup(title: title.isEmpty ? nil : title, items: [])
+            } else if line.hasPrefix("- ") || line.hasPrefix("* ") {
+                guard version != nil else { continue }
+                if currentGroup == nil { currentGroup = ChangelogGroup(title: nil, items: []) }
+                currentGroup?.items.append(String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces))
+            } else if !line.isEmpty {
+                appendContinuation(line)
+            }
+        }
+        flushEntry()
+        return entries
+    }
+
+    /// Split a `## ` header body into version + optional date. Accepts `[0.3.0] -
+    /// 2026-06-24`, `0.3.0 - 2026-06-24`, and `[Unreleased]`.
+    private static func parseHeader(_ text: String) -> (String, String?) {
+        var version = text
+        var date: String?
+        if let dash = text.range(of: " - ") {
+            version = String(text[..<dash.lowerBound])
+            date = String(text[dash.upperBound...]).trimmingCharacters(in: .whitespaces)
+        }
+        version = version.trimmingCharacters(in: CharacterSet(charactersIn: "[] "))
+        return (version, (date?.isEmpty ?? true) ? nil : date)
+    }
+}
+
+/// Minimal dotted-numeric version comparison — enough to decide "is this build
+/// newer than the one we last showed What's New for". Non-numeric segments count
+/// as 0, so `"0.10.0" > "0.9.0"` and `"0.3.0" > "0.3"`.
+public enum SemVer {
+    public static func components(_ version: String) -> [Int] {
+        version.split(separator: ".").map { segment in
+            Int(segment.prefix { $0.isNumber }) ?? 0
+        }
+    }
+
+    /// `true` when `lhs` is a strictly greater version than `rhs`.
+    public static func isGreater(_ lhs: String, than rhs: String) -> Bool {
+        let left = components(lhs)
+        let right = components(rhs)
+        for index in 0..<max(left.count, right.count) {
+            let leftValue = index < left.count ? left[index] : 0
+            let rightValue = index < right.count ? right[index] : 0
+            if leftValue != rightValue { return leftValue > rightValue }
+        }
+        return false
+    }
+}

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -37,6 +37,118 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-Sparkle additionally bundles permissively licensed components (e.g. `bsdiff`
-under a BSD-style license and an Ed25519 implementation). See the Sparkle
-distribution for their full notices.
+Sparkle additionally bundles the permissively licensed components below, which
+are compiled into the shipped Sparkle framework. Their notices are reproduced
+verbatim from Sparkle's own `LICENSE`.
+
+### bsdiff / bspatch (BSD 2-Clause)
+
+`bspatch.c` and `bsdiff.c`, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+```
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
+### sais-lite (MIT)
+
+`sais.c` and `sais.h`, from sais-lite (2010/08/07)
+<https://sites.google.com/site/yuta256/sais>:
+
+```
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### Ed25519 (zlib)
+
+Portable C implementation of Ed25519, from <https://github.com/orlp/ed25519>:
+
+```
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the
+authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial
+applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+   original software. If you use this software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+   being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+```
+
+### SUSignatureVerifier (BSD 2-Clause)
+
+```
+Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```

--- a/Tests/TeebeCoreTests/ChangelogParserTests.swift
+++ b/Tests/TeebeCoreTests/ChangelogParserTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import TeebeCore
+
+@Suite("ChangelogParser")
+struct ChangelogParserTests {
+    private let sample = """
+    # Changelog
+
+    Intro paragraph that should be ignored.
+
+    ## [Unreleased]
+
+    ### Added
+    - A brand new thing.
+
+    ## [0.3.0] - 2026-06-24
+
+    ### Changed
+    - Window resizing reworked into a coherent model — no more bounce on a
+      window drag.
+
+    ### Fixed
+    - Dock icon rendering.
+    - Updater start-up.
+
+    ## [0.2.0] - 2026-06-23
+
+    - An ungrouped bullet before any subheading.
+    """
+
+    @Test("parses entries newest-first with versions and dates")
+    func entriesAndDates() {
+        let entries = ChangelogParser.parse(sample)
+        #expect(entries.map(\.version) == ["Unreleased", "0.3.0", "0.2.0"])
+        #expect(entries[0].isUnreleased)
+        #expect(entries[1].date == "2026-06-24")
+        #expect(entries[0].date == nil)
+    }
+
+    @Test("groups bullets under their ### subheadings")
+    func groups() {
+        let entries = ChangelogParser.parse(sample)
+        let v030 = entries[1]
+        #expect(v030.groups.map(\.title) == ["Changed", "Fixed"])
+        #expect(v030.groups[1].items == ["Dock icon rendering.", "Updater start-up."])
+    }
+
+    @Test("rejoins a bullet that wraps across lines")
+    func wrappedBullet() {
+        let entries = ChangelogParser.parse(sample)
+        let changed = entries[1].groups[0].items
+        #expect(changed == ["Window resizing reworked into a coherent model — no more bounce on a window drag."])
+    }
+
+    @Test("bullets before any subheading land in an untitled group")
+    func ungroupedBullets() {
+        let entries = ChangelogParser.parse(sample)
+        let v020 = entries[2]
+        #expect(v020.groups.count == 1)
+        #expect(v020.groups[0].title == nil)
+        #expect(v020.groups[0].items == ["An ungrouped bullet before any subheading."])
+    }
+
+    @Test("empty input yields no entries")
+    func empty() {
+        #expect(ChangelogParser.parse("").isEmpty)
+        #expect(ChangelogParser.parse("# Changelog\n\nNothing here yet.").isEmpty)
+    }
+}
+
+@Suite("SemVer")
+struct SemVerTests {
+    @Test("compares dotted numeric versions")
+    func compare() {
+        #expect(SemVer.isGreater("0.3.0", than: "0.2.2"))
+        #expect(SemVer.isGreater("0.10.0", than: "0.9.0"))   // numeric, not lexicographic
+        #expect(SemVer.isGreater("1.0.0", than: "0.99.99"))
+        #expect(SemVer.isGreater("0.3.1", than: "0.3"))      // 0.3.1 > 0.3.0
+    }
+
+    @Test("equal or lower versions are not greater")
+    func notGreater() {
+        #expect(!SemVer.isGreater("0.3.0", than: "0.3.0"))
+        #expect(!SemVer.isGreater("0.2.0", than: "0.3.0"))
+        #expect(!SemVer.isGreater("0.3", than: "0.3.0"))     // trailing zero == equal
+        #expect(!SemVer.isGreater("0.3.0", than: "0.3"))
+    }
+}

--- a/Tests/TeebeTests/ShortcutsCatalogTests.swift
+++ b/Tests/TeebeTests/ShortcutsCatalogTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import Teebe
+
+@Suite("ShortcutsCatalog")
+struct ShortcutsCatalogTests {
+    @Test("has the expected groups in order")
+    func groupTitles() {
+        let titles = ShortcutsCatalog.groups.map(\.title)
+        #expect(titles == ["Sections", "Navigate", "Select files", "Files actions", "Search"])
+    }
+
+    @Test("every row has non-empty keys and an action")
+    func rowsAreWellFormed() {
+        let items = ShortcutsCatalog.groups.flatMap(\.items)
+        #expect(!items.isEmpty)
+        for item in items {
+            #expect(!item.keys.trimmingCharacters(in: .whitespaces).isEmpty)
+            #expect(!item.action.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+    }
+
+    @Test("row identifiers are unique")
+    func idsAreUnique() {
+        let ids = ShortcutsCatalog.groups.flatMap(\.items).map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("documents the headline shortcuts")
+    func coversKeyShortcuts() {
+        let keys = ShortcutsCatalog.groups.flatMap(\.items).map(\.keys)
+        // Spot-check that the marquee bindings are listed so the sheet can't silently
+        // drift from RootView/FilesSection.
+        #expect(keys.contains { $0.contains("⌘⇧C") })   // copy @-refs
+        #expect(keys.contains { $0.contains("⌘⌫") })    // trash
+        #expect(keys.contains { $0.contains("⌘F") })    // search
+        #expect(keys.contains { $0.contains("⌘1") })    // section focus
+    }
+}

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -117,6 +117,31 @@ struct SelectorModelTests {
         #expect(selector.worktree.worktreePath == "/repo")
     }
 
+    @Test("WORKTREES keyboard cursor moves and clamps; Enter commits the switch")
+    func worktreeHighlightNav() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-a", branch: "feat/a"),
+            Worktree(path: "/repo-b", branch: "feat/b"),
+        ]
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        // Activating WORKTREES seats the cursor on the currently-open worktree.
+        selector.highlightSelectedWorktree()
+        #expect(selector.highlightedWorktree?.path == "/repo")
+
+        selector.moveWorktreeHighlight(by: 1)
+        #expect(selector.highlightedWorktree?.path == "/repo-a")
+        selector.moveWorktreeHighlight(by: 5)   // clamps at the last row
+        #expect(selector.highlightedWorktree?.path == "/repo-b")
+        #expect(selector.selectedWorktree?.path == "/repo")   // not switched until commit
+
+        await selector.commitHighlightedWorktree()
+        #expect(selector.selectedWorktree?.path == "/repo-b")
+    }
+
     @Test("live dot lights for a worktree written to within the window, off after it")
     func liveDotWindow() async {
         let git = FakeGitClient()
@@ -442,6 +467,137 @@ struct WorktreeNavigationTests {
         #expect(model.visibleRows.map(\.node.name) == ["b.txt"])
     }
 
+    // MARK: - Left/Right arrow tree navigation
+
+    @Test("→ expands a collapsed folder, then descends into its first child")
+    func rightArrowExpandsThenDescends() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let src = try #require(model.visibleRows.first { $0.node.name == "src" }).node
+        model.select(src.path)
+
+        model.selectExpandOrDescend()
+        #expect(model.isExpanded(src))
+        #expect(model.selectedPath == src.path)   // cursor stays on the folder
+
+        model.selectExpandOrDescend()
+        #expect(model.selectedNode?.name == "b.txt")   // now steps into the child
+    }
+
+    @Test("← collapses an expanded folder; from a child it jumps to the parent")
+    func leftArrowCollapsesAndAscends() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let src = try #require(model.visibleRows.first { $0.node.name == "src" }).node
+        model.select(src.path)
+        model.selectExpandOrDescend()   // expand
+        let b = try #require(model.visibleRows.first { $0.node.name == "b.txt" }).node
+        model.select(b.path)
+
+        model.selectCollapseOrAscend()   // file → jump to parent
+        #expect(model.selectedNode?.name == "src")
+        #expect(model.isExpanded(src))   // parent stays expanded
+
+        model.selectCollapseOrAscend()   // expanded folder → collapse
+        #expect(model.isExpanded(src) == false)
+    }
+
+    // MARK: - Multi-selection
+
+    @Test("⌘-toggle and ⇧-range build and collapse the multi-selection")
+    func multiSelectToggleAndRange() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let rows = model.visibleRows.map(\.node.path)
+        let (first, second) = (rows[0], rows[1])
+
+        model.select(first)
+        model.toggleSelection(second)
+        #expect(model.selectedPaths == [first, second])
+        model.toggleSelection(second)
+        #expect(model.selectedPaths == [first])
+
+        model.select(first)
+        model.extendSelection(to: second)
+        #expect(model.selectedPaths == [first, second])
+        #expect(model.orderedSelection() == [first, second])   // visible (top-down) order
+
+        model.selectAllVisible()
+        #expect(model.selectedPaths.count == rows.count)
+
+        // A plain arrow collapses any multi-selection back to a single cursor.
+        model.selectPrevious()
+        #expect(model.selectedPaths.count == 1)
+    }
+
+    @Test("⇧↓ extends the selection by one row")
+    func shiftArrowExtends() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.select(model.visibleRows[0].node.path)
+        model.extendSelection(by: 1)
+        #expect(model.selectedPaths.count == 2)
+    }
+
+    @Test("selectedFileNodes excludes directories")
+    func selectedFileNodesExcludesDirs() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.selectAllVisible()   // src (dir) + a.txt
+        let files = model.selectedFileNodes()
+        #expect(files.allSatisfy { !$0.isDirectory })
+        #expect(files.contains { $0.name == "a.txt" })
+    }
+
+    @Test("requestTrashSelected stages a trash mutation for the whole selection")
+    func trashSelected() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        model.selectAllVisible()
+        model.requestTrashSelected(now: Date())
+        #expect(model.pendingMutation?.kind == .trash)
+        #expect(Set(model.pendingMutation?.paths ?? []) == model.selectedPaths)
+    }
+
+    // MARK: - Selection as @-refs
+
+    @Test("selectionRefs emits @-prefixed worktree-relative paths in visible order")
+    func selectionRefsFormat() async throws {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        let src = try #require(model.visibleRows.first { $0.node.name == "src" }).node
+        model.select(src.path)
+        model.selectExpandOrDescend()   // expand so src/b.txt is visible
+        let b = try #require(model.visibleRows.first { $0.node.name == "b.txt" }).node
+        let a = try #require(model.visibleRows.first { $0.node.name == "a.txt" }).node
+        model.select(a.path)
+        model.toggleSelection(b.path)
+
+        // Visible order is src/b.txt (depth 1, under src) then a.txt.
+        #expect(model.selectionRefs() == "@src/b.txt @a.txt")
+    }
+
+    @Test("selectionRefs quotes a path containing spaces")
+    func selectionRefsQuotesSpaces() async throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("tb-refs-\(UUID().uuidString)")
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? "x".write(to: dir.appendingPathComponent("my file.txt"), atomically: true, encoding: .utf8)
+        defer { try? fm.removeItem(at: dir) }
+        let model = WorktreeModel(environment: makeTestEnvironment())
+        await model.load(worktreePath: dir.path, repo: Repository(path: dir.path))
+        let file = try #require(model.visibleRows.first { $0.node.name == "my file.txt" }).node
+        model.select(file.path)
+        #expect(model.selectionRefs() == "@\"my file.txt\"")
+    }
+
     @Test("changeGroups groups changes by folder")
     func changeGroups() async {
         let (dir, cleanup) = tempTree(); defer { cleanup() }
@@ -456,6 +612,28 @@ struct WorktreeNavigationTests {
         let folders = model.changeGroups.map(\.folder)
         #expect(folders.contains("src"))
         #expect(folders.contains(""))
+    }
+
+    @Test("CHANGES selection moves through the list and clamps at the ends")
+    func changeNavigation() async {
+        let (dir, cleanup) = tempTree(); defer { cleanup() }
+        let git = FakeGitClient()
+        git.statusResult = StatusResult(changes: [
+            FileChange(path: "a.txt", worktreeStatus: .modified),
+            FileChange(path: "src/b.txt", worktreeStatus: .modified),
+        ])
+        let model = WorktreeModel(environment: makeTestEnvironment(git: git))
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+
+        let first = try? #require(model.selectCurrentOrFirstChange())
+        #expect(model.selectionSource == .changes)
+        #expect(model.selectedPath == dir + "/" + model.changes[0].path)
+        #expect(first?.path == model.changes[0].path)
+
+        #expect(model.moveChangeSelection(by: 1)?.path == model.changes[1].path)
+        #expect(model.selectedPath == dir + "/" + model.changes[1].path)
+        #expect(model.moveChangeSelection(by: 1)?.path == model.changes[1].path)   // clamp at end
+        #expect(model.moveChangeSelection(by: -5)?.path == model.changes[0].path)  // clamp at start
     }
 
     @Test("commitPending stages and commits, then clears the message")

--- a/Tests/TeebeTests/WhatsNewModelTests.swift
+++ b/Tests/TeebeTests/WhatsNewModelTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+@testable import Teebe
+import TeebeCore
+
+@MainActor
+@Suite("WhatsNewModel")
+struct WhatsNewModelTests {
+    private let changelog = """
+    # Changelog
+
+    ## [0.3.0] - 2026-06-24
+
+    ### Added
+    - A new thing.
+    """
+
+    private func makeStore() -> AppStateStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tb-wn-\(UUID().uuidString)")
+            .appendingPathComponent("state.json")
+        return AppStateStore(url: url)
+    }
+
+    @Test("parses the changelog into entries")
+    func parses() {
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: makeStore())
+        #expect(model.entries.map(\.version) == ["0.3.0"])
+        #expect(model.hasContent)
+        #expect(model.displayVersion == "v0.3.0")
+    }
+
+    @Test("a fresh install is recorded as seen but not greeted with the changelog")
+    func freshInstall() {
+        let store = makeStore()
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == false)
+        #expect(store.load().lastSeenVersion == "0.3.0")
+    }
+
+    @Test("auto-presents once after an update, then records the new version")
+    func presentsOnUpdate() {
+        let store = makeStore()
+        try? store.save(AppState(lastSeenVersion: "0.2.2"))
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == true)
+        #expect(store.load().lastSeenVersion == "0.3.0")
+    }
+
+    @Test("does not re-present for the same version")
+    func sameVersion() {
+        let store = makeStore()
+        try? store.save(AppState(lastSeenVersion: "0.3.0"))
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == false)
+    }
+
+    @Test("a dev build with no version never auto-presents and doesn't crash")
+    func devBuild() {
+        let store = makeStore()
+        let model = WhatsNewModel(version: nil, changelogMarkdown: changelog, store: store)
+        model.presentIfUpdated()
+        #expect(model.isPresented == false)
+        #expect(store.load().lastSeenVersion == nil)
+        #expect(model.displayVersion == "dev build")
+    }
+
+    @Test("manual present opens it regardless of seen state")
+    func manualPresent() {
+        let store = makeStore()
+        try? store.save(AppState(lastSeenVersion: "0.3.0"))
+        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
+        model.present()
+        #expect(model.isPresented == true)
+    }
+}

--- a/Tests/TeebeTests/WhatsNewModelTests.swift
+++ b/Tests/TeebeTests/WhatsNewModelTests.swift
@@ -34,46 +34,33 @@ struct WhatsNewModelTests {
     func freshInstall() {
         let store = makeStore()
         let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == false)
+        #expect(model.presentIfUpdated() == false)
         #expect(store.load().lastSeenVersion == "0.3.0")
     }
 
-    @Test("auto-presents once after an update, then records the new version")
+    @Test("greets once after an update, then records the new version")
     func presentsOnUpdate() {
         let store = makeStore()
         try? store.save(AppState(lastSeenVersion: "0.2.2"))
         let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == true)
+        #expect(model.presentIfUpdated() == true)
         #expect(store.load().lastSeenVersion == "0.3.0")
     }
 
-    @Test("does not re-present for the same version")
+    @Test("does not greet again for the same version")
     func sameVersion() {
         let store = makeStore()
         try? store.save(AppState(lastSeenVersion: "0.3.0"))
         let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == false)
+        #expect(model.presentIfUpdated() == false)
     }
 
-    @Test("a dev build with no version never auto-presents and doesn't crash")
+    @Test("a dev build with no version never greets and doesn't crash")
     func devBuild() {
         let store = makeStore()
         let model = WhatsNewModel(version: nil, changelogMarkdown: changelog, store: store)
-        model.presentIfUpdated()
-        #expect(model.isPresented == false)
+        #expect(model.presentIfUpdated() == false)
         #expect(store.load().lastSeenVersion == nil)
         #expect(model.displayVersion == "dev build")
-    }
-
-    @Test("manual present opens it regardless of seen state")
-    func manualPresent() {
-        let store = makeStore()
-        try? store.save(AppState(lastSeenVersion: "0.3.0"))
-        let model = WhatsNewModel(version: "0.3.0", changelogMarkdown: changelog, store: store)
-        model.present()
-        #expect(model.isPresented == true)
     }
 }

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Print one version's section body from CHANGELOG.md — everything between the
+# "## [VERSION]" heading and the next "## " heading, without the heading line
+# itself. This is the single source the Release workflow uses for BOTH the GitHub
+# release body and the Sparkle appcast release notes, so all surfaces stay in sync
+# with CHANGELOG.md.
+#
+# Usage: scripts/changelog-section.sh <version> [changelog-path]
+#   e.g. scripts/changelog-section.sh 0.3.0
+set -euo pipefail
+
+VERSION="${1:?usage: changelog-section.sh <version> [changelog-path]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+awk -v ver="$VERSION" '
+  /^## / {
+    if (inSection) exit            # next version heading ends the section
+    hdr = $0
+    sub(/^## /, "", hdr)
+    sub(/ - .*/, "", hdr)          # drop " - DATE"
+    gsub(/[][ ]/, "", hdr)         # drop brackets and spaces -> bare version
+    if (hdr == ver) { inSection = 1; next }
+  }
+  inSection { print }
+' "$CHANGELOG" \
+  | awk 'NF {seen=1} seen {print}' \
+  | awk '{ lines[NR]=$0 } END { last=NR; while (last>0 && lines[last]=="") last--; for (i=1;i<=last;i++) print lines[i] }'

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -51,6 +51,14 @@ shopt -u nullglob
 # CHANGELOG.md from Contents/Resources in a packaged build).
 cp CHANGELOG.md "$APP/Contents/Resources/CHANGELOG.md"
 
+# Ship the license notices INSIDE the bundle so they travel with the binary that
+# users download (the GPL requires the license to accompany conveyed object code;
+# Sparkle's MIT and the vendored BSD-2-Clause notices require reproduction in
+# materials provided with a binary distribution). THIRD-PARTY-LICENSES.md carries
+# the full Sparkle + bsdiff/sais/ed25519/SUSignatureVerifier texts.
+cp LICENSE "$APP/Contents/Resources/LICENSE"
+cp THIRD-PARTY-LICENSES.md "$APP/Contents/Resources/THIRD-PARTY-LICENSES.md"
+
 # Embed Sparkle.framework (SwiftPM stages it next to the binary) and point the
 # executable's runtime search path at the bundle's Frameworks dir.
 echo "==> embedding Sparkle.framework"
@@ -83,6 +91,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleShortVersionString</key><string>${APP_VERSION}</string>
   <key>CFBundleVersion</key><string>${BUILD_NUMBER}</string>
+  <key>NSHumanReadableCopyright</key><string>© 2026 Klein Tahiraj. Licensed under GPL-3.0-or-later (see LICENSE) or a commercial license. Bundles Sparkle and other components — see THIRD-PARTY-LICENSES.</string>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSPrincipalClass</key><string>NSApplication</string>
   <key>NSHighResolutionCapable</key><true/>

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.3.1}"
+APP_VERSION="${APP_VERSION:-0.4.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -47,6 +47,10 @@ for b in "$BINDIR"/*.bundle; do
 done
 shopt -u nullglob
 
+# Ship the changelog so the in-app "What's New" window can read it (Brand reads
+# CHANGELOG.md from Contents/Resources in a packaged build).
+cp CHANGELOG.md "$APP/Contents/Resources/CHANGELOG.md"
+
 # Embed Sparkle.framework (SwiftPM stages it next to the binary) and point the
 # executable's runtime search path at the bundle's Frameworks dir.
 echo "==> embedding Sparkle.framework"


### PR DESCRIPTION
Release **v0.4.0** (first release since v0.3.1).

Ships everything accumulated on `dev`: keyboard navigation, multi-select + agent send, automatic worktree detection, the Keyboard Shortcuts cheat sheet and What's New window, bounded section sizing, vertical maximize, the folder-tree icon — plus license notices bundled in the app and the What's New / Keyboard Shortcuts panels as movable windows.

Merge with a regular merge commit (not squash), then tag `v0.4.0`.