### PR TITLE
Fix FILES dead strip and polish section chrome

### DIFF
--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -239,7 +239,7 @@ final class AppModel {
                 try await environment.worktreeService.addWorktree(in: repo, at: url.path, branch: branch, createBranch: true)
                 await selector.selectRepo(repo)
             } catch {
-                errorMessage = "Couldn't create worktree: \(error)"
+                errorMessage = "Couldn't create worktree: \(WorktreeModel.describe(error))"
             }
         }
     }

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -13,6 +13,10 @@ final class SelectorModel {
         var behind: Int = 0
         var changeCount: Int = 0
         var isLive: Bool = false
+
+        /// Whether there is anything to pull or push — rows hide the "↓ ↑"
+        /// indicator entirely when both counts are zero.
+        var hasSync: Bool { ahead > 0 || behind > 0 }
     }
 
     private(set) var repositories: [Repository] = []
@@ -89,7 +93,7 @@ final class SelectorModel {
         } catch {
             worktrees = []
             branches = []
-            errorMessage = "\(error)"
+            errorMessage = WorktreeModel.describe(error)
         }
         await refreshWorktreeInfo()
         if let primary = worktrees.first(where: { $0.isPrimary }) ?? worktrees.first {
@@ -160,7 +164,7 @@ final class SelectorModel {
             errorMessage = nil
         } catch {
             // A transient failure shouldn't blank the list — keep what we have.
-            errorMessage = "\(error)"
+            errorMessage = WorktreeModel.describe(error)
             return
         }
         worktrees = discovered

--- a/Sources/Teebe/Views/ChangesSection.swift
+++ b/Sources/Teebe/Views/ChangesSection.swift
@@ -11,15 +11,9 @@ struct ChangesSection: View {
     var body: some View {
         VStack(spacing: 0) {
             SectionHeader(title: "CHANGES", isOpen: isOpen, isActive: app.activeSection == .changes, onToggle: { isOpen.toggle() }) {
-                HStack(spacing: 8) {
-                    countBadge(worktree.changeCount)
-                    if let active = app.selector.selectedWorktree {
-                        let info = app.selector.info(for: active)
-                        Text(info.syncText)
-                            .font(.system(size: 11)).monospacedDigit()
-                            .foregroundStyle(Palette.secondaryText)
-                    }
-                }
+                // Just the count: the ahead/behind indicator lives on the worktree
+                // rows — branch sync state isn't a property of the change list.
+                countBadge(worktree.changeCount)
             }
 
             if isOpen {
@@ -41,8 +35,8 @@ struct ChangesSection: View {
                         }
                     }
                 }
-                .padding(.top, 8)
-                .padding(.bottom, 6)
+                .padding(.top, Self.listTopPadding)
+                .padding(.bottom, Self.listBottomPadding)
                 .transition(.opacity)
             }
         }
@@ -53,13 +47,18 @@ struct ChangesSection: View {
     /// window grows for a worktree with many changes, so browsing between worktrees with
     /// very different change counts doesn't lurch the window. RootView's
     /// `changesContentHeight` mirrors this cap so the window math and the view agree.
-    static let maxListHeight: CGFloat = 144   // ~6 rows (24pt each), then scroll
+    static let maxListHeight: CGFloat = 144   // ~6 rows, then scroll
 
-    /// Natural height of the change list (rows are 24pt tall), capped at `maxListHeight`
-    /// so the section hugs its rows up to the cap and scrolls beyond it.
+    /// Row/padding metrics. RootView's `changesContentHeight` derives the window's
+    /// wrap height from these — keep every literal here so the two can't desync.
+    static let rowHeight: CGFloat = 24
+    static let listTopPadding: CGFloat = 8
+    static let listBottomPadding: CGFloat = 6
+
+    /// Natural height of the change list, capped at `maxListHeight` so the section
+    /// hugs its rows up to the cap and scrolls beyond it.
     private var listContentHeight: CGFloat {
-        let count = worktree.changeCount
-        let natural: CGFloat = count == 0 ? 24 : CGFloat(count) * 24
+        let natural = CGFloat(max(worktree.changeCount, 1)) * Self.rowHeight
         return min(natural, Self.maxListHeight)
     }
 
@@ -72,7 +71,7 @@ struct ChangesSection: View {
                 Text("No changes")
                     .font(.system(size: 12)).foregroundStyle(Palette.secondaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 25).padding(.vertical, 4)
+                    .padding(.horizontal, 30).padding(.vertical, 4)
             }
         }
     }
