### PR TITLE
Add v0.4.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.4.1] - 2026-07-01
+
+### Fixed
+- Deleting a file (Move to Trash) or discarding changes no longer silently does
+  nothing after you confirm it in the dialog.
+
 ## [0.4.0] - 2026-06-30
 
 ### Added


### PR DESCRIPTION
Retroactively documents v0.4.1 in CHANGELOG.md (the single source of truth the site changelog + release notes read from). The v0.4.1 release shipped without this entry, so teebe.io/changelog.html still topped out at 0.4.0.

Covers the one fix in v0.4.1: delete/discard no longer silently no-ops after confirming.