### PR TITLE
Add v0.4.1 changelog entry to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.4.1] - 2026-07-01
+
+### Fixed
+- Deleting a file (Move to Trash) or discarding changes no longer silently does
+  nothing after you confirm it in the dialog.
+
 ## [0.4.0] - 2026-06-30
 
 ### Added


### PR DESCRIPTION
Brings the v0.4.1 CHANGELOG.md entry to main (the release shipped without it). Docs-only; version is already 0.4.1 on both branches.