### PR TITLE
Explain folder access in TCC prompts and privacy notice

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,6 +34,24 @@ identity and is not sold or shared.
 - We do **not** use cookies or ad trackers.
 - We have no accounts, so there is no personal profile to collect.
 
+## What the app reads on your Mac (and why)
+
+Everything below stays on your Mac. None of it is collected, stored by us, or
+transmitted anywhere.
+
+- **Your repository folders.** teebe reads the folder you add (and its git
+  worktrees) to show worktrees, changes, and files. macOS may ask you to allow
+  access if a repository lives in Documents, Desktop, or Downloads; if you
+  decline, teebe simply can't display repositories in that folder — nothing
+  else breaks, and you can change your mind in System Settings → Privacy &
+  Security → Files & Folders.
+- **Claude Code session logs** (`~/.claude/projects`). To show the per-worktree
+  agent badge ("working" / "needs you"), teebe reads the tail of the newest
+  session log for each worktree and reduces it to that single status. The
+  content of your agent conversations is never stored, indexed, displayed, or
+  sent anywhere — it is parsed in memory, only to tell whether the agent is
+  mid-turn or waiting for you.
+
 ## Updates
 
 teebe checks for new versions via [Sparkle](https://sparkle-project.org/), which

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -94,6 +94,9 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>NSHumanReadableCopyright</key><string>© 2026 Klein Tahiraj. Licensed under GPL-3.0-or-later (see LICENSE) or a commercial license. Bundles Sparkle and other components — see THIRD-PARTY-LICENSES.</string>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSPrincipalClass</key><string>NSApplication</string>
+  <key>NSDocumentsFolderUsageDescription</key><string>teebe only reads the folder your repository lives in, to show its worktrees, changes, and files. Nothing is uploaded or modified without your action.</string>
+  <key>NSDesktopFolderUsageDescription</key><string>teebe only reads the folder your repository lives in, to show its worktrees, changes, and files. Nothing is uploaded or modified without your action.</string>
+  <key>NSDownloadsFolderUsageDescription</key><string>teebe only reads the folder your repository lives in, to show its worktrees, changes, and files. Nothing is uploaded or modified without your action.</string>
   <key>NSHighResolutionCapable</key><true/>
   <key>SUFeedURL</key><string>${SU_FEED_URL}</string>
   <key>SUPublicEDKey</key><string>${SU_PUBLIC_ED_KEY}</string>


### PR DESCRIPTION
Add NSDocuments/Desktop/DownloadsFolderUsageDescription purpose strings
so the macOS folder-access dialog says why teebe wants the folder, and
document in PRIVACY.md exactly what the app reads locally (repository
folders and the tail of Claude Code session logs for the agent badge)
and that declining folder access degrades gracefully.
