### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-07-28
+
+### Added
+- **Agent status per worktree.** Each worktree now shows what its AI agent is
+  doing, "working" while a session is mid-turn and "needs you" once the turn
+  ends or stalls, with a notification when an agent finishes and is waiting on
+  you.
+
+### Fixed
+- The green live-activity dot no longer stays lit forever after a single file
+  change. It now goes out a few seconds after the last write, which also stops
+  a pulse animation that kept running in the background and used CPU while the
+  app was idle.
+
+### Changed
+- The macOS folder-access prompt now explains why teebe needs access to your
+  repositories, and the privacy notice spells out that everything stays on
+  your Mac.
+
 ## [0.4.2] - 2026-07-16
 
 ### Fixed

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.4.2}"
+APP_VERSION="${APP_VERSION:-0.5.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with


### PR DESCRIPTION
Version bump + CHANGELOG entry ahead of the v0.5.0 release.

Highlights since v0.4.2: per-worktree agent status (#67), the live-dot expiry fix that also cures the idle CPU burn (#71/#72), and the TCC/privacy copy improvements.