@@ -80,7 +79,7 @@ struct ChangesSection: View {
     private func changeRow(_ change: FileChange, indented: Bool) -> some View {
         let selected = isSelected(change)
         return HStack(spacing: 7) {
-            Image(systemName: "doc")
+            Image(systemName: change.iconName)
                 .font(.system(size: 11))
                 .foregroundStyle(selected ? .white : Palette.secondaryText)
             Text((change.path as NSString).lastPathComponent)
@@ -88,7 +87,8 @@ struct ChangesSection: View {
             Spacer(minLength: 4)
             StatusLetter(change: change)
         }
-        .padding(.leading, indented ? 41 : 25).padding(.trailing, 11).frame(height: 24)
+        // Leading 30 lines the icon up with the FILES rows' icon column below.
+        .padding(.leading, indented ? 46 : 30).padding(.trailing, 11).frame(height: Self.rowHeight)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(selected ? Palette.accent : .clear)
         .foregroundStyle(selected ? .white : .primary)

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -235,7 +235,9 @@ struct SectionHeader<Trailing: View>: View {
             Spacer(minLength: 6)
             trailing()
         }
-        .padding(.horizontal, 9)
+        // 11pt matches the list rows' trailing inset so header controls and row
+        // content share one right edge.
+        .padding(.horizontal, 11)
         .frame(height: 32)
         .contentShape(Rectangle())
         // The layout/window resize is animated by RootView.setOpen (it eases on

--- a/Sources/Teebe/Views/FilesSection.swift
+++ b/Sources/Teebe/Views/FilesSection.swift
@@ -10,8 +10,8 @@ struct FilesSection: View {
     @Binding var isOpen: Bool
     /// Owned by RootView; lets ⌘F focus the search field and ↓/Esc hand focus back.
     var searchFocused: FocusState<Bool>.Binding
-    /// The reveal area the tree fills below its search box. Fixed (not flexible) while
-    /// browsing so a CHANGES reflow can't momentarily balloon FILES.
+    /// The reveal area below the section header (search box + tree). Fixed (not
+    /// flexible) while browsing so a CHANGES reflow can't momentarily balloon FILES.
     var revealHeight: CGFloat
     /// While the window edge is being dragged, FILES becomes the flexible filler so the
     /// drag resizes it; otherwise it's pinned to `revealHeight`.
@@ -32,7 +32,8 @@ struct FilesSection: View {
                         }
                         Toggle("Show ignored", isOn: $worktree.showIgnored)
                     } label: {
-                        Text("···").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).hoverChip()
+                        Image(systemName: "ellipsis").font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Palette.secondaryText).hoverChip()
                     }
                     .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
                     .help("Sort & filter")
@@ -91,13 +92,19 @@ struct FilesSection: View {
                         }
                     }
                 }
+                // Idle → a fixed reveal pane (the tree scrolls inside it), so a CHANGES
+                // reflow can't make FILES balloon for a frame. Dragging → the flexible
+                // filler, so the window edge resizes the reveal. The frame sits on the
+                // search+tree content, NOT the whole section: `revealHeight` is the area
+                // *below* the header (RootView budgets the header separately in
+                // `collapsedHeight`), so pinning the outer VStack — header included —
+                // rendered the section one header-height short and left a dead strip of
+                // empty material at the window's bottom edge.
+                .frame(height: liveResizing ? nil : revealHeight)
+                .frame(maxHeight: liveResizing ? .infinity : nil)
                 .transition(.opacity)
             }
         }
-        // Open + idle → a fixed reveal pane (the tree scrolls inside it), so a CHANGES
-        // height change can't make FILES balloon for a frame. Open + dragging → the
-        // flexible filler, so the window edge resizes the reveal. Closed → just the header.
-        .frame(height: isOpen && !liveResizing ? revealHeight : nil)
         .frame(maxHeight: isOpen && liveResizing ? .infinity : nil)
         .clipped()
     }
@@ -115,7 +122,7 @@ struct FileRowsView: View {
             Text(app.repositories.isEmpty ? "Add a repository to get started" : "No files")
                 .font(.system(size: 12)).foregroundStyle(Palette.secondaryText)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 25).padding(.vertical, 6)
