### PR TITLE
Select already-tracked repo when re-added via Add Repository

### DIFF
--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -92,7 +92,12 @@ final class AppModel {
         // worktrees (firmlink /var → /private/var), avoiding duplicate/mismatched entries.
         let standardized = PathUtil.standardized((path as NSString).expandingTildeInPath)
         setError(nil)   // a fresh attempt clears any stale banner
-        guard !repositories.contains(where: { $0.path == standardized }) else { return false }
+        // Re-adding a tracked repo isn't an error — the user picked it expecting to
+        // see it, so switch to it instead of silently doing nothing.
+        if let existing = repositories.first(where: { $0.path == standardized }) {
+            await selector.selectRepo(existing)
+            return false
+        }
         do {
             _ = try await environment.git.worktrees(repoPath: standardized)
         } catch {

--- a/Tests/TeebeTests/UserStoryTests.swift
+++ b/Tests/TeebeTests/UserStoryTests.swift
@@ -22,6 +22,20 @@ struct RepoStoryTests {
         #expect(app.repositories.count == 1)
     }
 
+    @Test("A3b: re-adding a tracked repo selects it instead of doing nothing")
+    func a3bReAddSelects() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/a", branch: "main", isPrimary: true)]
+        let app = AppModel(environment: makeTestEnvironment(git: git))
+        _ = await app.addRepository(path: "/a")
+        _ = await app.addRepository(path: "/b")
+        #expect(app.selector.selectedRepo?.path == "/b")
+        // Picking /a again from the add panel must switch back to it.
+        #expect(await app.addRepository(path: "/a") == false)
+        #expect(app.repositories.count == 2)
+        #expect(app.selector.selectedRepo?.path == "/a")
+    }
+
     @Test("A4: removing a repo persists the removal")
     func a4RemovePersists() async {
         let git = FakeGitClient()


### PR DESCRIPTION
Clicking + and picking a folder that is already tracked silently did nothing (the duplicate guard returned early without selecting), forcing a second trip through the ⋯ menu. Re-adding a tracked repo now switches to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTRDiVsHSdMq1U4MzRLGfT