### PR TITLE
Fold the agent chip into the worktree dot

### DIFF
--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -87,23 +87,48 @@ struct StatusLetter: View {
     }
 }
 
-/// A green dot that pulses while a worktree is being written to (live agent).
+/// The worktree's whole story in one dot: a pulsing green while an agent is
+/// working there (or files are being written), steady amber when the agent's
+/// turn ended or stalled — it needs you — and dim gray when no conversation
+/// points at the worktree.
 ///
-/// The pulse is driven off `active` via `onChange`, not a one-shot `onAppear`, so
+/// The pulse is driven off state via `onChange`, not a one-shot `onAppear`, so
 /// a worktree that goes live *after* the row appears starts pulsing, and one that
 /// goes idle stops — the previous version latched whatever state it saw at appear.
 struct LiveDot: View {
+    /// Files are being written in the worktree right now (fs watcher).
     var active: Bool
+    /// What the Claude session pointing at the worktree is doing.
+    var agent: AgentActivityState = .idle
     @State private var animate = false
+
+    /// Amber never pulses — "needs you" is precisely the moment nothing is
+    /// happening, and it outranks stray fs activity (the agent's last writes
+    /// would otherwise flash green for a beat after its turn ended).
+    private var pulsing: Bool { agent == .working || (agent == .idle && active) }
+
+    private var fill: Color {
+        if agent == .needsAttention { return Palette.amber }
+        return pulsing ? Palette.live : Color(white: 0.79)
+    }
 
     var body: some View {
         Circle()
-            .fill(active ? Palette.live : Color(white: 0.79))
+            .fill(fill)
             .frame(width: 7, height: 7)
             .overlay(ring)
-            .animation(.easeInOut(duration: 0.25), value: active)   // fade the fill on state change
+            .animation(.easeInOut(duration: 0.25), value: fill)   // fade the fill on state change
             .onAppear { syncPulse() }
-            .onChange(of: active) { _, _ in syncPulse() }
+            .onChange(of: pulsing) { _, _ in syncPulse() }
+            .help(helpText)
+    }
+
+    private var helpText: String {
+        switch agent {
+        case .working: return "A coding agent is working in this worktree"
+        case .needsAttention: return "The agent finished its turn or stalled — it needs you"
+        case .idle: return active ? "Files are changing in this worktree" : ""
+        }
     }
 
     /// The expanding halo. Hidden entirely while idle so a stopped pulse can't
@@ -113,41 +138,16 @@ struct LiveDot: View {
             .stroke(Palette.live, lineWidth: 2)
             .scaleEffect(animate ? 2.4 : 1)
             .opacity(animate ? 0 : 0.5)
-            .opacity(active ? 1 : 0)
+            .opacity(pulsing ? 1 : 0)
     }
 
     private func syncPulse() {
-        if active {
+        if pulsing {
             withAnimation(.easeOut(duration: 1.6).repeatForever(autoreverses: false)) { animate = true }
         } else {
             withAnimation(.easeOut(duration: 0.2)) { animate = false }
         }
     }
-}
-
-/// Compact chip showing what the AI agent in a worktree is doing: "working"
-/// while a session is mid-turn, "needs you" once its turn ended or it stalled.
-/// Hidden when idle. `onAccent` recolors for the filled active-row background.
-struct AgentBadge: View {
-    var state: AgentActivityState
-    var onAccent: Bool = false
-
-    var body: some View {
-        if state != .idle {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(onAccent ? .white : tint)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1.5)
-                .background(Capsule().fill((onAccent ? Color.white : tint).opacity(0.18)))
-                .help(state == .working
-                    ? "A coding agent is working in this worktree"
-                    : "The agent finished its turn or stalled — it needs you")
-        }
-    }
-
-    private var label: String { state == .working ? "working" : "needs you" }
-    private var tint: Color { state == .working ? Palette.accent : Palette.amber }
 }
 
 // MARK: - Press / hover chrome for compact controls

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -43,7 +43,10 @@ struct WorktreesSection: View {
                     }
                 } else if let active = selector.selectedWorktree {
                     HStack(spacing: 5) {
-                        LiveDot(active: selector.info(for: active).isLive)
+                        // The dot carries the agent state too (amber = needs you),
+                        // so "needs you" stays visible even with the section folded.
+                        LiveDot(active: selector.info(for: active).isLive,
+                                agent: selector.info(for: active).agentState)
                         // Same treatment as the collapsed FILES header's branch label;
                         // the accent colour (+ dot) marks this one as the active worktree.
                         Text(active.branch ?? active.name)
@@ -52,9 +55,6 @@ struct WorktreesSection: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                             .layoutPriority(1)
-                        // Surface the agent chip even with the section collapsed —
-                        // "needs you" must not hide behind a fold.
-                        AgentBadge(state: selector.info(for: active).agentState)
                     }
                 }
             }
@@ -138,7 +138,7 @@ struct WorktreesSection: View {
         // distinct from the filled accent of the committed worktree. Enter commits it.
         let isHighlighted = app.activeSection == .worktrees && selector.highlightedWorktree?.path == worktree.path
         return HStack(spacing: 7) {
-            LiveDot(active: info.isLive)
+            LiveDot(active: info.isLive, agent: info.agentState)
             Image(systemName: "point.3.connected.trianglepath.dotted")
                 .font(.system(size: 11))
                 .foregroundStyle(isActive ? .white : Palette.secondaryText)
@@ -146,7 +146,6 @@ struct WorktreesSection: View {
                 .font(.system(size: 13, weight: .medium))
                 .lineLimit(1)
             Spacer(minLength: 4)
-            AgentBadge(state: info.agentState, onAccent: isActive)
             // "↓0 ↑0" is pure noise — only show the sync arrows once there is
             // something to pull or push.
             if info.hasSync {


### PR DESCRIPTION
One dot now tells the worktree's story: pulsing green while an agent is working (or files are being written), steady amber when the agent's turn ended or stalled (needs you), dim gray when no conversation points at the worktree. The "working"/"needs you" text chip is gone; tooltips on the dot keep the explanation. Amber outranks fs activity so the agent's trailing writes can't flash green after its turn ends, and it never pulses — needing you is exactly the moment nothing is happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTRDiVsHSdMq1U4MzRLGfT