### PR TITLE
Strip em dashes from public docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ All notable changes to teebe are documented here. The format is based on
 ## [0.3.0] - 2026-06-24
 
 ### Changed
-- Window resizing reworked into a coherent content-wrap model — no more
+- Window resizing reworked into a coherent content-wrap model: no more
   bounce / jump / gap on resize.
 
 ### Added
@@ -80,7 +80,7 @@ All notable changes to teebe are documented here. The format is based on
 
 ### Changed
 - The CHANGES section now hugs its rows like WORKTREES instead of taking the
-  flexible vertical space — FILES is the sole space-filling section, and the
+  flexible vertical space; FILES is the sole space-filling section, and the
   window resizes as the change count changes.
 
 ## [0.2.0] - 2026-06-23

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement (CLA)
 
-Teebe is dual-licensed (GPL-3.0-or-later **and** a commercial license — see
+Teebe is dual-licensed (GPL-3.0-or-later **and** a commercial license; see
 [`LICENSING.md`](LICENSING.md)). To keep offering it under both, the project must
 hold the rights to license every contribution under both. This CLA secures that.
 
@@ -9,8 +9,8 @@ project, you agree to the terms below. The "Project Owner" is Klein Tahiraj.
 
 ## 1. Definitions
 
-"Contribution" means any original work of authorship — code, documentation, or
-other material — that you intentionally submit to this project for inclusion.
+"Contribution" means any original work of authorship (code, documentation, or
+other material) that you intentionally submit to this project for inclusion.
 
 ## 2. Copyright license
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ in **git worktrees**. In short:
    git switch dev && git pull
    git worktree add ../teebe-<name> -b feat/<name> dev
    ```
-2. Keep changes focused. This codebase is test-first — add or update tests for
+2. Keep changes focused. This codebase is test-first: add or update tests for
    any behavior change in `TeebeCore` or the view models.
 3. Run `swift test` and `swiftlint lint` locally before pushing.
 4. Open a pull request into **`dev`** (never directly into `main`). CI (build,
@@ -62,10 +62,10 @@ licenses.
 
 teebe self-updates via [Sparkle](https://sparkle-project.org). Updates are
 delivered through an **appcast** (`appcast.xml`). The app's `SUFeedURL` points at
-**`https://teebe.io/appcast.xml`** — hosted on our own domain (the `teebe-site`
+**`https://teebe.io/appcast.xml`**, hosted on our own domain (the `teebe-site`
 GitHub Pages repo) so the feed URL baked into shipped binaries is
 host-independent. The appcast's `.app` zip enclosures still live on GitHub
-Releases. Each update is integrity-signed with an **EdDSA key** — this is
+Releases. Each update is integrity-signed with an **EdDSA key**; this is
 Sparkle's own signature and is independent of Apple notarization (which governs
 first-launch Gatekeeper trust, not updates).
 
@@ -82,13 +82,13 @@ stores the private key in the login Keychain):
 
 Then add these to the GitHub repo (Settings → Secrets and variables → Actions):
 
-- `SPARKLE_PUBLIC_ED_KEY` — the public key string (embedded in `Info.plist` at
+- `SPARKLE_PUBLIC_ED_KEY`: the public key string (embedded in `Info.plist` at
   build time via `SU_PUBLIC_ED_KEY`).
-- `SPARKLE_ED_PRIVATE_KEY` — the contents of `sparkle_private.key` (used by CI
+- `SPARKLE_ED_PRIVATE_KEY`: the contents of `sparkle_private.key` (used by CI
   to sign the appcast). Treat it like any signing secret; do not commit it.
 
 Delete `sparkle_private.key` after adding the secret. The private key is the
-root of update trust — if it leaks, rotate it (new keypair, new public key in
+root of update trust; if it leaks, rotate it (new keypair, new public key in
 the next release).
 
 ### What happens on release
@@ -106,7 +106,7 @@ the previous release, so existing apps see nothing new. Once published, existing
 users get an in-app "Update available" prompt; the menu also has **Check for
 Updates…**.
 
-> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_KEY`** — the
+> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_KEY`**: the
 > private half of an SSH **deploy key** whose public half is installed on
 > `klein-t/teebe-site` with write access. A deploy key is scoped to that single
 > repo and isn't tied to a personal account, so a leak can only push to

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -5,13 +5,13 @@ Copyright (c) 2026 Klein Tahiraj. All rights reserved.
 Teebe is **dual-licensed**. You may use it under **either** of the following,
 at your choice:
 
-## 1. Open-source license — GPL-3.0-or-later (default)
+## 1. Open-source license: GPL-3.0-or-later (default)
 
 Teebe is free and open source under the **GNU General Public License, version 3
 or (at your option) any later version**. The full text is in [`LICENSE`](LICENSE).
 
-In plain terms, the GPL lets anyone use, study, modify, and redistribute Teebe —
-including for a fee — **provided that** any distributed work based on Teebe is
+In plain terms, the GPL lets anyone use, study, modify, and redistribute Teebe,
+including for a fee, **provided that** any distributed work based on Teebe is
 also released under the GPL with complete corresponding source code, and without
 additional restrictions.
 
@@ -19,7 +19,7 @@ This means you **cannot** take Teebe's source, build a closed-source or
 proprietary product on top of it, and distribute that product. Any derivative
 you ship must itself be GPL and open source.
 
-> Note: simply *running* Teebe inside an organization — even commercially —
+> Note: simply *running* Teebe inside an organization, even commercially,
 > imposes no obligations. The GPL's copyleft only applies when you **distribute**
 > Teebe or a derivative work.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -20,7 +20,7 @@ records one anonymous, aggregate event:
 When you open a page on `teebe.io`, a small script records one anonymous,
 aggregate page-view event: the **page** you viewed, the **referring site** (if
 any), and your **country**. To tell a fresh visit from a page-to-page click we
-keep a single per-tab flag in your browser's `sessionStorage` — it holds no
+keep a single per-tab flag in your browser's `sessionStorage`; it holds no
 identifier and is gone when you close the tab.
 
 We use all of this only to gauge interest and adoption. It is not tied to your
@@ -29,7 +29,7 @@ identity and is not sold or shared.
 ## What we don't collect
 
 - We do **not** store your IP address.
-- We do **not** track anything you do inside the app — teebe contains no in-app
+- We do **not** track anything you do inside the app; teebe contains no in-app
   analytics or telemetry.
 - We do **not** use cookies or ad trackers.
 - We have no accounts, so there is no personal profile to collect.


### PR DESCRIPTION
Punctuation-only pass: replace every em dash in the public-facing markdown (PRIVACY, CHANGELOG, CLA, LICENSING, CONTRIBUTING) with commas, colons, semicolons, or parentheses. Keeps PRIVACY.md and CHANGELOG.md in sync with the same cleanup already deployed on teebe.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zEPqwMC3hNRNhrwQSrF8s