### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.4.2] - 2026-07-16
+
+### Fixed
+- The FILES section no longer leaves an empty strip at the bottom of the window,
+  and the file tree no longer snaps upward when a window resize ends.
+- Git failures now show a short human-readable message instead of a raw
+  technical error dump.
+
+### Changed
+- CHANGES rows now use the same per-type file icons as the FILES tree.
+- The "↓0 ↑0" sync indicator is hidden when there is nothing to pull or push,
+  and no longer appears in the CHANGES header.
+- Tidier section headers: unified icon sizes, typography and alignment across
+  sections.
+
 ## [0.4.1] - 2026-07-01
 
 ### Fixed

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.4.1}"
+APP_VERSION="${APP_VERSION:-0.4.2}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with


### PR DESCRIPTION
Version bump + changelog entry for the v0.4.2 patch release (FILES dead-strip fix and section chrome polish, #64).