### PR TITLE
Fix delete/discard silently no-oping when confirmed

### DIFF
--- a/Sources/Teebe/ViewModels/WorktreeModel.swift
+++ b/Sources/Teebe/ViewModels/WorktreeModel.swift
@@ -540,7 +540,16 @@ final class WorktreeModel {
     }
 
     func confirmPendingMutation() async {
-        guard let mutation = pendingMutation, let worktreePath else { return }
+        guard let mutation = pendingMutation else { return }
+        await confirm(mutation)
+    }
+
+    /// Execute a specific guarded mutation. Callers pass the mutation explicitly
+    /// (captured synchronously) rather than reading `pendingMutation` here: the
+    /// confirmation dialog clears `pendingMutation` as it dismisses, so a confirm
+    /// deferred into a `Task` would otherwise find it already nil and silently no-op.
+    func confirm(_ mutation: PendingMutation) async {
+        guard let worktreePath else { return }
         pendingMutation = nil
         await perform {
             switch mutation.kind {

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -136,7 +136,14 @@ struct RootView: View {
             return .handled
         }
         .confirmationDialog(confirmTitle, isPresented: confirmBinding, titleVisibility: .visible) {
-            Button("Confirm", role: .destructive) { Task { await worktree.confirmPendingMutation() } }
+            // Capture the mutation synchronously: dismissing the dialog drives
+            // `confirmBinding` to false → `cancelPendingMutation()`, which would clear
+            // `pendingMutation` before a deferred `Task` could read it.
+            Button("Confirm", role: .destructive) {
+                if let mutation = worktree.pendingMutation {
+                    Task { await worktree.confirm(mutation) }
+                }
+            }
             Button("Cancel", role: .cancel) { worktree.cancelPendingMutation() }
         } message: {
             Text(confirmMessage)

--- a/Tests/TeebeTests/DeleteIntegrationTests.swift
+++ b/Tests/TeebeTests/DeleteIntegrationTests.swift
@@ -1,0 +1,119 @@
+import Testing
+import Foundation
+@testable import Teebe
+@testable import TeebeCore
+
+/// End-to-end delete coverage using the *real* `FileManagerFileOps` (not the
+/// fake), so a regression in the actual trash + tree-refresh path is caught.
+@MainActor
+@Suite("Delete integration (real FileManagerFileOps)")
+struct DeleteIntegrationTests {
+    private func tempDir() -> (String, () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("tb-del-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Resolve /var → /private/var so paths match the tree builder's realpath form.
+        let resolved = PathUtil.standardized(dir.path)
+        return (resolved, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    private func realOpsEnvironment(git: FakeGitClient = FakeGitClient()) -> AppEnvironment {
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tb-del-store-\(UUID().uuidString)")
+            .appendingPathComponent("state.json")
+        return AppEnvironment(
+            git: git,
+            opener: FakeFileOpener(),
+            ops: FileManagerFileOps(),
+            store: AppStateStore(url: storeURL),
+            activityMonitor: WorktreeActivityMonitor(),
+            makeWatcher: { FakeWatcher() }
+        )
+    }
+
+    @Test("trashing a selected file removes it from disk and the tree")
+    func trashRemovesFromTreeAndDisk() async throws {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let fileURL = URL(fileURLWithPath: dir).appendingPathComponent("a.txt")
+        try "hello".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let model = WorktreeModel(environment: realOpsEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+
+        // Sanity: the file shows in the tree before delete.
+        #expect(model.visibleRows.contains { $0.node.path == fileURL.path })
+
+        model.select(fileURL.path)
+        model.requestTrashSelected()
+        #expect(model.pendingMutation?.kind == .trash)
+
+        await model.confirmPendingMutation()
+
+        #expect(model.errorMessage == nil)
+        #expect(FileManager.default.fileExists(atPath: fileURL.path) == false)
+        #expect(model.visibleRows.contains { $0.node.path == fileURL.path } == false)
+    }
+
+    /// Reproduces the SwiftUI confirmation-dialog ordering: tapping "Confirm" defers
+    /// the delete into a `Task`, but the dialog's own dismissal synchronously drives
+    /// `isPresented` to false, which cancels the pending mutation *before* the task
+    /// runs. The file must still be trashed.
+    @Test("confirm survives the dialog's synchronous dismissal (does not no-op)")
+    func confirmRaceWithDismissal() async throws {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let fileURL = URL(fileURLWithPath: dir).appendingPathComponent("race.txt")
+        try "x".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let model = WorktreeModel(environment: realOpsEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+
+        model.requestTrash(path: fileURL.path)
+        // Mimic the confirmationDialog "Confirm" button: capture the mutation
+        // synchronously, schedule the async work in a Task (which does not run
+        // synchronously), then let the dialog's dismissal write isPresented=false →
+        // cancelPendingMutation() runs first, on this same turn.
+        guard let mutation = model.pendingMutation else { Issue.record("no pending mutation"); return }
+        let confirm = Task { await model.confirm(mutation) }
+        model.cancelPendingMutation()   // dialog dismissal (synchronous)
+        await confirm.value
+
+        #expect(model.errorMessage == nil)
+        #expect(FileManager.default.fileExists(atPath: fileURL.path) == false)
+    }
+
+    /// The model-level invariant behind the fix: a captured mutation still executes
+    /// even after `pendingMutation` has been cleared (as the dialog does on dismiss).
+    @Test("confirm(_:) executes a captured mutation after pendingMutation is cleared")
+    func confirmCapturedAfterClear() async throws {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let fileURL = URL(fileURLWithPath: dir).appendingPathComponent("captured.txt")
+        try "x".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let model = WorktreeModel(environment: realOpsEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+
+        model.requestTrash(path: fileURL.path)
+        guard let mutation = model.pendingMutation else { Issue.record("no pending mutation"); return }
+        model.cancelPendingMutation()   // dialog clears the presentation flag
+        await model.confirm(mutation)   // captured mutation still runs
+
+        #expect(FileManager.default.fileExists(atPath: fileURL.path) == false)
+    }
+
+    @Test("context-menu trash of a single file removes it from disk and the tree")
+    func contextMenuTrash() async throws {
+        let (dir, cleanup) = tempDir(); defer { cleanup() }
+        let fileURL = URL(fileURLWithPath: dir).appendingPathComponent("b.txt")
+        try "bye".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let model = WorktreeModel(environment: realOpsEnvironment())
+        await model.load(worktreePath: dir, repo: Repository(path: dir))
+        #expect(model.visibleRows.contains { $0.node.path == fileURL.path })
+
+        model.requestTrash(path: fileURL.path)
+        await model.confirmPendingMutation()
+
+        #expect(model.errorMessage == nil)
+        #expect(FileManager.default.fileExists(atPath: fileURL.path) == false)
+        #expect(model.visibleRows.contains { $0.node.path == fileURL.path } == false)
+    }
+}


### PR DESCRIPTION
## What
Deleting a file (Move to Trash) did nothing after confirming. Same latent bug affected Discard, which shares the dialog.

## Root cause
The confirmation dialog's `isPresented` binding clears `pendingMutation` on dismissal:

```swift
get: { pendingMutation != nil }
set: { if !$0 { cancelPendingMutation() } }   // → pendingMutation = nil
```

The Confirm button deferred the work into `Task { await confirmPendingMutation() }`. Tapping Confirm dismisses the dialog **synchronously** (setter → `cancelPendingMutation()` → `pendingMutation = nil`) while the confirm work is deferred. By the time the `Task` runs, `confirmPendingMutation()` hits `guard let mutation = pendingMutation else { return }` — already nil — and no-ops. Nothing gets trashed.

The existing fake-based tests never caught this because they call the confirm method directly, with no dialog dismissal in between.

## Fix
- Capture the mutation **synchronously** in the Confirm action, before the dialog dismisses, and execute that captured value via a new `confirm(_:)` method decoupled from the presentation flag. `confirmPendingMutation()` is kept as a thin delegator.

## Tests
Added `DeleteIntegrationTests` wiring the **real** `FileManagerFileOps` into `WorktreeModel` against a temp dir:
- reproduces the dialog dismissal ordering (fails before the fix),
- asserts a captured mutation still executes after `pendingMutation` is cleared,
- covers both the ⌘⌫ selection path and the context-menu single-file path end to end (real trash + tree refresh).

All 161 tests pass; SwiftLint clean (no new warnings).