+                .padding(.horizontal, 30).padding(.vertical, 6)
         } else {
             LazyVStack(spacing: 0) {
                 ForEach(worktree.visibleRows) { row in

--- a/Sources/Teebe/Views/RootView.swift
+++ b/Sources/Teebe/Views/RootView.swift
@@ -272,22 +272,23 @@ struct RootView: View {
     }
 
     /// Height of the open worktree list (mirrors WorktreesSection, including its cap);
-    /// 0 when closed.
+    /// 0 when closed. Built from the section's own metrics so the two can't desync.
     private var worktreesContentHeight: CGFloat {
         guard openWorktrees else { return 0 }
         let s = app.selector
-        let repoRow: CGFloat = s.selectedRepo != nil ? 25 : 0
-        let rows: CGFloat = s.worktrees.isEmpty ? 26 : CGFloat(s.worktrees.count) * 26
-        return min(8 + repoRow + rows, WorktreesSection.maxListHeight)
+        let repoRow: CGFloat = s.selectedRepo != nil ? WorktreesSection.repoRowHeight : 0
+        let rows = CGFloat(max(s.worktrees.count, 1)) * WorktreesSection.rowHeight
+        return min(WorktreesSection.listVerticalPadding * 2 + repoRow + rows,
+                   WorktreesSection.maxListHeight)
     }
 
     /// Height of the open change list (mirrors ChangesSection, including its cap); 0
-    /// when closed. The +14 is the section's top/bottom padding around the list.
+    /// when closed. Built from the section's own metrics so the two can't desync.
     private var changesContentHeight: CGFloat {
         guard openChanges else { return 0 }
-        let count = app.selector.worktree.changeCount
-        let natural: CGFloat = count == 0 ? 24 : CGFloat(count) * 24
-        return 14 + min(natural, ChangesSection.maxListHeight)
+        let natural = CGFloat(max(app.selector.worktree.changeCount, 1)) * ChangesSection.rowHeight
+        return ChangesSection.listTopPadding + ChangesSection.listBottomPadding
+            + min(natural, ChangesSection.maxListHeight)
     }
 
     /// Size the window to the current state, anchored at the top so it grows and

--- a/Sources/Teebe/Views/StatusBadge.swift
+++ b/Sources/Teebe/Views/StatusBadge.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 import TeebeCore
 
-extension FileNode {
-    /// SF Symbol name for the file-row icon.
-    var iconName: String {
-        if isDirectory { return "folder" }
+/// SF Symbol for a file, by extension — shared by the FILES tree and the CHANGES
+/// rows so the same file gets the same icon in both lists.
+enum FileIcon {
+    static func symbol(forFileNamed name: String) -> String {
         switch (name as NSString).pathExtension.lowercased() {
         case "swift": return "swift"
         case "md", "markdown", "txt": return "doc.text"
@@ -12,5 +12,19 @@ extension FileNode {
         case "png", "jpg", "jpeg", "gif", "pdf": return "photo"
         default: return "doc"
         }
+    }
+}
+
+extension FileNode {
+    /// SF Symbol name for the file-row icon.
+    var iconName: String {
+        isDirectory ? "folder" : FileIcon.symbol(forFileNamed: name)
+    }
+}
+
+extension FileChange {
+    /// SF Symbol name for the change-row icon.
+    var iconName: String {
+        FileIcon.symbol(forFileNamed: (path as NSString).lastPathComponent)
     }
 }

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -30,12 +30,13 @@ struct WorktreesSection: View {
                                 Button("Remove \(selected.name)", role: .destructive) { app.removeRepository(selected) }
                             }
                         } label: {
-                            Text("···").font(.system(size: 13)).foregroundStyle(Palette.secondaryText).hoverChip()
+                            Image(systemName: "ellipsis").font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(Palette.secondaryText).hoverChip()
                         }
                         .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
                         .help("Repository actions")
                         Button { Task { await selector.refreshWorktrees() } } label: {
-                            Image(systemName: "arrow.clockwise").font(.system(size: 11))
+                            Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .semibold))
                         }
                         .buttonStyle(IconButtonStyle()).foregroundStyle(Palette.secondaryText)
                         .help("Refresh worktrees")
@@ -43,8 +44,10 @@ struct WorktreesSection: View {
                 } else if let active = selector.selectedWorktree {
                     HStack(spacing: 5) {
                         LiveDot(active: selector.info(for: active).isLive)
+                        // Same treatment as the collapsed FILES header's branch label;
+                        // the accent colour (+ dot) marks this one as the active worktree.
                         Text(active.branch ?? active.name)
-                            .font(.system(size: 12.5, weight: .semibold))
+                            .font(.system(size: 11, design: .monospaced))
                             .foregroundStyle(Palette.accent)
                             .lineLimit(1)
                             .truncationMode(.middle)
@@ -79,12 +82,18 @@ struct WorktreesSection: View {
     /// RootView's `worktreesContentHeight` mirrors this cap.
     static let maxListHeight: CGFloat = 200
 
+    /// Row/padding metrics. RootView's `worktreesContentHeight` derives the window's
+    /// wrap height from these — keep every literal here so the two can't desync.
+    static let rowHeight: CGFloat = 26
+    static let repoRowHeight: CGFloat = 25
+    static let listVerticalPadding: CGFloat = 4
+
     /// Natural height of the worktree list, capped at `maxListHeight` so the section
     /// hugs its rows up to the cap and scrolls beyond it.
     private var listContentHeight: CGFloat {
-        let repoRow: CGFloat = selector.selectedRepo != nil ? 25 : 0
-        let rows: CGFloat = selector.worktrees.isEmpty ? 26 : CGFloat(selector.worktrees.count) * 26
-        return min(8 + repoRow + rows, Self.maxListHeight)   // 8 = worktreeListBody vertical padding
+        let repoRow: CGFloat = selector.selectedRepo != nil ? Self.repoRowHeight : 0
+        let rows = CGFloat(max(selector.worktrees.count, 1)) * Self.rowHeight
+        return min(Self.listVerticalPadding * 2 + repoRow + rows, Self.maxListHeight)
     }
 
     private var worktreeListBody: some View {
@@ -102,7 +111,7 @@ struct WorktreesSection: View {
                     .padding(.horizontal, 25).padding(.vertical, 5)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Self.listVerticalPadding)
     }
 
     private func repoSubheader(_ repo: Repository) -> some View {
@@ -116,7 +125,7 @@ struct WorktreesSection: View {
             // The sync indicator belongs on individual worktree rows, not the repo
             // root — the root isn't itself a branch with an ahead/behind count.
         }
-        .padding(.horizontal, 11).frame(height: 25)
+        .padding(.horizontal, 11).frame(height: Self.repoRowHeight)
     }
 
     private func worktreeRow(_ worktree: Worktree) -> some View {
@@ -134,12 +143,16 @@ struct WorktreesSection: View {
                 .font(.system(size: 13, weight: .medium))
                 .lineLimit(1)
             Spacer(minLength: 4)
-            Text(info.syncText)
-                .font(.system(size: 11))
-                .monospacedDigit()
-                .foregroundStyle(isActive ? .white.opacity(0.85) : Palette.secondaryText)
+            // "↓0 ↑0" is pure noise — only show the sync arrows once there is
+            // something to pull or push.
+            if info.hasSync {
+                Text(info.syncText)
+                    .font(.system(size: 11))
+                    .monospacedDigit()
+                    .foregroundStyle(isActive ? .white.opacity(0.85) : Palette.secondaryText)
+            }
         }
-        .padding(.leading, 25).padding(.trailing, 11).frame(height: 26)
+        .padding(.leading, 25).padding(.trailing, 11).frame(height: Self.rowHeight)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isActive ? Palette.accent : .clear)
         .foregroundStyle(isActive ? .white : .primary)

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -117,6 +117,24 @@ struct SelectorModelTests {
         #expect(selector.worktree.worktreePath == "/repo")
     }
 
+    @Test("hasSync only when there is something to pull or push")
+    func worktreeInfoHasSync() {
+        #expect(SelectorModel.WorktreeInfo().hasSync == false)
+        #expect(SelectorModel.WorktreeInfo(ahead: 1).hasSync == true)
+        #expect(SelectorModel.WorktreeInfo(behind: 2).hasSync == true)
+        #expect(SelectorModel.WorktreeInfo(ahead: 1, behind: 2).hasSync == true)
+    }
+
+    @Test("a failed repo selection surfaces a human-readable error, not a raw Swift error")
+    func selectRepoErrorIsHumanReadable() async {
+        let git = FakeGitClient()
+        git.worktreesError = .notAGitRepository(path: "/x")
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git))
+
+        await selector.selectRepo(Repository(path: "/x"))
+        #expect(selector.errorMessage == "Not a git repository: /x")
+    }
+
     @Test("WORKTREES keyboard cursor moves and clamps; Enter commits the switch")
     func worktreeHighlightNav() async {
         let git = FakeGitClient()


### PR DESCRIPTION
Fixes every finding from the UI stability audit:

**Layout bug (the one real defect):** the FILES pane's fixed frame included its own section header while RootView's window budget also counted that header, so an open FILES section always rendered ~32pt short — a constant dead strip of empty material at the window's bottom edge, plus a matching upward content snap when a window-edge drag ended. The reveal frame now pins the search+tree content only.

**Drift-proofing:** RootView's wrap-height math now reads row/padding metrics owned by the sections (`rowHeight`, `repoRowHeight`, list paddings) instead of duplicating them as magic numbers.

**Polish:**
- CHANGES rows share the FILES tree's per-type file icons (same file, same icon)
- "↓0 ↑0" hidden when there's nothing to pull/push; removed from the CHANGES header (worktree rows own it)
- "···" text menu labels → `ellipsis` SF Symbol; header glyphs unified at 11pt semibold
- Section-header insets aligned with row insets (11pt); CHANGES rows aligned with the FILES icon column
- Collapsed-header branch labels share one typography
- Git failures surface human-readable messages (`WorktreeModel.describe`) instead of raw Swift errors

**Verification:** instrumented self-drive harness across all 8 section states — every settled frame equals its computed target, x/width constant throughout (no horizontal or vertical wiggle), rapid toggling settles exactly; screenshots confirm the dead strip is gone and the tree runs flush to the window edge. 163/163 tests pass; no new SwiftLint warnings (2 tests added for `hasSync` and error humanization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gf2sGyFVSieHtjiT8iYK3