### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-07-28
+
+### Added
+- **Agent status per worktree.** Each worktree now shows what its AI agent is
+  doing, "working" while a session is mid-turn and "needs you" once the turn
+  ends or stalls, with a notification when an agent finishes and is waiting on
+  you.
+
+### Fixed
+- The green live-activity dot no longer stays lit forever after a single file
+  change. It now goes out a few seconds after the last write, which also stops
+  a pulse animation that kept running in the background and used CPU while the
+  app was idle.
+
+### Changed
+- The macOS folder-access prompt now explains why teebe needs access to your
+  repositories, and the privacy notice spells out that everything stays on
+  your Mac.
+
 ## [0.4.2] - 2026-07-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ All notable changes to teebe are documented here. The format is based on
 ## [0.3.0] - 2026-06-24
 
 ### Changed
-- Window resizing reworked into a coherent content-wrap model — no more
+- Window resizing reworked into a coherent content-wrap model: no more
   bounce / jump / gap on resize.
 
 ### Added
@@ -80,7 +80,7 @@ All notable changes to teebe are documented here. The format is based on
 
 ### Changed
 - The CHANGES section now hugs its rows like WORKTREES instead of taking the
-  flexible vertical space — FILES is the sole space-filling section, and the
+  flexible vertical space; FILES is the sole space-filling section, and the
   window resizes as the change count changes.
 
 ## [0.2.0] - 2026-06-23

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement (CLA)
 
-Teebe is dual-licensed (GPL-3.0-or-later **and** a commercial license — see
+Teebe is dual-licensed (GPL-3.0-or-later **and** a commercial license; see
 [`LICENSING.md`](LICENSING.md)). To keep offering it under both, the project must
 hold the rights to license every contribution under both. This CLA secures that.
 
@@ -9,8 +9,8 @@ project, you agree to the terms below. The "Project Owner" is Klein Tahiraj.
 
 ## 1. Definitions
 
-"Contribution" means any original work of authorship — code, documentation, or
-other material — that you intentionally submit to this project for inclusion.
+"Contribution" means any original work of authorship (code, documentation, or
+other material) that you intentionally submit to this project for inclusion.
 
 ## 2. Copyright license
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ in **git worktrees**. In short:
    git switch dev && git pull
    git worktree add ../teebe-<name> -b feat/<name> dev
    ```
-2. Keep changes focused. This codebase is test-first — add or update tests for
+2. Keep changes focused. This codebase is test-first: add or update tests for
    any behavior change in `TeebeCore` or the view models.
 3. Run `swift test` and `swiftlint lint` locally before pushing.
 4. Open a pull request into **`dev`** (never directly into `main`). CI (build,
@@ -62,10 +62,10 @@ licenses.
 
 teebe self-updates via [Sparkle](https://sparkle-project.org). Updates are
 delivered through an **appcast** (`appcast.xml`). The app's `SUFeedURL` points at
-**`https://teebe.io/appcast.xml`** — hosted on our own domain (the `teebe-site`
+**`https://teebe.io/appcast.xml`**, hosted on our own domain (the `teebe-site`
 GitHub Pages repo) so the feed URL baked into shipped binaries is
 host-independent. The appcast's `.app` zip enclosures still live on GitHub
-Releases. Each update is integrity-signed with an **EdDSA key** — this is
+Releases. Each update is integrity-signed with an **EdDSA key**; this is
 Sparkle's own signature and is independent of Apple notarization (which governs
 first-launch Gatekeeper trust, not updates).
 
@@ -82,13 +82,13 @@ stores the private key in the login Keychain):
 
 Then add these to the GitHub repo (Settings → Secrets and variables → Actions):
 
