### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.4.0}"
+APP_VERSION="${APP_VERSION:-0.4.1}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with


### PR DESCRIPTION
Patch release bump for v0.4.1.

Ships the fix for delete/discard silently no-oping when confirmed (#59).