### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] - 2026-08-04
+
+### Fixed
+- Picking an already-tracked folder from the add (+) panel now switches to that
+  repository instead of silently doing nothing.
+- The CHANGES count no longer rolls its digits when you switch worktrees — it
+  snaps to the new worktree's total, and still animates when changes happen in
+  the current worktree.
+- Agent status now follows the worktree the agent is actually working in. A
+  session that starts in the main checkout and moves into a linked worktree
+  used to show as activity on the main checkout.
+
+### Changed
+- The "working" / "needs you" chip is gone; the worktree dot now tells the
+  whole story — pulsing green while an agent is working, steady amber when it
+  needs you, gray when nothing is happening there.
+
 ## [0.5.0] - 2026-07-28
 
 ### Added

--- a/Sources/Teebe/ViewModels/AppEnvironment.swift
+++ b/Sources/Teebe/ViewModels/AppEnvironment.swift
@@ -12,9 +12,11 @@ struct AppEnvironment {
     let activityMonitor: WorktreeActivityMonitor
     /// Factory for a file-system watcher (overridable with a fake in tests).
     let makeWatcher: @MainActor () -> FileSystemWatcher
-    /// Reads the agent activity state for a worktree path (live: Claude Code
-    /// session logs via `AgentSessionScanner`; tests inject a script).
-    let agentStatus: @Sendable (_ worktreePath: String, _ now: Date) -> AgentActivityState
+    /// Reads the agent activity states for all of a repo's worktree paths at
+    /// once (live: Claude Code session logs via `AgentSessionScanner`; tests
+    /// inject a script). Batched so the scanner can attribute a session logged
+    /// under one worktree's project dir to the worktree it actually runs in.
+    let agentStatuses: @Sendable (_ worktreePaths: [String], _ now: Date) -> [String: AgentActivityState]
     /// Where the session logs live, so a watcher can react to log writes.
     /// nil disables watching (and in tests, the watcher entirely).
     let agentProjectsRootPath: String?
@@ -28,7 +30,7 @@ struct AppEnvironment {
         store: AppStateStore,
         activityMonitor: WorktreeActivityMonitor,
         makeWatcher: @escaping @MainActor () -> FileSystemWatcher,
-        agentStatus: @escaping @Sendable (String, Date) -> AgentActivityState = { _, _ in .idle },
+        agentStatuses: @escaping @Sendable ([String], Date) -> [String: AgentActivityState] = { _, _ in [:] },
         agentProjectsRootPath: String? = nil,
         notify: @escaping @MainActor (String, String) -> Void = { _, _ in }
     ) {
@@ -38,7 +40,7 @@ struct AppEnvironment {
         self.store = store
         self.activityMonitor = activityMonitor
         self.makeWatcher = makeWatcher
-        self.agentStatus = agentStatus
+        self.agentStatuses = agentStatuses
         self.agentProjectsRootPath = agentProjectsRootPath
         self.notify = notify
     }
@@ -66,7 +68,7 @@ struct AppEnvironment {
             store: AppStateStore(),
             activityMonitor: WorktreeActivityMonitor(),
             makeWatcher: { FSEventsWatcher() },
-            agentStatus: { path, now in scanner.state(forWorktreePath: path, now: now) },
+            agentStatuses: { paths, now in scanner.states(forWorktreePaths: paths, now: now) },
             agentProjectsRootPath: projectsRoot.path,
             notify: AgentNotifier.post
         )

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -92,7 +92,12 @@ final class AppModel {
         // worktrees (firmlink /var → /private/var), avoiding duplicate/mismatched entries.
         let standardized = PathUtil.standardized((path as NSString).expandingTildeInPath)
         setError(nil)   // a fresh attempt clears any stale banner
-        guard !repositories.contains(where: { $0.path == standardized }) else { return false }
+        // Re-adding a tracked repo isn't an error — the user picked it expecting to
+        // see it, so switch to it instead of silently doing nothing.
+        if let existing = repositories.first(where: { $0.path == standardized }) {
+            await selector.selectRepo(existing)
+            return false
+        }
         do {
             _ = try await environment.git.worktrees(repoPath: standardized)
         } catch {

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -219,27 +219,34 @@ final class SelectorModel {
     /// WORKTREES list (drives the sync arrows and pulse dot).
     func refreshWorktreeInfo(now: Date = Date()) async {
         let statusService = environment.statusService
-        let agentStatus = environment.agentStatus
+        let agentStatuses = environment.agentStatuses
         let worktrees = self.worktrees
+        let paths = worktrees.map(\.path)
+        // One batched agent-log scan for the whole repo — the scanner needs every
+        // worktree path to attribute a session to the worktree it runs in, not
+        // the one it was launched from. Runs off-main alongside the git reads.
+        let agentTask = Task.detached { agentStatuses(paths, now) }
         // Fetch each worktree's status concurrently — these are independent git
         // reads, so a repo with many worktrees shouldn't serialize N `git status`
-        // calls on every repo switch. The agent-log scan rides along per worktree.
-        let statuses = await withTaskGroup(of: (String, StatusResult?, AgentActivityState).self) { group in
+        // calls on every repo switch.
+        let statuses = await withTaskGroup(of: (String, StatusResult?).self) { group in
             for worktree in worktrees {
                 let path = worktree.path
                 group.addTask {
-                    (path, try? await statusService.status(worktreePath: path), agentStatus(path, now))
+                    (path, try? await statusService.status(worktreePath: path))
                 }
             }
-            var byPath: [String: (StatusResult?, AgentActivityState)] = [:]
-            for await (path, status, agent) in group {
-                byPath[path] = (status, agent)
+            var byPath: [String: StatusResult?] = [:]
+            for await (path, status) in group {
+                byPath[path] = status
             }
             return byPath
         }
+        let agentStates = await agentTask.value
         var info: [String: WorktreeInfo] = [:]
         for worktree in worktrees {
-            let (status, agent) = statuses[worktree.path] ?? (nil, .idle)
+            let status = statuses[worktree.path] ?? nil
+            let agent = agentStates[worktree.path] ?? .idle
             info[worktree.path] = WorktreeInfo(
                 ahead: status?.ahead ?? 0,
                 behind: status?.behind ?? 0,
@@ -261,17 +268,10 @@ final class SelectorModel {
     /// Re-derive only the agent badges — no git. Used by the projects-root
     /// watcher and the periodic poll; cheap enough to run often.
     func refreshAgentStates(now: Date = Date()) async {
-        let agentStatus = environment.agentStatus
+        let agentStatuses = environment.agentStatuses
         let worktrees = self.worktrees
-        let states = await withTaskGroup(of: (String, AgentActivityState).self) { group in
-            for worktree in worktrees {
-                let path = worktree.path
-                group.addTask { (path, agentStatus(path, now)) }
-            }
-            var byPath: [String: AgentActivityState] = [:]
-            for await (path, state) in group { byPath[path] = state }
-            return byPath
-        }
+        let paths = worktrees.map(\.path)
+        let states = await Task.detached { agentStatuses(paths, now) }.value
         var info = worktreeInfo
         for worktree in worktrees {
             var entry = info[worktree.path] ?? WorktreeInfo()

--- a/Sources/Teebe/Views/ChangesSection.swift
+++ b/Sources/Teebe/Views/ChangesSection.swift
@@ -13,7 +13,7 @@ struct ChangesSection: View {
             SectionHeader(title: "CHANGES", isOpen: isOpen, isActive: app.activeSection == .changes, onToggle: { isOpen.toggle() }) {
                 // Just the count: the ahead/behind indicator lives on the worktree
                 // rows — branch sync state isn't a property of the change list.
-                countBadge(worktree.changeCount)
+                CountBadge(count: worktree.changeCount, contextID: worktree.worktreePath)
             }
 
             if isOpen {
@@ -127,14 +127,46 @@ struct ChangesSection: View {
         }
     }
 
-    private func countBadge(_ count: Int) -> some View {
-        Text("\(count)")
+}
+
+/// The CHANGES header count. Digits roll (`numericText`) only when the count of the
+/// *same* worktree changes (edits, stage/discard); a count arriving because the user
+/// switched worktrees snaps into place — rolling between two unrelated worktrees'
+/// totals reads as a glitch, not a change.
+private struct CountBadge: View {
+    let count: Int
+    /// Identity of the thing being counted (the worktree path).
+    let contextID: String?
+
+    @State private var displayed = 0
+    /// Which context `displayed` belongs to. Deliberately only updated when a count
+    /// arrives: a worktree switch changes `contextID` first and the new status lands
+    /// asynchronously later, so the mismatch at that moment is what marks the update
+    /// as "different worktree → snap".
+    @State private var displayedContext: String?
+
+    var body: some View {
+        Text("\(displayed)")
             .font(.system(size: 10, weight: .semibold))
             .monospacedDigit()
-            .contentTransition(.numericText())
+            .contentTransition(.numericText(value: Double(displayed)))
             .foregroundStyle(Palette.headerLabel)
             .padding(.horizontal, 5).frame(minWidth: 18, minHeight: 16)
             .background(Color.primary.opacity(0.07), in: Capsule())
-            .animation(.snappy(duration: 0.22), value: count)
+            .onAppear {
+                displayed = count
+                displayedContext = contextID
+            }
+            .onChange(of: count) { _, newCount in
+                let sameWorktree = displayedContext == contextID
+                displayedContext = contextID
+                if sameWorktree {
+                    withAnimation(.snappy(duration: 0.22)) { displayed = newCount }
+                } else {
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) { displayed = newCount }
+                }
+            }
     }
 }

--- a/Sources/Teebe/Views/Components.swift
+++ b/Sources/Teebe/Views/Components.swift
@@ -87,23 +87,48 @@ struct StatusLetter: View {
     }
 }
 
-/// A green dot that pulses while a worktree is being written to (live agent).
+/// The worktree's whole story in one dot: a pulsing green while an agent is
+/// working there (or files are being written), steady amber when the agent's
+/// turn ended or stalled — it needs you — and dim gray when no conversation
+/// points at the worktree.
 ///
-/// The pulse is driven off `active` via `onChange`, not a one-shot `onAppear`, so
+/// The pulse is driven off state via `onChange`, not a one-shot `onAppear`, so
 /// a worktree that goes live *after* the row appears starts pulsing, and one that
 /// goes idle stops — the previous version latched whatever state it saw at appear.
 struct LiveDot: View {
+    /// Files are being written in the worktree right now (fs watcher).
     var active: Bool
+    /// What the Claude session pointing at the worktree is doing.
+    var agent: AgentActivityState = .idle
     @State private var animate = false
+
+    /// Amber never pulses — "needs you" is precisely the moment nothing is
+    /// happening, and it outranks stray fs activity (the agent's last writes
+    /// would otherwise flash green for a beat after its turn ended).
+    private var pulsing: Bool { agent == .working || (agent == .idle && active) }
+
+    private var fill: Color {
+        if agent == .needsAttention { return Palette.amber }
+        return pulsing ? Palette.live : Color(white: 0.79)
+    }
 
     var body: some View {
         Circle()
-            .fill(active ? Palette.live : Color(white: 0.79))
+            .fill(fill)
             .frame(width: 7, height: 7)
             .overlay(ring)
-            .animation(.easeInOut(duration: 0.25), value: active)   // fade the fill on state change
+            .animation(.easeInOut(duration: 0.25), value: fill)   // fade the fill on state change
             .onAppear { syncPulse() }
-            .onChange(of: active) { _, _ in syncPulse() }
+            .onChange(of: pulsing) { _, _ in syncPulse() }
+            .help(helpText)
+    }
+
+    private var helpText: String {
+        switch agent {
+        case .working: return "A coding agent is working in this worktree"
+        case .needsAttention: return "The agent finished its turn or stalled — it needs you"
+        case .idle: return active ? "Files are changing in this worktree" : ""
+        }
     }
 
     /// The expanding halo. Hidden entirely while idle so a stopped pulse can't
@@ -113,41 +138,16 @@ struct LiveDot: View {
             .stroke(Palette.live, lineWidth: 2)
             .scaleEffect(animate ? 2.4 : 1)
             .opacity(animate ? 0 : 0.5)
-            .opacity(active ? 1 : 0)
+            .opacity(pulsing ? 1 : 0)
     }
 
     private func syncPulse() {
-        if active {
+        if pulsing {
             withAnimation(.easeOut(duration: 1.6).repeatForever(autoreverses: false)) { animate = true }
         } else {
             withAnimation(.easeOut(duration: 0.2)) { animate = false }
         }
     }
-}
-
-/// Compact chip showing what the AI agent in a worktree is doing: "working"
-/// while a session is mid-turn, "needs you" once its turn ended or it stalled.
-/// Hidden when idle. `onAccent` recolors for the filled active-row background.
-struct AgentBadge: View {
-    var state: AgentActivityState
-    var onAccent: Bool = false
-
-    var body: some View {
-        if state != .idle {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(onAccent ? .white : tint)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1.5)
-                .background(Capsule().fill((onAccent ? Color.white : tint).opacity(0.18)))
-                .help(state == .working
-                    ? "A coding agent is working in this worktree"
-                    : "The agent finished its turn or stalled — it needs you")
-        }
-    }
-
-    private var label: String { state == .working ? "working" : "needs you" }
-    private var tint: Color { state == .working ? Palette.accent : Palette.amber }
 }
 
 // MARK: - Press / hover chrome for compact controls

--- a/Sources/Teebe/Views/WorktreesSection.swift
+++ b/Sources/Teebe/Views/WorktreesSection.swift
@@ -43,7 +43,10 @@ struct WorktreesSection: View {
                     }
                 } else if let active = selector.selectedWorktree {
                     HStack(spacing: 5) {
-                        LiveDot(active: selector.info(for: active).isLive)
+                        // The dot carries the agent state too (amber = needs you),
+                        // so "needs you" stays visible even with the section folded.
+                        LiveDot(active: selector.info(for: active).isLive,
+                                agent: selector.info(for: active).agentState)
                         // Same treatment as the collapsed FILES header's branch label;
                         // the accent colour (+ dot) marks this one as the active worktree.
                         Text(active.branch ?? active.name)
@@ -52,9 +55,6 @@ struct WorktreesSection: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                             .layoutPriority(1)
-                        // Surface the agent chip even with the section collapsed —
-                        // "needs you" must not hide behind a fold.
-                        AgentBadge(state: selector.info(for: active).agentState)
                     }
                 }
             }
@@ -138,7 +138,7 @@ struct WorktreesSection: View {
         // distinct from the filled accent of the committed worktree. Enter commits it.
         let isHighlighted = app.activeSection == .worktrees && selector.highlightedWorktree?.path == worktree.path
         return HStack(spacing: 7) {
-            LiveDot(active: info.isLive)
+            LiveDot(active: info.isLive, agent: info.agentState)
             Image(systemName: "point.3.connected.trianglepath.dotted")
                 .font(.system(size: 11))
                 .foregroundStyle(isActive ? .white : Palette.secondaryText)
@@ -146,7 +146,6 @@ struct WorktreesSection: View {
                 .font(.system(size: 13, weight: .medium))
                 .lineLimit(1)
             Spacer(minLength: 4)
-            AgentBadge(state: info.agentState, onAccent: isActive)
             // "↓0 ↑0" is pure noise — only show the sync arrows once there is
             // something to pull or push.
             if info.hasSync {

--- a/Sources/TeebeCore/AgentStatus.swift
+++ b/Sources/TeebeCore/AgentStatus.swift
@@ -43,11 +43,18 @@ public struct AgentSessionEntry: Equatable, Sendable {
     public var kind: Kind
     public var timestamp: Date
     public var isSidechain: Bool
+    /// The directory the session was operating in when this entry was logged.
+    /// This is the ground truth for *which worktree* the agent is in: a session
+    /// launched in the primary checkout that moves into a linked worktree keeps
+    /// logging under the launch dir's project folder, but its entries' `cwd`
+    /// follows the agent.
+    public var cwd: String?
 
-    public init(kind: Kind, timestamp: Date, isSidechain: Bool) {
+    public init(kind: Kind, timestamp: Date, isSidechain: Bool, cwd: String? = nil) {
         self.kind = kind
         self.timestamp = timestamp
         self.isSidechain = isSidechain
+        self.cwd = cwd
     }
 
     /// Parse one JSONL line; nil for meta lines, malformed JSON, or entries
@@ -74,7 +81,8 @@ public struct AgentSessionEntry: Equatable, Sendable {
         return AgentSessionEntry(
             kind: kind,
             timestamp: timestamp,
-            isSidechain: dict["isSidechain"] as? Bool ?? false
+            isSidechain: dict["isSidechain"] as? Bool ?? false,
+            cwd: dict["cwd"] as? String
         )
     }
 
@@ -136,32 +144,66 @@ public struct AgentSessionScanner: Sendable {
         String(path.map { $0.isASCII && ($0.isLetter || $0.isNumber) ? $0 : "-" })
     }
 
-    /// The agent state for a worktree, judged from the most recently modified
-    /// session file in its project dir.
+    /// The agent state for a single worktree, judged only from sessions logged
+    /// under its own project dir.
     public func state(forWorktreePath path: String, now: Date = Date()) -> AgentActivityState {
-        let dir = projectsRoot.appendingPathComponent(
-            Self.projectDirName(forWorktreePath: path), isDirectory: true)
-        guard let newest = newestSessionFile(in: dir) else { return .idle }
-        // Fast path: a file untouched for the idle window can't be anything else.
-        if now.timeIntervalSince(newest.mtime) >= thresholds.idle { return .idle }
-        return AgentStateDeriver.derive(
-            lastEntry: lastMainChainEntry(in: newest.url), now: now, thresholds: thresholds)
+        states(forWorktreePaths: [path], now: now)[path] ?? .idle
     }
 
-    private func newestSessionFile(in dir: URL) -> (url: URL, mtime: Date)? {
+    /// States for a repo's worktrees, attributing each session to the worktree
+    /// its entries actually ran in (the entry `cwd`), not the directory it was
+    /// launched from. A session started in the primary checkout that then works
+    /// inside a linked worktree logs under the primary's project dir — a purely
+    /// per-dir lookup would pin its "working" badge on the primary.
+    public func states(forWorktreePaths paths: [String], now: Date = Date()) -> [String: AgentActivityState] {
+        var result: [String: AgentActivityState] = [:]
+        for path in paths { result[path] = .idle }
+        // Every fresh session file across every project dir (files idle-old by
+        // mtime can only be idle — skip without reading them).
+        var files: [(launchPath: String, url: URL, mtime: Date)] = []
+        var seen = Set<URL>()
+        for path in paths {
+            let dir = projectsRoot.appendingPathComponent(
+                Self.projectDirName(forWorktreePath: path), isDirectory: true)
+            for file in sessionFiles(in: dir) where now.timeIntervalSince(file.mtime) < thresholds.idle {
+                guard seen.insert(file.url.standardizedFileURL).inserted else { continue }
+                files.append((path, file.url, file.mtime))
+            }
+        }
+        // Oldest first, so when two sessions land on the same worktree the newer
+        // session's verdict wins (the per-dir "newest file wins" rule, kept).
+        for file in files.sorted(by: { $0.mtime < $1.mtime }) {
+            guard let entry = lastMainChainEntry(in: file.url) else { continue }
+            let state = AgentStateDeriver.derive(lastEntry: entry, now: now, thresholds: thresholds)
+            guard state != .idle else { continue }
+            let owner = owningPath(forCwd: entry.cwd, among: paths) ?? file.launchPath
+            result[owner] = state
+        }
+        return result
+    }
+
+    /// The deepest known worktree containing `cwd` — sessions record the exact
+    /// directory they run in, which is often a subdirectory of the worktree.
+    /// nil when `cwd` is missing or outside every known worktree.
+    private func owningPath(forCwd cwd: String?, among paths: [String]) -> String? {
+        guard let cwd else { return nil }
+        return paths
+            .filter { cwd == $0 || cwd.hasPrefix($0 + "/") }
+            .max { $0.count < $1.count }
+    }
+
+    private func sessionFiles(in dir: URL) -> [(url: URL, mtime: Date)] {
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: dir, includingPropertiesForKeys: [.contentModificationDateKey],
             options: [.skipsHiddenFiles]
-        ) else { return nil }
+        ) else { return [] }
         return entries
             .filter { $0.pathExtension == "jsonl" }
-            .compactMap { url -> (URL, Date)? in
+            .compactMap { url -> (url: URL, mtime: Date)? in
                 guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
                       let mtime = values.contentModificationDate else { return nil }
-                return (url, mtime)
+                return (url: url, mtime: mtime)
             }
-            .max { $0.1 < $1.1 }
-            .map { (url: $0.0, mtime: $0.1) }
     }
 
     /// Scan the tail of the file backwards for the last parseable entry that

--- a/Tests/TeebeCoreTests/AgentStatusTests.swift
+++ b/Tests/TeebeCoreTests/AgentStatusTests.swift
@@ -10,37 +10,37 @@ private func iso(_ date: Date) -> String {
     return formatter.string(from: date)
 }
 
-private func humanPromptLine(at date: Date, sidechain: Bool = false) -> String {
+private func humanPromptLine(at date: Date, sidechain: Bool = false, cwd: String = "/Users/k/Documents/CODE/teebe") -> String {
     """
     {"parentUuid":null,"isSidechain":\(sidechain),"type":"user",\
     "message":{"role":"user","content":"hey can u check the product"},\
     "uuid":"u1","timestamp":"\(iso(date))","origin":{"kind":"human"},"promptSource":"typed",\
-    "cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1","gitBranch":"dev"}
+    "cwd":"\(cwd)","sessionId":"s1","gitBranch":"dev"}
     """
 }
 
-private func toolResultLine(at date: Date, sidechain: Bool = false) -> String {
+private func toolResultLine(at date: Date, sidechain: Bool = false, cwd: String = "/Users/k/Documents/CODE/teebe") -> String {
     """
     {"parentUuid":"a1","isSidechain":\(sidechain),"type":"user",\
     "message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"ok"}]},\
-    "uuid":"u2","timestamp":"\(iso(date))","cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1"}
+    "uuid":"u2","timestamp":"\(iso(date))","cwd":"\(cwd)","sessionId":"s1"}
     """
 }
 
-private func assistantToolUseLine(at date: Date, sidechain: Bool = false) -> String {
+private func assistantToolUseLine(at date: Date, sidechain: Bool = false, cwd: String = "/Users/k/Documents/CODE/teebe") -> String {
     """
     {"parentUuid":"u1","isSidechain":\(sidechain),"type":"assistant",\
     "message":{"role":"assistant","content":[{"type":"text","text":"Looking."},\
     {"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]},\
-    "uuid":"a1","timestamp":"\(iso(date))","cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1"}
+    "uuid":"a1","timestamp":"\(iso(date))","cwd":"\(cwd)","sessionId":"s1"}
     """
 }
 
-private func assistantTextLine(at date: Date, sidechain: Bool = false) -> String {
+private func assistantTextLine(at date: Date, sidechain: Bool = false, cwd: String = "/Users/k/Documents/CODE/teebe") -> String {
     """
     {"parentUuid":"u2","isSidechain":\(sidechain),"type":"assistant",\
     "message":{"role":"assistant","content":[{"type":"text","text":"Done — here is the answer."}]},\
-    "uuid":"a2","timestamp":"\(iso(date))","cwd":"/Users/k/Documents/CODE/teebe","sessionId":"s1"}
+    "uuid":"a2","timestamp":"\(iso(date))","cwd":"\(cwd)","sessionId":"s1"}
     """
 }
 
@@ -123,6 +123,15 @@ struct AgentSessionEntryTests {
     func sidechainFlag() throws {
         let entry = try #require(AgentSessionEntry.parse(line: assistantTextLine(at: date, sidechain: true)))
         #expect(entry.isSidechain == true)
+    }
+
+    @Test("cwd is carried through; missing cwd parses to nil")
+    func cwdCarried() throws {
+        let entry = try #require(AgentSessionEntry.parse(
+            line: assistantToolUseLine(at: date, cwd: "/repo/.claude/worktrees/audit/web")))
+        #expect(entry.cwd == "/repo/.claude/worktrees/audit/web")
+        let noCwd = #"{"type":"user","message":{"role":"user","content":"hi"},"uuid":"u9","timestamp":"2026-07-17T10:12:43.312Z"}"#
+        #expect(AgentSessionEntry.parse(line: noCwd)?.cwd == nil)
     }
 }
 
@@ -282,6 +291,96 @@ struct AgentSessionScannerTests {
         let fx = try makeFixture()
         try write(metaLines, to: fx.dir.appendingPathComponent("s1.jsonl"))
         #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+}
+
+// MARK: - Scanner worktree attribution (entry cwd, not launch dir)
+
+@Suite("AgentSessionScanner worktree attribution")
+struct AgentScannerAttributionTests {
+    let now = Date(timeIntervalSince1970: 1_784_000_000)
+    // The linked worktree lives *under* the primary (teebe's own layout for
+    // agent-created worktrees), so attribution must pick the deepest match.
+    let primary = "/Users/k/Documents/CODE/teebe"
+    let linked = "/Users/k/Documents/CODE/teebe/.claude/worktrees/audit"
+    var paths: [String] { [primary, linked] }
+
+    struct Fixture {
+        var scanner: AgentSessionScanner
+        var root: URL
+        var primaryDir: URL
+    }
+
+    func makeFixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("teebe-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let primaryDir = root.appendingPathComponent(
+            AgentSessionScanner.projectDirName(forWorktreePath: primary), isDirectory: true)
+        try FileManager.default.createDirectory(at: primaryDir, withIntermediateDirectories: true)
+        let scanner = AgentSessionScanner(
+            projectsRoot: root, thresholds: AgentStatusThresholds(stall: 600, idle: 1_800))
+        return Fixture(scanner: scanner, root: root, primaryDir: primaryDir)
+    }
+
+    func write(_ lines: [String], to url: URL, mtime: Date) throws {
+        try lines.joined(separator: "\n").appending("\n").write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+    }
+
+    @Test("a session launched in the primary but running inside a linked worktree badges the worktree")
+    func sessionFollowsCwd() throws {
+        let fx = try makeFixture()
+        // Entries' cwd is a *subdirectory* of the linked worktree, as real
+        // sessions record (the agent cd'd into web/).
+        try write(
+            [assistantToolUseLine(at: now.addingTimeInterval(-5), cwd: linked + "/web")],
+            to: fx.primaryDir.appendingPathComponent("s1.jsonl"), mtime: now.addingTimeInterval(-5))
+        let states = fx.scanner.states(forWorktreePaths: paths, now: now)
+        #expect(states[linked] == .working)
+        #expect(states[primary] == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("a cwd outside every known worktree falls back to the launch dir")
+    func unknownCwdFallsBack() throws {
+        let fx = try makeFixture()
+        try write(
+            [assistantToolUseLine(at: now.addingTimeInterval(-5), cwd: "/somewhere/else")],
+            to: fx.primaryDir.appendingPathComponent("s1.jsonl"), mtime: now.addingTimeInterval(-5))
+        let states = fx.scanner.states(forWorktreePaths: paths, now: now)
+        #expect(states[primary] == .working)
+        #expect(states[linked] == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("sessions for different worktrees under one project dir badge independently")
+    func concurrentSessions() throws {
+        let fx = try makeFixture()
+        try write(
+            [assistantTextLine(at: now.addingTimeInterval(-60), cwd: primary)],
+            to: fx.primaryDir.appendingPathComponent("s1.jsonl"), mtime: now.addingTimeInterval(-60))
+        try write(
+            [assistantToolUseLine(at: now.addingTimeInterval(-5), cwd: linked)],
+            to: fx.primaryDir.appendingPathComponent("s2.jsonl"), mtime: now.addingTimeInterval(-5))
+        let states = fx.scanner.states(forWorktreePaths: paths, now: now)
+        #expect(states[primary] == .needsAttention)
+        #expect(states[linked] == .working)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("for the same worktree the newer session's verdict wins")
+    func newerSessionWins() throws {
+        let fx = try makeFixture()
+        try write(
+            [assistantTextLine(at: now.addingTimeInterval(-900), cwd: linked)],
+            to: fx.primaryDir.appendingPathComponent("old.jsonl"), mtime: now.addingTimeInterval(-900))
+        try write(
+            [assistantToolUseLine(at: now.addingTimeInterval(-5), cwd: linked)],
+            to: fx.primaryDir.appendingPathComponent("new.jsonl"), mtime: now.addingTimeInterval(-5))
+        let states = fx.scanner.states(forWorktreePaths: paths, now: now)
+        #expect(states[linked] == .working)
         try? FileManager.default.removeItem(at: fx.root)
     }
 }

--- a/Tests/TeebeTests/AgentStatusModelTests.swift
+++ b/Tests/TeebeTests/AgentStatusModelTests.swift
@@ -22,7 +22,7 @@ struct AgentStatusModelTests {
         return SelectorModel(environment: makeTestEnvironment(
             git: git,
             makeWatcher: box.map { b in { b.make() } },
-            agentStatus: states.provider,
+            agentStatuses: states.provider,
             agentProjectsRootPath: projectsRoot,
             notify: spy.record
         ))

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -135,7 +135,7 @@ final class WatcherBox {
 // MARK: - Fake agent status
 
 /// Scriptable per-worktree agent states for tests; the closure form feeds
-/// `AppEnvironment.agentStatus`.
+/// `AppEnvironment.agentStatuses`.
 final class FakeAgentStates: @unchecked Sendable {
     private let lock = NSLock()
     private var states: [String: AgentActivityState] = [:]
@@ -145,8 +145,10 @@ final class FakeAgentStates: @unchecked Sendable {
         set { lock.lock(); states[path] = newValue; lock.unlock() }
     }
 
-    var provider: @Sendable (String, Date) -> AgentActivityState {
-        { [self] path, _ in self[path] ?? .idle }
+    var provider: @Sendable ([String], Date) -> [String: AgentActivityState] {
+        { [self] paths, _ in
+            Dictionary(uniqueKeysWithValues: paths.map { ($0, self[$0] ?? .idle) })
+        }
     }
 }
 
@@ -176,7 +178,7 @@ func makeTestEnvironment(
     store: AppStateStore? = nil,
     monitor: WorktreeActivityMonitor = WorktreeActivityMonitor(),
     makeWatcher: (@MainActor () -> FileSystemWatcher)? = nil,
-    agentStatus: (@Sendable (String, Date) -> AgentActivityState)? = nil,
+    agentStatuses: (@Sendable ([String], Date) -> [String: AgentActivityState])? = nil,
     agentProjectsRootPath: String? = nil,
     notify: (@MainActor (String, String) -> Void)? = nil
 ) -> AppEnvironment {
@@ -190,7 +192,7 @@ func makeTestEnvironment(
         store: store ?? AppStateStore(url: storeURL),
         activityMonitor: monitor,
         makeWatcher: makeWatcher ?? { FakeWatcher() },
-        agentStatus: agentStatus ?? { _, _ in .idle },
+        agentStatuses: agentStatuses ?? { _, _ in [:] },
         agentProjectsRootPath: agentProjectsRootPath,
         notify: notify ?? { _, _ in }
     )

--- a/Tests/TeebeTests/UserStoryTests.swift
+++ b/Tests/TeebeTests/UserStoryTests.swift
@@ -22,6 +22,20 @@ struct RepoStoryTests {
         #expect(app.repositories.count == 1)
     }
 
+    @Test("A3b: re-adding a tracked repo selects it instead of doing nothing")
+    func a3bReAddSelects() async {
+        let git = FakeGitClient()
+        git.worktreesResult = [Worktree(path: "/a", branch: "main", isPrimary: true)]
+        let app = AppModel(environment: makeTestEnvironment(git: git))
+        _ = await app.addRepository(path: "/a")
+        _ = await app.addRepository(path: "/b")
+        #expect(app.selector.selectedRepo?.path == "/b")
+        // Picking /a again from the add panel must switch back to it.
+        #expect(await app.addRepository(path: "/a") == false)
+        #expect(app.repositories.count == 2)
+        #expect(app.selector.selectedRepo?.path == "/a")
+    }
+
     @Test("A4: removing a repo persists the removal")
     func a4RemovePersists() async {
         let git = FakeGitClient()

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.5.0}"
+APP_VERSION="${APP_VERSION:-0.5.1}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with


### PR DESCRIPTION
Patch release: re-add-folder selection, worktree-switch count animation, agent-status attribution, agent chip folded into the worktree dot. See CHANGELOG 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTRDiVsHSdMq1U4MzRLGfT