### PR TITLE
Expire stale live dots so the pulse animation stops (fixes #71)

### DIFF
--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -55,6 +55,10 @@ final class SelectorModel {
     /// Periodic re-derive so purely time-based transitions (stall, idle-out)
     /// happen even when no session log is being written.
     private var agentPollTask: Task<Void, Never>?
+    /// One-shot follow-up scheduled while any live dot is lit, so `isLive` expires
+    /// shortly after the busy window lapses instead of latching until the next
+    /// event (a latched dot keeps a repeat-forever pulse animation burning CPU).
+    private var liveExpiryTask: Task<Void, Never>?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -67,10 +71,27 @@ final class SelectorModel {
     /// Recompute only the cheap `isLive` flags from the activity monitor (no git),
     /// e.g. after a file-watch event reports external activity.
     func refreshLiveState(now: Date = Date()) {
+        var anyLive = false
         for wt in worktrees {
             var info = worktreeInfo[wt.path] ?? WorktreeInfo()
             info.isLive = environment.activityMonitor.isBusy(worktreePath: wt.path, within: 5, now: now)
+            anyLive = anyLive || info.isLive
             worktreeInfo[wt.path] = info
+        }
+        scheduleLiveExpiry(anyLive: anyLive)
+    }
+
+    /// While any dot is lit, keep a single pending re-check just past the busy
+    /// window; each activity event pushes it back, so the last write is followed
+    /// by exactly one expiry pass that turns the dot (and its animation) off.
+    private func scheduleLiveExpiry(anyLive: Bool) {
+        liveExpiryTask?.cancel()
+        liveExpiryTask = nil
+        guard anyLive else { return }
+        liveExpiryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(5.5))
+            guard !Task.isCancelled else { return }
+            self?.refreshLiveState()
         }
     }
 
@@ -255,6 +276,7 @@ final class SelectorModel {
         for worktree in worktrees {
             var entry = info[worktree.path] ?? WorktreeInfo()
             entry.agentState = states[worktree.path] ?? .idle
+            entry.isLive = environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
             info[worktree.path] = entry
         }
         notifyAgentTransitions(from: worktreeInfo, to: info)

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -184,6 +184,26 @@ struct SelectorModelTests {
         #expect(selector.info(for: git.worktreesResult[1]).isLive == false)
     }
 
+    @Test("agent poll expires a stale live dot once the busy window lapses")
+    func liveDotExpiresViaAgentPoll() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let monitor = WorktreeActivityMonitor()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, monitor: monitor))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        let t = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/repo", at: t)
+        selector.refreshLiveState(now: t.addingTimeInterval(1))
+        #expect(selector.info(for: git.worktreesResult[0]).isLive == true)
+
+        // No further file events: the periodic agent poll is the only thing that
+        // runs, and it must also let the live flag expire — otherwise the dot
+        // (and its repeat-forever pulse animation) runs until the next rescan.
+        await selector.refreshAgentStates(now: t.addingTimeInterval(30))
+        #expect(selector.info(for: git.worktreesResult[0]).isLive == false)
+    }
+
     @Test("refreshWorktreeInfo computes live state alongside sync counts")
     func liveDotViaRefreshInfo() async {
         let git = FakeGitClient()


### PR DESCRIPTION
## Problem
Once a worktree saw a single write, its green live dot latched on: `isLive` was only recomputed on file-watch events, and the 30s agent poll preserved the stale flag. The dot's repeat-forever pulse animation then kept SwiftUI's display link running indefinitely, a steady ~11% idle CPU draw, and the live indicator itself showed activity that wasn't happening.

## Fix
- `refreshAgentStates` (30s poll + agent-watch events) now re-derives `isLive` from the activity monitor instead of copying the stale value.
- `refreshLiveState` schedules a single one-shot re-check just past the 5s busy window, pushed back on each new activity event, so the dot goes out promptly after the last write instead of waiting for the next poll.

## Tests
New test `liveDotExpiresViaAgentPoll` (fails on `dev`, passes here). Full suite: 192 tests green. SwiftLint: no new violations.

Fixes #71