-- `SPARKLE_PUBLIC_ED_KEY` — the public key string (embedded in `Info.plist` at
+- `SPARKLE_PUBLIC_ED_KEY`: the public key string (embedded in `Info.plist` at
   build time via `SU_PUBLIC_ED_KEY`).
-- `SPARKLE_ED_PRIVATE_KEY` — the contents of `sparkle_private.key` (used by CI
+- `SPARKLE_ED_PRIVATE_KEY`: the contents of `sparkle_private.key` (used by CI
   to sign the appcast). Treat it like any signing secret; do not commit it.
 
 Delete `sparkle_private.key` after adding the secret. The private key is the
-root of update trust — if it leaks, rotate it (new keypair, new public key in
+root of update trust; if it leaks, rotate it (new keypair, new public key in
 the next release).
 
 ### What happens on release
@@ -106,7 +106,7 @@ the previous release, so existing apps see nothing new. Once published, existing
 users get an in-app "Update available" prompt; the menu also has **Check for
 Updates…**.
 
-> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_KEY`** — the
+> The `publish-appcast` workflow needs a repo secret **`SITE_DEPLOY_KEY`**: the
 > private half of an SSH **deploy key** whose public half is installed on
 > `klein-t/teebe-site` with write access. A deploy key is scoped to that single
 > repo and isn't tied to a personal account, so a leak can only push to

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -5,13 +5,13 @@ Copyright (c) 2026 Klein Tahiraj. All rights reserved.
 Teebe is **dual-licensed**. You may use it under **either** of the following,
 at your choice:
 
-## 1. Open-source license — GPL-3.0-or-later (default)
+## 1. Open-source license: GPL-3.0-or-later (default)
 
 Teebe is free and open source under the **GNU General Public License, version 3
 or (at your option) any later version**. The full text is in [`LICENSE`](LICENSE).
 
-In plain terms, the GPL lets anyone use, study, modify, and redistribute Teebe —
-including for a fee — **provided that** any distributed work based on Teebe is
+In plain terms, the GPL lets anyone use, study, modify, and redistribute Teebe,
+including for a fee, **provided that** any distributed work based on Teebe is
 also released under the GPL with complete corresponding source code, and without
 additional restrictions.
 
@@ -19,7 +19,7 @@ This means you **cannot** take Teebe's source, build a closed-source or
 proprietary product on top of it, and distribute that product. Any derivative
 you ship must itself be GPL and open source.
 
-> Note: simply *running* Teebe inside an organization — even commercially —
+> Note: simply *running* Teebe inside an organization, even commercially,
 > imposes no obligations. The GPL's copyleft only applies when you **distribute**
 > Teebe or a derivative work.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -42,14 +42,14 @@ transmitted anywhere.
 - **Your repository folders.** teebe reads the folder you add (and its git
   worktrees) to show worktrees, changes, and files. macOS may ask you to allow
   access if a repository lives in Documents, Desktop, or Downloads; if you
-  decline, teebe simply can't display repositories in that folder — nothing
-  else breaks, and you can change your mind in System Settings → Privacy &
-  Security → Files & Folders.
+  decline, teebe simply can't display repositories in that folder. Nothing
+  else breaks, and you can change your mind any time in System Settings →
+  Privacy & Security → Files & Folders.
 - **Claude Code session logs** (`~/.claude/projects`). To show the per-worktree
   agent badge ("working" / "needs you"), teebe reads the tail of the newest
   session log for each worktree and reduces it to that single status. The
   content of your agent conversations is never stored, indexed, displayed, or
-  sent anywhere — it is parsed in memory, only to tell whether the agent is
+  sent anywhere: it is parsed in memory, only to tell whether the agent is
   mid-turn or waiting for you.
 
 ## Updates

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -20,7 +20,7 @@ records one anonymous, aggregate event:
 When you open a page on `teebe.io`, a small script records one anonymous,
 aggregate page-view event: the **page** you viewed, the **referring site** (if
 any), and your **country**. To tell a fresh visit from a page-to-page click we
-keep a single per-tab flag in your browser's `sessionStorage` — it holds no
+keep a single per-tab flag in your browser's `sessionStorage`; it holds no
 identifier and is gone when you close the tab.
 
 We use all of this only to gauge interest and adoption. It is not tied to your
@@ -29,7 +29,7 @@ identity and is not sold or shared.
 ## What we don't collect
 
 - We do **not** store your IP address.
-- We do **not** track anything you do inside the app — teebe contains no in-app
+- We do **not** track anything you do inside the app; teebe contains no in-app
   analytics or telemetry.
 - We do **not** use cookies or ad trackers.
 - We have no accounts, so there is no personal profile to collect.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,6 +34,24 @@ identity and is not sold or shared.
 - We do **not** use cookies or ad trackers.
 - We have no accounts, so there is no personal profile to collect.
 
+## What the app reads on your Mac (and why)
+
+Everything below stays on your Mac. None of it is collected, stored by us, or
+transmitted anywhere.
+
+- **Your repository folders.** teebe reads the folder you add (and its git
+  worktrees) to show worktrees, changes, and files. macOS may ask you to allow
+  access if a repository lives in Documents, Desktop, or Downloads; if you
+  decline, teebe simply can't display repositories in that folder — nothing
+  else breaks, and you can change your mind in System Settings → Privacy &
+  Security → Files & Folders.
+- **Claude Code session logs** (`~/.claude/projects`). To show the per-worktree
+  agent badge ("working" / "needs you"), teebe reads the tail of the newest
+  session log for each worktree and reduces it to that single status. The
+  content of your agent conversations is never stored, indexed, displayed, or
+  sent anywhere — it is parsed in memory, only to tell whether the agent is
+  mid-turn or waiting for you.
+
 ## Updates
 
 teebe checks for new versions via [Sparkle](https://sparkle-project.org/), which

--- a/Sources/Teebe/AgentNotifier.swift
+++ b/Sources/Teebe/AgentNotifier.swift
@@ -1,0 +1,24 @@
+import AppKit
+@preconcurrency import UserNotifications
+
+/// Posts "an agent needs you" notifications. Notification Center requires a real
+/// app bundle — an unbundled `swift run` binary would crash inside
+/// `UNUserNotificationCenter.current()`, so that path falls back to a beep.
+enum AgentNotifier {
+    @MainActor static func post(title: String, body: String) {
+        guard Bundle.main.bundleIdentifier != nil else {
+            NSSound.beep()
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.sound = .default
+            center.add(UNNotificationRequest(
+                identifier: UUID().uuidString, content: content, trigger: nil))
+        }
+    }
+}

--- a/Sources/Teebe/ViewModels/AppEnvironment.swift
+++ b/Sources/Teebe/ViewModels/AppEnvironment.swift
@@ -12,6 +12,36 @@ struct AppEnvironment {
     let activityMonitor: WorktreeActivityMonitor
     /// Factory for a file-system watcher (overridable with a fake in tests).
     let makeWatcher: @MainActor () -> FileSystemWatcher
+    /// Reads the agent activity state for a worktree path (live: Claude Code
+    /// session logs via `AgentSessionScanner`; tests inject a script).
+    let agentStatus: @Sendable (_ worktreePath: String, _ now: Date) -> AgentActivityState
+    /// Where the session logs live, so a watcher can react to log writes.
+    /// nil disables watching (and in tests, the watcher entirely).
+    let agentProjectsRootPath: String?
+    /// Posts a user-facing notification (title, body).
+    let notify: @MainActor (_ title: String, _ body: String) -> Void
+
+    init(
+        git: GitClient,
+        opener: FileOpener,
+        ops: FileOps,
+        store: AppStateStore,
+        activityMonitor: WorktreeActivityMonitor,
+        makeWatcher: @escaping @MainActor () -> FileSystemWatcher,
+        agentStatus: @escaping @Sendable (String, Date) -> AgentActivityState = { _, _ in .idle },
+        agentProjectsRootPath: String? = nil,
+        notify: @escaping @MainActor (String, String) -> Void = { _, _ in }
+    ) {
+        self.git = git
+        self.opener = opener
+        self.ops = ops
+        self.store = store
+        self.activityMonitor = activityMonitor
+        self.makeWatcher = makeWatcher
+        self.agentStatus = agentStatus
+        self.agentProjectsRootPath = agentProjectsRootPath
+        self.notify = notify
+    }
 
     var worktreeService: WorktreeService { WorktreeService(git: git) }
     var statusService: StatusService { StatusService(git: git) }
@@ -23,13 +53,22 @@ struct AppEnvironment {
     }
 
     static func live() -> AppEnvironment {
-        AppEnvironment(
+        // `TEEBE_CLAUDE_PROJECTS_DIR` override exists for live testing against a
+        // synthetic projects tree; real runs use `~/.claude/projects`.
+        let projectsRoot = ProcessInfo.processInfo.environment["TEEBE_CLAUDE_PROJECTS_DIR"]
+            .map { URL(fileURLWithPath: $0, isDirectory: true) }
+            ?? AgentSessionScanner.defaultProjectsRoot
+        let scanner = AgentSessionScanner(projectsRoot: projectsRoot)
+        return AppEnvironment(
             git: ProcessGitClient(),
             opener: WorkspaceFileOpener(),
             ops: FileManagerFileOps(),
             store: AppStateStore(),
             activityMonitor: WorktreeActivityMonitor(),
-            makeWatcher: { FSEventsWatcher() }
+            makeWatcher: { FSEventsWatcher() },
+            agentStatus: { path, now in scanner.state(forWorktreePath: path, now: now) },
+            agentProjectsRootPath: projectsRoot.path,
+            notify: AgentNotifier.post
         )
     }
 }

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -13,6 +13,9 @@ final class SelectorModel {
         var behind: Int = 0
         var changeCount: Int = 0
         var isLive: Bool = false
+        /// What the AI agent working in this worktree is doing (from its
+        /// Claude Code session log).
+        var agentState: AgentActivityState = .idle
 
         /// Whether there is anything to pull or push — rows hide the "↓ ↑"
         /// indicator entirely when both counts are zero.
@@ -46,6 +49,12 @@ final class SelectorModel {
     /// dir), used to filter watcher events. Resolved via `git rev-parse` so it's
     /// correct even when `<repo>/.git` is a gitlink file rather than a directory.
     private var worktreesAdminDir: String?
+    /// Watches the Claude projects root so agent badges react to session-log
+    /// writes (which happen outside any repo, so the repo watchers never see them).
+    private var agentWatcher: FileSystemWatcher?
+    /// Periodic re-derive so purely time-based transitions (stall, idle-out)
+    /// happen even when no session log is being written.
+    private var agentPollTask: Task<Void, Never>?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -73,6 +82,7 @@ final class SelectorModel {
         repoWatcher?.stop()
         repoWatcher = nil
         worktreesAdminDir = nil
+        stopAgentWatching()
         selectedRepo = nil
         worktrees = []
         selectedWorktree = nil
@@ -86,6 +96,7 @@ final class SelectorModel {
     func selectRepo(_ repo: Repository) async {
         selectedRepo = repo
         await startRepoWatching(repo)
+        startAgentWatching()
         do {
             worktrees = try await environment.worktreeService.worktrees(for: repo)
             branches = try await environment.branchService.branches(for: repo)
@@ -187,36 +198,110 @@ final class SelectorModel {
     /// WORKTREES list (drives the sync arrows and pulse dot).
     func refreshWorktreeInfo(now: Date = Date()) async {
         let statusService = environment.statusService
+        let agentStatus = environment.agentStatus
         let worktrees = self.worktrees
         // Fetch each worktree's status concurrently — these are independent git
         // reads, so a repo with many worktrees shouldn't serialize N `git status`
-        // calls on every repo switch.
-        let statuses = await withTaskGroup(of: (String, StatusResult?).self) { group in
+        // calls on every repo switch. The agent-log scan rides along per worktree.
+        let statuses = await withTaskGroup(of: (String, StatusResult?, AgentActivityState).self) { group in
             for worktree in worktrees {
                 let path = worktree.path
-                group.addTask { (path, try? await statusService.status(worktreePath: path)) }
+                group.addTask {
+                    (path, try? await statusService.status(worktreePath: path), agentStatus(path, now))
+                }
             }
-            var byPath: [String: StatusResult] = [:]
-            for await (path, status) in group {
-                if let status { byPath[path] = status }
+            var byPath: [String: (StatusResult?, AgentActivityState)] = [:]
+            for await (path, status, agent) in group {
+                byPath[path] = (status, agent)
             }
             return byPath
         }
         var info: [String: WorktreeInfo] = [:]
         for worktree in worktrees {
-            let status = statuses[worktree.path]
+            let (status, agent) = statuses[worktree.path] ?? (nil, .idle)
             info[worktree.path] = WorktreeInfo(
                 ahead: status?.ahead ?? 0,
                 behind: status?.behind ?? 0,
                 changeCount: status?.changes.count ?? 0,
-                isLive: environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
+                isLive: environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now),
+                agentState: agent
             )
         }
+        notifyAgentTransitions(from: worktreeInfo, to: info)
         worktreeInfo = info
     }
 
     func info(for worktree: Worktree) -> WorktreeInfo {
         worktreeInfo[worktree.path] ?? WorktreeInfo()
+    }
+
+    // MARK: - Agent status (Claude Code session logs)
+
+    /// Re-derive only the agent badges — no git. Used by the projects-root
+    /// watcher and the periodic poll; cheap enough to run often.
+    func refreshAgentStates(now: Date = Date()) async {
+        let agentStatus = environment.agentStatus
+        let worktrees = self.worktrees
+        let states = await withTaskGroup(of: (String, AgentActivityState).self) { group in
+            for worktree in worktrees {
+                let path = worktree.path
+                group.addTask { (path, agentStatus(path, now)) }
+            }
+            var byPath: [String: AgentActivityState] = [:]
+            for await (path, state) in group { byPath[path] = state }
+            return byPath
+        }
+        var info = worktreeInfo
+        for worktree in worktrees {
+            var entry = info[worktree.path] ?? WorktreeInfo()
+            entry.agentState = states[worktree.path] ?? .idle
+            info[worktree.path] = entry
+        }
+        notifyAgentTransitions(from: worktreeInfo, to: info)
+        worktreeInfo = info
+    }
+
+    /// Notify only on the working → needsAttention edge: the turn just ended (or
+    /// stalled). A session discovered already-finished stays silent, so app
+    /// launch never replays old sessions as notifications.
+    private func notifyAgentTransitions(from old: [String: WorktreeInfo], to new: [String: WorktreeInfo]) {
+        for worktree in worktrees {
+            guard old[worktree.path]?.agentState == .working,
+                  new[worktree.path]?.agentState == .needsAttention else { continue }
+            let name = worktree.branch ?? worktree.name
+            environment.notify("Agent needs you", "\(name) — the agent finished or is waiting")
+        }
+    }
+
+    /// Watch the Claude projects root (session logs live outside the repo, so the
+    /// repo watchers never see them) and poll slowly for time-only transitions.
+    private func startAgentWatching() {
+        stopAgentWatching()
+        guard let root = environment.agentProjectsRootPath else { return }
+        let watcher = environment.makeWatcher()
+        watcher.start(paths: [root], debounce: 1.0) { [weak self] _ in
+            Task { @MainActor in await self?.handleAgentWatchEvent() }
+        }
+        agentWatcher = watcher
+        agentPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                guard !Task.isCancelled else { return }
+                await self?.refreshAgentStates()
+            }
+        }
+    }
+
+    private func stopAgentWatching() {
+        agentWatcher?.stop()
+        agentWatcher = nil
+        agentPollTask?.cancel()
+        agentPollTask = nil
+    }
+
+    /// A coalesced batch of session-log writes — re-derive the badges.
+    func handleAgentWatchEvent() async {
+        await refreshAgentStates()
     }
 
     func selectWorktree(_ wt: Worktree) async {

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -55,6 +55,10 @@ final class SelectorModel {
     /// Periodic re-derive so purely time-based transitions (stall, idle-out)
     /// happen even when no session log is being written.
     private var agentPollTask: Task<Void, Never>?
+    /// One-shot follow-up scheduled while any live dot is lit, so `isLive` expires
+    /// shortly after the busy window lapses instead of latching until the next
+    /// event (a latched dot keeps a repeat-forever pulse animation burning CPU).
+    private var liveExpiryTask: Task<Void, Never>?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -67,10 +71,27 @@ final class SelectorModel {
     /// Recompute only the cheap `isLive` flags from the activity monitor (no git),
     /// e.g. after a file-watch event reports external activity.
     func refreshLiveState(now: Date = Date()) {
+        var anyLive = false
         for wt in worktrees {
             var info = worktreeInfo[wt.path] ?? WorktreeInfo()
             info.isLive = environment.activityMonitor.isBusy(worktreePath: wt.path, within: 5, now: now)
+            anyLive = anyLive || info.isLive
             worktreeInfo[wt.path] = info
+        }
+        scheduleLiveExpiry(anyLive: anyLive)
+    }
+
+    /// While any dot is lit, keep a single pending re-check just past the busy
+    /// window; each activity event pushes it back, so the last write is followed
+    /// by exactly one expiry pass that turns the dot (and its animation) off.
+    private func scheduleLiveExpiry(anyLive: Bool) {
+        liveExpiryTask?.cancel()
+        liveExpiryTask = nil
+        guard anyLive else { return }
+        liveExpiryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(5.5))
+            guard !Task.isCancelled else { return }
+            self?.refreshLiveState()
         }
     }
 
@@ -255,6 +276,7 @@ final class SelectorModel {
         for worktree in worktrees {
             var entry = info[worktree.path] ?? WorktreeInfo()
             entry.agentState = states[worktree.path] ?? .idle
+            entry.isLive = environment.activityMonitor.isBusy(worktreePath: worktree.path, within: 5, now: now)
             info[worktree.path] = entry
         }
         notifyAgentTransitions(from: worktreeInfo, to: info)

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -125,6 +125,31 @@ struct LiveDot: View {
     }
 }
 
+/// Compact chip showing what the AI agent in a worktree is doing: "working"
+/// while a session is mid-turn, "needs you" once its turn ended or it stalled.
+/// Hidden when idle. `onAccent` recolors for the filled active-row background.
+struct AgentBadge: View {
+    var state: AgentActivityState
+    var onAccent: Bool = false
+
+    var body: some View {
+        if state != .idle {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(onAccent ? .white : tint)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1.5)
+                .background(Capsule().fill((onAccent ? Color.white : tint).opacity(0.18)))
+                .help(state == .working
+                    ? "A coding agent is working in this worktree"
+                    : "The agent finished its turn or stalled — it needs you")
+        }
+    }
+
+    private var label: String { state == .working ? "working" : "needs you" }
+    private var tint: Color { state == .working ? Palette.accent : Palette.amber }
+}
+
 // MARK: - Press / hover chrome for compact controls
 
 /// Tactile press feedback for prominent action buttons (e.g. Commit): the whole

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -52,6 +52,9 @@ struct WorktreesSection: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                             .layoutPriority(1)
+                        // Surface the agent chip even with the section collapsed —
+                        // "needs you" must not hide behind a fold.
+                        AgentBadge(state: selector.info(for: active).agentState)
                     }
                 }
             }
@@ -143,6 +146,7 @@ struct WorktreesSection: View {
                 .font(.system(size: 13, weight: .medium))
                 .lineLimit(1)
             Spacer(minLength: 4)
+            AgentBadge(state: info.agentState, onAccent: isActive)
             // "↓0 ↑0" is pure noise — only show the sync arrows once there is
             // something to pull or push.
             if info.hasSync {

--- a/Sources/TeebeCore/AgentStatus.swift
+++ b/Sources/TeebeCore/AgentStatus.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+/// What an AI coding agent (a Claude Code session) is doing in a worktree,
+/// derived from the session logs under `~/.claude/projects`.
+public enum AgentActivityState: String, Equatable, Sendable {
+    /// A session is mid-turn: the model is thinking or running tools.
+    case working
+    /// The turn ended (final assistant text) or the session stalled — the agent
+    /// is waiting on the user.
+    case needsAttention
+    /// No session, or the newest one has been silent long enough to ignore.
+    case idle
+}
+
+/// Time windows for interpreting the last session entry.
+public struct AgentStatusThresholds: Equatable, Sendable {
+    /// A mid-turn entry older than this with no follow-up means the session
+    /// stalled (interrupted, crashed, or waiting on something) — surface it.
+    public var stall: TimeInterval
+    /// Anything older than this is treated as no agent at all.
+    public var idle: TimeInterval
+
+    public init(stall: TimeInterval = 600, idle: TimeInterval = 1_800) {
+        self.stall = stall
+        self.idle = idle
+    }
+}
+
+/// One meaningful message entry from a Claude Code session log (`*.jsonl`).
+/// Meta lines (mode, snapshots, attachments, summaries…) are not entries.
+public struct AgentSessionEntry: Equatable, Sendable {
+    public enum Kind: Equatable, Sendable {
+        /// A prompt typed by the human — the model is about to work.
+        case humanPrompt
+        /// A tool result fed back to the model — mid-turn.
+        case toolResult
+        /// An assistant message that requests a tool — mid-turn.
+        case assistantToolUse
+        /// An assistant message with no tool call — the turn's final text.
+        case assistantText
+    }
+
+    public var kind: Kind
+    public var timestamp: Date
+    public var isSidechain: Bool
+
+    public init(kind: Kind, timestamp: Date, isSidechain: Bool) {
+        self.kind = kind
+        self.timestamp = timestamp
+        self.isSidechain = isSidechain
+    }
+
+    /// Parse one JSONL line; nil for meta lines, malformed JSON, or entries
+    /// without a usable timestamp.
+    public static func parse(line: String) -> AgentSessionEntry? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              let type = dict["type"] as? String,
+              type == "user" || type == "assistant",
+              let message = dict["message"] as? [String: Any],
+              let timestampString = dict["timestamp"] as? String,
+              let timestamp = parseTimestamp(timestampString)
+        else { return nil }
+
+        let blocks = (message["content"] as? [[String: Any]]) ?? []
+        let blockTypes = Set(blocks.compactMap { $0["type"] as? String })
+        let kind: Kind
+        if type == "assistant" {
+            kind = blockTypes.contains("tool_use") ? .assistantToolUse : .assistantText
+        } else {
+            kind = blockTypes.contains("tool_result") ? .toolResult : .humanPrompt
+        }
+        return AgentSessionEntry(
+            kind: kind,
+            timestamp: timestamp,
+            isSidechain: dict["isSidechain"] as? Bool ?? false
+        )
+    }
+
+    private static func parseTimestamp(_ string: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: string) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: string)
+    }
+}
+
+/// Maps the last main-chain session entry to an activity state.
+public enum AgentStateDeriver {
+    public static func derive(
+        lastEntry: AgentSessionEntry?,
+        now: Date,
+        thresholds: AgentStatusThresholds = AgentStatusThresholds()
+    ) -> AgentActivityState {
+        guard let entry = lastEntry else { return .idle }
+        let age = now.timeIntervalSince(entry.timestamp)
+        if age >= thresholds.idle { return .idle }
+        switch entry.kind {
+        case .assistantText:
+            return .needsAttention
+        case .humanPrompt, .toolResult, .assistantToolUse:
+            return age >= thresholds.stall ? .needsAttention : .working
+        }
+    }
+}
+
+/// Reads the newest Claude Code session log for a worktree and derives what the
+/// agent there is doing. Pure filesystem reads; no side effects.
+public struct AgentSessionScanner: Sendable {
+    public var projectsRoot: URL
+    public var thresholds: AgentStatusThresholds
+
+    /// How much of the tail of a session file is scanned for the last entry.
+    private static let tailBytes = 256 * 1_024
+
+    public init(
+        projectsRoot: URL = AgentSessionScanner.defaultProjectsRoot,
+        thresholds: AgentStatusThresholds = AgentStatusThresholds()
+    ) {
+        self.projectsRoot = projectsRoot
+        self.thresholds = thresholds
+    }
+
+    public static var defaultProjectsRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+    }
+
+    /// Claude Code names each project dir by replacing every character of the
+    /// cwd that isn't an ASCII letter or digit with "-".
+    public static func projectDirName(forWorktreePath path: String) -> String {
+        String(path.map { $0.isASCII && ($0.isLetter || $0.isNumber) ? $0 : "-" })
+    }
+
+    /// The agent state for a worktree, judged from the most recently modified
+    /// session file in its project dir.
+    public func state(forWorktreePath path: String, now: Date = Date()) -> AgentActivityState {
+        let dir = projectsRoot.appendingPathComponent(
+            Self.projectDirName(forWorktreePath: path), isDirectory: true)
+        guard let newest = newestSessionFile(in: dir) else { return .idle }
+        // Fast path: a file untouched for the idle window can't be anything else.
+        if now.timeIntervalSince(newest.mtime) >= thresholds.idle { return .idle }
+        return AgentStateDeriver.derive(
+            lastEntry: lastMainChainEntry(in: newest.url), now: now, thresholds: thresholds)
+    }
+
+    private func newestSessionFile(in dir: URL) -> (url: URL, mtime: Date)? {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+        return entries
+            .filter { $0.pathExtension == "jsonl" }
+            .compactMap { url -> (URL, Date)? in
+                guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                      let mtime = values.contentModificationDate else { return nil }
+                return (url, mtime)
+            }
+            .max { $0.1 < $1.1 }
+            .map { (url: $0.0, mtime: $0.1) }
+    }
+
+    /// Scan the tail of the file backwards for the last parseable entry that
+    /// belongs to the main conversation (sidechains are subagent chatter).
+    private func lastMainChainEntry(in url: URL) -> AgentSessionEntry? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let size = try? handle.seekToEnd() else { return nil }
+        let offset = size > UInt64(Self.tailBytes) ? size - UInt64(Self.tailBytes) : 0
+        guard (try? handle.seek(toOffset: offset)) != nil,
+              let data = try? handle.readToEnd(),
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        for line in text.split(separator: "\n").reversed() {
+            if let entry = AgentSessionEntry.parse(line: String(line)), !entry.isSidechain {
+                return entry
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/TeebeCoreTests/AgentStatusTests.swift
+++ b/Tests/TeebeCoreTests/AgentStatusTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import Testing
+@testable import TeebeCore
+
+// MARK: - Fixture builders (mirror the real ~/.claude/projects/*.jsonl shapes)
+
+private func iso(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}
+
+private func humanPromptLine(at date: Date, sidechain: Bool = false) -> String {
+    """
+    {"parentUuid":null,"isSidechain":\(sidechain),"type":"user",\
+    "message":{"role":"user","content":"hey can u check the product"},\
+    "uuid":"u1","timestamp":"\(iso(date))","origin":{"kind":"human"},"promptSource":"typed",\
+    "cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1","gitBranch":"dev"}
+    """
+}
+
+private func toolResultLine(at date: Date, sidechain: Bool = false) -> String {
+    """
+    {"parentUuid":"a1","isSidechain":\(sidechain),"type":"user",\
+    "message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"ok"}]},\
+    "uuid":"u2","timestamp":"\(iso(date))","cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1"}
+    """
+}
+
+private func assistantToolUseLine(at date: Date, sidechain: Bool = false) -> String {
+    """
+    {"parentUuid":"u1","isSidechain":\(sidechain),"type":"assistant",\
+    "message":{"role":"assistant","content":[{"type":"text","text":"Looking."},\
+    {"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]},\
+    "uuid":"a1","timestamp":"\(iso(date))","cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1"}
+    """
+}
+
+private func assistantTextLine(at date: Date, sidechain: Bool = false) -> String {
+    """
+    {"parentUuid":"u2","isSidechain":\(sidechain),"type":"assistant",\
+    "message":{"role":"assistant","content":[{"type":"text","text":"Done — here is the answer."}]},\
+    "uuid":"a2","timestamp":"\(iso(date))","cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1"}
+    """
+}
+
+private let metaLines = [
+    #"{"type":"last-prompt","leafUuid":"x","sessionId":"s1"}"#,
+    #"{"type":"mode","mode":"normal","sessionId":"s1"}"#,
+    #"{"type":"permission-mode","permissionMode":"auto","sessionId":"s1"}"#,
+    #"{"type":"file-history-snapshot","messageId":"m1","snapshot":{},"isSnapshotUpdate":false}"#,
+    #"{"parentUuid":null,"isSidechain":false,"attachment":{"type":"hook_success"},"type":"attachment","uuid":"at1","timestamp":"2026-07-17T10:12:43.312Z"}"#,
+    #"{"type":"summary","summary":"Earlier context","leafUuid":"x"}"#
+]
+
+// MARK: - Project dir encoding
+
+@Suite("ClaudeProjects path encoding")
+struct ClaudeProjectsPathTests {
+    @Test("plain repo path encodes slashes to dashes")
+    func plainPath() {
+        #expect(AgentSessionScanner.projectDirName(forWorktreePath: "/Users/k/Documents/CODE/teebe")
+            == "-Users-k-Documents-CODE-teebe")
+    }
+
+    @Test("dots and other non-alphanumerics also become dashes")
+    func dottedPath() {
+        #expect(AgentSessionScanner.projectDirName(forWorktreePath: "/Users/k/katast/.claude/worktrees/dev")
+            == "-Users-k-katast--claude-worktrees-dev")
+        #expect(AgentSessionScanner.projectDirName(forWorktreePath: "/Users/k/my_repo v2")
+            == "-Users-k-my-repo-v2")
+    }
+}
+
+// MARK: - Entry parsing
+
+@Suite("AgentSessionEntry parsing")
+struct AgentSessionEntryTests {
+    let date = Date(timeIntervalSince1970: 1_784_000_000)
+
+    @Test("human prompt (string content) parses as humanPrompt")
+    func humanPrompt() throws {
+        let entry = try #require(AgentSessionEntry.parse(line: humanPromptLine(at: date)))
+        #expect(entry.kind == .humanPrompt)
+        #expect(abs(entry.timestamp.timeIntervalSince(date)) < 1)
+        #expect(entry.isSidechain == false)
+    }
+
+    @Test("user entry carrying a tool_result parses as toolResult")
+    func toolResult() throws {
+        let entry = try #require(AgentSessionEntry.parse(line: toolResultLine(at: date)))
+        #expect(entry.kind == .toolResult)
+    }
+
+    @Test("assistant message with a tool_use block parses as assistantToolUse")
+    func assistantToolUse() throws {
+        let entry = try #require(AgentSessionEntry.parse(line: assistantToolUseLine(at: date)))
+        #expect(entry.kind == .assistantToolUse)
+    }
+
+    @Test("assistant message with only text parses as assistantText")
+    func assistantText() throws {
+        let entry = try #require(AgentSessionEntry.parse(line: assistantTextLine(at: date)))
+        #expect(entry.kind == .assistantText)
+    }
+
+    @Test("meta / non-message lines parse to nil")
+    func metaLinesAreNil() {
+        for line in metaLines {
+            #expect(AgentSessionEntry.parse(line: line) == nil, "should ignore: \(line.prefix(40))")
+        }
+        #expect(AgentSessionEntry.parse(line: "not json at all") == nil)
+        #expect(AgentSessionEntry.parse(line: "") == nil)
+    }
+
+    @Test("missing timestamp parses to nil")
+    func missingTimestamp() {
+        let line = #"{"type":"user","message":{"role":"user","content":"hi"},"uuid":"u9"}"#
+        #expect(AgentSessionEntry.parse(line: line) == nil)
+    }
+
+    @Test("sidechain flag is carried through")
+    func sidechainFlag() throws {
+        let entry = try #require(AgentSessionEntry.parse(line: assistantTextLine(at: date, sidechain: true)))
+        #expect(entry.isSidechain == true)
+    }
+}
+
+// MARK: - State derivation
+
+@Suite("AgentStateDeriver")
+struct AgentStateDeriverTests {
+    let now = Date(timeIntervalSince1970: 1_784_000_000)
+    let thresholds = AgentStatusThresholds(stall: 600, idle: 1_800)
+
+    func entry(_ kind: AgentSessionEntry.Kind, age: TimeInterval) -> AgentSessionEntry {
+        AgentSessionEntry(kind: kind, timestamp: now.addingTimeInterval(-age), isSidechain: false)
+    }
+
+    @Test("no entry means idle")
+    func noEntry() {
+        #expect(AgentStateDeriver.derive(lastEntry: nil, now: now, thresholds: thresholds) == .idle)
+    }
+
+    @Test("fresh assistant final text means the turn ended — needs attention")
+    func turnEnded() {
+        #expect(AgentStateDeriver.derive(lastEntry: entry(.assistantText, age: 5), now: now, thresholds: thresholds)
+            == .needsAttention)
+    }
+
+    @Test("fresh mid-turn entries mean working", arguments: [
+        AgentSessionEntry.Kind.humanPrompt, .toolResult, .assistantToolUse
+    ])
+    func working(kind: AgentSessionEntry.Kind) {
+        #expect(AgentStateDeriver.derive(lastEntry: entry(kind, age: 30), now: now, thresholds: thresholds)
+            == .working)
+    }
+
+    @Test("a mid-turn entry past the stall threshold needs attention")
+    func stalled() {
+        #expect(AgentStateDeriver.derive(lastEntry: entry(.assistantToolUse, age: 700), now: now, thresholds: thresholds)
+            == .needsAttention)
+    }
+
+    @Test("anything past the idle threshold is idle", arguments: [
+        AgentSessionEntry.Kind.humanPrompt, .toolResult, .assistantToolUse, .assistantText
+    ])
+    func pastIdle(kind: AgentSessionEntry.Kind) {
+        #expect(AgentStateDeriver.derive(lastEntry: entry(kind, age: 1_801), now: now, thresholds: thresholds)
+            == .idle)
+    }
+}
+
+// MARK: - Scanner (filesystem integration)
+
+@Suite("AgentSessionScanner")
+struct AgentSessionScannerTests {
+    let now = Date(timeIntervalSince1970: 1_784_000_000)
+    let worktreePath = "/Users/k/Documents/CODE/teebe"
+
+    /// A throwaway projects root with a project dir for `worktreePath`.
+    struct Fixture {
+        var scanner: AgentSessionScanner
+        var root: URL
+        var dir: URL
+    }
+
+    func makeFixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("teebe-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let projectDir = root.appendingPathComponent(
+            AgentSessionScanner.projectDirName(forWorktreePath: worktreePath), isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        let scanner = AgentSessionScanner(
+            projectsRoot: root, thresholds: AgentStatusThresholds(stall: 600, idle: 1_800))
+        return Fixture(scanner: scanner, root: root, dir: projectDir)
+    }
+
+    func write(_ lines: [String], to url: URL, mtime: Date? = nil) throws {
+        try lines.joined(separator: "\n").appending("\n").write(to: url, atomically: true, encoding: .utf8)
+        if let mtime {
+            try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+        }
+    }
+
+    @Test("no project dir for the worktree means idle")
+    func noProjectDir() throws {
+        let fx = try makeFixture()
+        #expect(fx.scanner.state(forWorktreePath: "/nowhere/else", now: now) == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("session ending in a tool_use is working")
+    func workingSession() throws {
+        let fx = try makeFixture()
+        try write(
+            [humanPromptLine(at: now.addingTimeInterval(-60)), assistantToolUseLine(at: now.addingTimeInterval(-5))],
+            to: fx.dir.appendingPathComponent("s1.jsonl"))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .working)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("session ending in final assistant text needs attention")
+    func finishedSession() throws {
+        let fx = try makeFixture()
+        try write(
+            [humanPromptLine(at: now.addingTimeInterval(-120)), assistantTextLine(at: now.addingTimeInterval(-10))],
+            to: fx.dir.appendingPathComponent("s1.jsonl"))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .needsAttention)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("trailing sidechain entries are skipped — main chain decides")
+    func sidechainSkipped() throws {
+        let fx = try makeFixture()
+        try write(
+            [
+                assistantToolUseLine(at: now.addingTimeInterval(-30)),
+                assistantTextLine(at: now.addingTimeInterval(-4), sidechain: true)
+            ],
+            to: fx.dir.appendingPathComponent("s1.jsonl"))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .working)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("trailing meta lines are skipped")
+    func metaSkipped() throws {
+        let fx = try makeFixture()
+        try write(
+            [assistantTextLine(at: now.addingTimeInterval(-10))] + metaLines,
+            to: fx.dir.appendingPathComponent("s1.jsonl"))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .needsAttention)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("the most recently modified session file wins")
+    func newestFileWins() throws {
+        let fx = try makeFixture()
+        try write(
+            [assistantTextLine(at: now.addingTimeInterval(-900))],
+            to: fx.dir.appendingPathComponent("old.jsonl"), mtime: now.addingTimeInterval(-900))
+        try write(
+            [assistantToolUseLine(at: now.addingTimeInterval(-5))],
+            to: fx.dir.appendingPathComponent("new.jsonl"), mtime: now.addingTimeInterval(-5))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .working)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("a session file idle-old by mtime is idle without reading it")
+    func staleFileIsIdle() throws {
+        let fx = try makeFixture()
+        try write(
+            [assistantTextLine(at: now.addingTimeInterval(-7_200))],
+            to: fx.dir.appendingPathComponent("s1.jsonl"), mtime: now.addingTimeInterval(-7_200))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("an empty or meta-only session file is idle")
+    func emptyFileIsIdle() throws {
+        let fx = try makeFixture()
+        try write(metaLines, to: fx.dir.appendingPathComponent("s1.jsonl"))
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+}

--- a/Tests/TeebeTests/AgentStatusModelTests.swift
+++ b/Tests/TeebeTests/AgentStatusModelTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+@testable import Teebe
+import TeebeCore
+import Testing
+
+@MainActor
+@Suite("Agent status in SelectorModel")
+struct AgentStatusModelTests {
+    let repo = Repository(path: "/repo")
+
+    func makeSelector(
+        states: FakeAgentStates,
+        spy: NotificationSpy = NotificationSpy(),
+        git: FakeGitClient = FakeGitClient(),
+        box: WatcherBox? = nil,
+        projectsRoot: String? = nil
+    ) -> SelectorModel {
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-wt", branch: "feat/x")
+        ]
+        return SelectorModel(environment: makeTestEnvironment(
+            git: git,
+            makeWatcher: box.map { b in { b.make() } },
+            agentStatus: states.provider,
+            agentProjectsRootPath: projectsRoot,
+            notify: spy.record
+        ))
+    }
+
+    @Test("refreshWorktreeInfo picks up each worktree's agent state")
+    func refreshPopulatesAgentState() async {
+        let states = FakeAgentStates()
+        states["/repo-wt"] = .working
+        let selector = makeSelector(states: states)
+
+        await selector.selectRepo(repo)
+        #expect(selector.info(for: selector.worktrees[0]).agentState == .idle)
+        #expect(selector.info(for: selector.worktrees[1]).agentState == .working)
+    }
+
+    @Test("refreshAgentStates updates badges without re-running git status")
+    func cheapRefresh() async {
+        let states = FakeAgentStates()
+        let git = FakeGitClient()
+        let selector = makeSelector(states: states, git: git)
+        await selector.selectRepo(repo)
+        let gitCallsAfterSelect = git.statusCallCount
+
+        states["/repo-wt"] = .working
+        await selector.refreshAgentStates()
+        #expect(selector.info(for: selector.worktrees[1]).agentState == .working)
+        #expect(git.statusCallCount == gitCallsAfterSelect)
+    }
+
+    @Test("working → needsAttention notifies once, naming the worktree")
+    func transitionNotifies() async {
+        let states = FakeAgentStates()
+        let spy = NotificationSpy()
+        let selector = makeSelector(states: states, spy: spy)
+        await selector.selectRepo(repo)
+
+        states["/repo-wt"] = .working
+        await selector.refreshAgentStates()
+        #expect(spy.posted.isEmpty)
+
+        states["/repo-wt"] = .needsAttention
+        await selector.refreshAgentStates()
+        #expect(spy.posted.count == 1)
+        #expect(spy.posted.first?.body.contains("feat/x") == true)
+
+        // Still needing attention on the next poll is not a new event.
+        await selector.refreshAgentStates()
+        #expect(spy.posted.count == 1)
+    }
+
+    @Test("a session already needing attention at discovery does not notify")
+    func staleSessionDoesNotNotify() async {
+        let states = FakeAgentStates()
+        states["/repo-wt"] = .needsAttention
+        let spy = NotificationSpy()
+        let selector = makeSelector(states: states, spy: spy)
+
+        await selector.selectRepo(repo)
+        #expect(selector.info(for: selector.worktrees[1]).agentState == .needsAttention)
+        #expect(spy.posted.isEmpty)
+    }
+
+    @Test("selecting a repo watches the Claude projects root; clearing stops it")
+    func projectsWatcherLifecycle() async {
+        let states = FakeAgentStates()
+        let box = WatcherBox()
+        let selector = makeSelector(states: states, box: box, projectsRoot: "/fake/.claude/projects")
+        await selector.selectRepo(repo)
+
+        let watcher = box.watching("/fake/.claude/projects")
+        #expect(watcher != nil)
+        #expect(watcher?.isWatching == true)
+
+        // A session-log change re-derives states via the cheap path.
+        states["/repo-wt"] = .working
+        await selector.handleAgentWatchEvent()
+        #expect(selector.info(for: selector.worktrees[1]).agentState == .working)
+
+        selector.clearSelection()
+        #expect(watcher?.isWatching == false)
+    }
+
+    @Test("without a projects root no agent watcher is started")
+    func noRootNoWatcher() async {
+        let states = FakeAgentStates()
+        let box = WatcherBox()
+        let selector = makeSelector(states: states, box: box, projectsRoot: nil)
+        await selector.selectRepo(repo)
+        #expect(box.watching(".claude") == nil)
+    }
+}

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -132,6 +132,40 @@ final class WatcherBox {
     }
 }
 
+// MARK: - Fake agent status
+
+/// Scriptable per-worktree agent states for tests; the closure form feeds
+/// `AppEnvironment.agentStatus`.
+final class FakeAgentStates: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [String: AgentActivityState] = [:]
+
+    subscript(path: String) -> AgentActivityState? {
+        get { lock.lock(); defer { lock.unlock() }; return states[path] }
+        set { lock.lock(); states[path] = newValue; lock.unlock() }
+    }
+
+    var provider: @Sendable (String, Date) -> AgentActivityState {
+        { [self] path, _ in self[path] ?? .idle }
+    }
+}
+
+/// Records notifications the models post (delivery happens on the main actor).
+final class NotificationSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [(title: String, body: String)] = []
+
+    var posted: [(title: String, body: String)] {
+        lock.lock(); defer { lock.unlock() }; return recorded
+    }
+
+    var record: @MainActor (String, String) -> Void {
+        { [self] title, body in
+            lock.lock(); recorded.append((title, body)); lock.unlock()
+        }
+    }
+}
+
 // MARK: - Test environment
 
 @MainActor
@@ -141,7 +175,10 @@ func makeTestEnvironment(
     ops: FakeFileOps = FakeFileOps(),
     store: AppStateStore? = nil,
     monitor: WorktreeActivityMonitor = WorktreeActivityMonitor(),
-    makeWatcher: (@MainActor () -> FileSystemWatcher)? = nil
+    makeWatcher: (@MainActor () -> FileSystemWatcher)? = nil,
+    agentStatus: (@Sendable (String, Date) -> AgentActivityState)? = nil,
+    agentProjectsRootPath: String? = nil,
+    notify: (@MainActor (String, String) -> Void)? = nil
 ) -> AppEnvironment {
     let storeURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("tb-test-\(UUID().uuidString)")
@@ -152,6 +189,9 @@ func makeTestEnvironment(
         ops: ops,
         store: store ?? AppStateStore(url: storeURL),
         activityMonitor: monitor,
-        makeWatcher: makeWatcher ?? { FakeWatcher() }
+        makeWatcher: makeWatcher ?? { FakeWatcher() },
+        agentStatus: agentStatus ?? { _, _ in .idle },
+        agentProjectsRootPath: agentProjectsRootPath,
+        notify: notify ?? { _, _ in }
     )
 }

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -184,6 +184,26 @@ struct SelectorModelTests {
         #expect(selector.info(for: git.worktreesResult[1]).isLive == false)
     }
 
+    @Test("agent poll expires a stale live dot once the busy window lapses")
+    func liveDotExpiresViaAgentPoll() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/repo", branch: "main", isPrimary: true)]
+        let monitor = WorktreeActivityMonitor()
+        let selector = SelectorModel(environment: makeTestEnvironment(git: git, monitor: monitor))
+        await selector.selectRepo(Repository(path: "/repo"))
+
+        let t = Date(timeIntervalSince1970: 1000)
+        monitor.recordActivity(worktreePath: "/repo", at: t)
+        selector.refreshLiveState(now: t.addingTimeInterval(1))
+        #expect(selector.info(for: git.worktreesResult[0]).isLive == true)
+
+        // No further file events: the periodic agent poll is the only thing that
+        // runs, and it must also let the live flag expire — otherwise the dot
+        // (and its repeat-forever pulse animation) runs until the next rescan.
+        await selector.refreshAgentStates(now: t.addingTimeInterval(30))
+        #expect(selector.info(for: git.worktreesResult[0]).isLive == false)
+    }
+
     @Test("refreshWorktreeInfo computes live state alongside sync counts")
     func liveDotViaRefreshInfo() async {
         let git = FakeGitClient()

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.4.2}"
+APP_VERSION="${APP_VERSION:-0.5.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -94,6 +94,9 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>NSHumanReadableCopyright</key><string>© 2026 Klein Tahiraj. Licensed under GPL-3.0-or-later (see LICENSE) or a commercial license. Bundles Sparkle and other components — see THIRD-PARTY-LICENSES.</string>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSPrincipalClass</key><string>NSApplication</string>
+  <key>NSDocumentsFolderUsageDescription</key><string>teebe only reads the folder your repository lives in, to show its worktrees, changes, and files. Nothing is uploaded or modified without your action.</string>
+  <key>NSDesktopFolderUsageDescription</key><string>teebe only reads the folder your repository lives in, to show its worktrees, changes, and files. Nothing is uploaded or modified without your action.</string>
+  <key>NSDownloadsFolderUsageDescription</key><string>teebe only reads the folder your repository lives in, to show its worktrees, changes, and files. Nothing is uploaded or modified without your action.</string>
   <key>NSHighResolutionCapable</key><true/>
   <key>SUFeedURL</key><string>${SU_FEED_URL}</string>
   <key>SUPublicEDKey</key><string>${SU_PUBLIC_ED_KEY}</string>


### PR DESCRIPTION
Release v0.5.0.

- Per-worktree agent status with notifications (#67)
- Live-dot expiry fix, also cures the sustained idle CPU usage (#71, #72)
- TCC folder-access explanation and privacy copy alignment (#68, #69, #70)