### PR TITLE
Low-power mode, watcher/scanner CPU fixes, launch-crash fix (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to teebe are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] - 2026-08-07
+
+### Added
+- **Low-power mode.** When teebe's window is covered, every file watcher stops
+  and the app idles at near-zero CPU — while "agent needs you" notifications
+  keep arriving, now instantly, via a tiny Claude Code hook (`notifyutil` ping
+  on turn end). teebe offers to add the hook once at launch; declining keeps
+  everything working the old way.
+
+### Fixed
+- Under a continuous stream of agent writes the tree could stop updating until
+  the burst ended (the debounce never fired). Updates now land at least every
+  couple of seconds no matter how busy the agents are.
+- A session log whose scanned tail started mid-emoji (or mid-character) was
+  silently read as "no agent" — the worktree dot went gray while the agent was
+  actually working.
+
+### Changed
+- Session-log scanning is lighter: timestamp parsers are built once instead of
+  per line, and only the last relevant lines of each log are decoded.
+
 ## [0.5.1] - 2026-08-04
 
 ### Fixed

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -100,9 +100,17 @@ private struct RootWindowContent: View {
         RootView(app: app, preview: preview)
             .task {
                 await app.bootstrap()
+                app.setUpHookIfNeeded()            // one-time Claude Code hook offer
                 if whatsNew.presentIfUpdated() {   // greet once after an update
                     openWindow(id: WindowID.whatsNew)
                 }
+            }
+            // Covered window → low-power mode (stop FSEvents, ride the hook ping);
+            // visible again → restart watchers and catch up.
+            .onReceive(NotificationCenter.default.publisher(
+                for: NSApplication.didChangeOcclusionStateNotification
+            )) { _ in
+                app.setBackgrounded(!NSApp.occlusionState.contains(.visible))
             }
     }
 }

--- a/Sources/Teebe/ViewModels/AppEnvironment.swift
+++ b/Sources/Teebe/ViewModels/AppEnvironment.swift
@@ -22,6 +22,9 @@ struct AppEnvironment {
     let agentProjectsRootPath: String?
     /// Posts a user-facing notification (title, body).
     let notify: @MainActor (_ title: String, _ body: String) -> Void
+    /// Factory for the darwin-notification listener the Claude Code hook pings
+    /// (`notifyutil -p dev.teebe.agent`). Overridable with a fake in tests.
+    let makeAgentPingListener: @MainActor () -> AgentPingListening
 
     init(
         git: GitClient,
@@ -32,7 +35,8 @@ struct AppEnvironment {
         makeWatcher: @escaping @MainActor () -> FileSystemWatcher,
         agentStatuses: @escaping @Sendable ([String], Date) -> [String: AgentActivityState] = { _, _ in [:] },
         agentProjectsRootPath: String? = nil,
-        notify: @escaping @MainActor (String, String) -> Void = { _, _ in }
+        notify: @escaping @MainActor (String, String) -> Void = { _, _ in },
+        makeAgentPingListener: @escaping @MainActor () -> AgentPingListening = { DarwinAgentPingListener() }
     ) {
         self.git = git
         self.opener = opener
@@ -43,6 +47,7 @@ struct AppEnvironment {
         self.agentStatuses = agentStatuses
         self.agentProjectsRootPath = agentProjectsRootPath
         self.notify = notify
+        self.makeAgentPingListener = makeAgentPingListener
     }
 
     var worktreeService: WorktreeService { WorktreeService(git: git) }

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -75,13 +75,9 @@ final class AppModel {
             ?? repositories.first
         isHydrating = false
         guard let target else { return }
-        await selector.selectRepo(target)   // focuses the primary worktree
-        // Restore the last selected worktree if it still exists (else keep primary).
-        if let wtPath = lastWorktreePath,
-           selector.selectedWorktree?.path != wtPath,
-           let saved = selector.worktrees.first(where: { $0.path == wtPath }) {
-            await selector.selectWorktree(saved)
-        }
+        // One shot: the saved worktree (when it still exists) is selected directly,
+        // never primary-then-saved — the double load crashed the first layout pass.
+        await selector.selectRepo(target, preferredWorktreePath: lastWorktreePath)
     }
 
     // MARK: - Low-power mode + Claude Code hook

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -84,6 +84,60 @@ final class AppModel {
         }
     }
 
+    // MARK: - Low-power mode + Claude Code hook
+
+    /// Mirror window occlusion into the selector's low-power mode: covered window
+    /// → stop all FSEvents streams and ride on the hook ping.
+    func setBackgrounded(_ backgrounded: Bool) {
+        Task { await selector.setLowPower(backgrounded) }
+    }
+
+    /// What to do about the Claude Code ping hook at launch.
+    enum HookSetupAction: Equatable { case ask, repair, none }
+
+    static func hookSetupAction(installed: Bool, response: String?) -> HookSetupAction {
+        if installed { return .none }
+        switch response {
+        case "accepted": return .repair   // user opted in once — restore silently
+        case "declined": return .none     // user said no — never touch, never re-ask
+        default: return .ask
+        }
+    }
+
+    /// Launch-time hook setup: offer once, then keep the user's choice. An
+    /// accepted hook that later disappears (settings rewritten by another tool)
+    /// is repaired without asking again.
+    func setUpHookIfNeeded() {
+        let action = Self.hookSetupAction(
+            installed: ClaudeHookInstaller.isInstalled(),
+            response: state.hookOfferResponse)
+        switch action {
+        case .none:
+            return
+        case .repair:
+            try? ClaudeHookInstaller.install()
+        case .ask:
+            let alert = NSAlert()
+            alert.messageText = "Notify instantly, use less battery?"
+            alert.informativeText = """
+            teebe can add a tiny hook to Claude Code (~/.claude/settings.json) that \
+            pings it the moment an agent finishes. With the hook, teebe stops all \
+            background file watching while its window is covered — near-zero CPU — \
+            and "agent needs you" notifications become instant. The hook is one \
+            `notifyutil` command; it sends no data anywhere.
+            """
+            alert.addButton(withTitle: "Add Hook")
+            alert.addButton(withTitle: "No Thanks")
+            let accepted = alert.runModal() == .alertFirstButtonReturn
+            state.hookOfferResponse = accepted ? "accepted" : "declined"
+            try? environment.store.save(state)
+            if accepted {
+                do { try ClaudeHookInstaller.install() }
+                catch { setError("Couldn't update ~/.claude/settings.json — hook not added.") }
+            }
+        }
+    }
+
     /// Add a repository after verifying it is a git repo (it must answer
     /// `worktree list`). Persists on success.
     @discardableResult

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -122,9 +122,12 @@ final class SelectorModel {
         onSelectionChange?()
     }
 
-    /// Select a repo: discover its worktrees + branches, then focus the primary
-    /// worktree.
-    func selectRepo(_ repo: Repository) async {
+    /// Select a repo: discover its worktrees + branches, then focus
+    /// `preferredWorktreePath` when it still exists, else the primary worktree.
+    /// Restoring a saved selection goes through the preference rather than a
+    /// primary-then-saved double load: two full tree loads inside the window's
+    /// first layout pass escalate into an AppKit constraint-loop crash at launch.
+    func selectRepo(_ repo: Repository, preferredWorktreePath: String? = nil) async {
         selectedRepo = repo
         await startRepoWatching(repo)
         startAgentWatching()
@@ -138,8 +141,11 @@ final class SelectorModel {
             errorMessage = WorktreeModel.describe(error)
         }
         await refreshWorktreeInfo()
-        if let primary = worktrees.first(where: { $0.isPrimary }) ?? worktrees.first {
-            await selectWorktree(primary)
+        let target = preferredWorktreePath.flatMap { preferred in
+            worktrees.first { $0.path == preferred }
+        } ?? worktrees.first(where: { $0.isPrimary }) ?? worktrees.first
+        if let target {
+            await selectWorktree(target)
         }
         onSelectionChange?()
     }

--- a/Sources/Teebe/ViewModels/SelectorModel.swift
+++ b/Sources/Teebe/ViewModels/SelectorModel.swift
@@ -55,6 +55,16 @@ final class SelectorModel {
     /// Periodic re-derive so purely time-based transitions (stall, idle-out)
     /// happen even when no session log is being written.
     private var agentPollTask: Task<Void, Never>?
+    /// Darwin-notification listener for the Claude Code hook ping — the push
+    /// signal that keeps badges and notifications instant even in low power.
+    private var agentPingListener: AgentPingListening?
+    /// Low-power mode (window occluded): every FSEvents watcher is stopped and
+    /// the app rides on the hook ping plus a slow poll. See `setLowPower`.
+    private(set) var isLowPower = false
+    /// Poll cadences for the time-only agent transitions (stall/idle-out).
+    /// Vars so tests can shrink them.
+    var agentPollInterval: TimeInterval = 30
+    var lowPowerAgentPollInterval: TimeInterval = 120
     /// One-shot follow-up scheduled while any live dot is lit, so `isLive` expires
     /// shortly after the busy window lapses instead of latching until the next
     /// event (a latched dot keeps a repeat-forever pulse animation burning CPU).
@@ -296,29 +306,75 @@ final class SelectorModel {
     }
 
     /// Watch the Claude projects root (session logs live outside the repo, so the
-    /// repo watchers never see them) and poll slowly for time-only transitions.
+    /// repo watchers never see them), listen for the hook ping, and poll slowly
+    /// for time-only transitions.
     private func startAgentWatching() {
         stopAgentWatching()
-        guard let root = environment.agentProjectsRootPath else { return }
-        let watcher = environment.makeWatcher()
-        watcher.start(paths: [root], debounce: 1.0) { [weak self] _ in
-            Task { @MainActor in await self?.handleAgentWatchEvent() }
+        guard environment.agentProjectsRootPath != nil else { return }
+        startAgentWatcher()
+        let listener = environment.makeAgentPingListener()
+        listener.start { [weak self] in
+            Task { @MainActor in await self?.refreshAgentStates() }
         }
-        agentWatcher = watcher
+        agentPingListener = listener
         agentPollTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(30))
+                guard let interval = self?.currentAgentPollInterval else { return }
+                try? await Task.sleep(for: .seconds(interval))
                 guard !Task.isCancelled else { return }
                 await self?.refreshAgentStates()
             }
         }
     }
 
+    /// Just the FSEvents stream over the projects root — the part of agent
+    /// watching that low power turns off (the ping and slow poll stay on).
+    private func startAgentWatcher() {
+        agentWatcher?.stop()
+        agentWatcher = nil
+        guard !isLowPower, let root = environment.agentProjectsRootPath else { return }
+        let watcher = environment.makeWatcher()
+        watcher.start(paths: [root], debounce: 1.0) { [weak self] _ in
+            Task { @MainActor in await self?.handleAgentWatchEvent() }
+        }
+        agentWatcher = watcher
+    }
+
+    private var currentAgentPollInterval: TimeInterval {
+        isLowPower ? lowPowerAgentPollInterval : agentPollInterval
+    }
+
     private func stopAgentWatching() {
         agentWatcher?.stop()
         agentWatcher = nil
+        agentPingListener?.stop()
+        agentPingListener = nil
         agentPollTask?.cancel()
         agentPollTask = nil
+    }
+
+    // MARK: - Low-power mode (window occluded)
+
+    /// With the window occluded nobody is looking at the tree, so live FSEvents
+    /// streams (worktree, repo git dir, projects root) only burn CPU: with N busy
+    /// agents they wake the app about once a second. Low power stops them all and
+    /// relies on the hook ping (instant, push) plus the slow poll (stall/idle),
+    /// so "Agent needs you" notifications still fire while backgrounded. Exiting
+    /// restarts the watchers and re-derives everything missed.
+    func setLowPower(_ on: Bool) async {
+        guard on != isLowPower else { return }
+        isLowPower = on
+        if on {
+            repoWatcher?.stop()
+            agentWatcher?.stop()
+            agentWatcher = nil
+            worktree.pauseWatching()
+        } else {
+            if let repo = selectedRepo { await startRepoWatching(repo) }
+            startAgentWatcher()
+            await worktree.resumeWatching()
+            await refreshWorktrees()
+        }
     }
 
     /// A coalesced batch of session-log writes — re-derive the badges.

--- a/Sources/Teebe/ViewModels/WorktreeModel.swift
+++ b/Sources/Teebe/ViewModels/WorktreeModel.swift
@@ -152,6 +152,20 @@ final class WorktreeModel {
         self.watcher = watcher
     }
 
+    /// Low power: drop the worktree's FSEvents stream (the busiest watcher — it
+    /// spans the whole tree). `resumeWatching` restores it and refreshes to catch
+    /// anything written while paused.
+    func pauseWatching() {
+        watcher?.stop()
+        watcher = nil
+    }
+
+    func resumeWatching() async {
+        guard let worktreePath, watcher == nil else { return }
+        startWatching(worktreePath)
+        await refresh()
+    }
+
     /// Handle a file-watch event for the active worktree: record *external* activity
     /// (skipping our own recent writes), notify the owner, then refresh. Synchronous
     /// and parameterized so it is unit-testable without real FSEvents.

--- a/Sources/TeebeCore/AgentStatus.swift
+++ b/Sources/TeebeCore/AgentStatus.swift
@@ -86,13 +86,21 @@ public struct AgentSessionEntry: Equatable, Sendable {
         )
     }
 
+    // Built once — ISO8601DateFormatter is expensive to construct and thread-safe,
+    // and this parser runs for every scanned session-log line.
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+    private static let plainFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
     private static func parseTimestamp(_ string: String) -> Date? {
-        let fractional = ISO8601DateFormatter()
-        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = fractional.date(from: string) { return date }
-        let plain = ISO8601DateFormatter()
-        plain.formatOptions = [.withInternetDateTime]
-        return plain.date(from: string)
+        fractionalFormatter.date(from: string) ?? plainFormatter.date(from: string)
     }
 }
 
@@ -120,16 +128,18 @@ public enum AgentStateDeriver {
 public struct AgentSessionScanner: Sendable {
     public var projectsRoot: URL
     public var thresholds: AgentStatusThresholds
-
     /// How much of the tail of a session file is scanned for the last entry.
-    private static let tailBytes = 256 * 1_024
+    /// Injectable so tests can exercise the window boundary with small files.
+    public var tailBytes: Int
 
     public init(
         projectsRoot: URL = AgentSessionScanner.defaultProjectsRoot,
-        thresholds: AgentStatusThresholds = AgentStatusThresholds()
+        thresholds: AgentStatusThresholds = AgentStatusThresholds(),
+        tailBytes: Int = 256 * 1_024
     ) {
         self.projectsRoot = projectsRoot
         self.thresholds = thresholds
+        self.tailBytes = tailBytes
     }
 
     public static var defaultProjectsRoot: URL {
@@ -208,19 +218,32 @@ public struct AgentSessionScanner: Sendable {
 
     /// Scan the tail of the file backwards for the last parseable entry that
     /// belongs to the main conversation (sidechains are subagent chatter).
+    ///
+    /// Lines are located and decoded individually, from the end: a tail window
+    /// that opens mid-multibyte-character (or mid-line) only invalidates that
+    /// first truncated line instead of poisoning a whole-buffer decode, and the
+    /// scan stops at the first hit instead of materializing every line of the
+    /// window when only the last one or two matter.
     private func lastMainChainEntry(in url: URL) -> AgentSessionEntry? {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         guard let size = try? handle.seekToEnd() else { return nil }
-        let offset = size > UInt64(Self.tailBytes) ? size - UInt64(Self.tailBytes) : 0
+        let offset = size > UInt64(tailBytes) ? size - UInt64(tailBytes) : 0
         guard (try? handle.seek(toOffset: offset)) != nil,
-              let data = try? handle.readToEnd(),
-              let text = String(data: data, encoding: .utf8)
+              let data = try? handle.readToEnd(), !data.isEmpty
         else { return nil }
-        for line in text.split(separator: "\n").reversed() {
-            if let entry = AgentSessionEntry.parse(line: String(line)), !entry.isSidechain {
+        let newline = UInt8(ascii: "\n")
+        var end = data.endIndex
+        while end > data.startIndex {
+            let start = data[data.startIndex..<end].lastIndex(of: newline).map { $0 + 1 }
+                ?? data.startIndex
+            if start < end,
+               let line = String(data: data[start..<end], encoding: .utf8),
+               let entry = AgentSessionEntry.parse(line: line),
+               !entry.isSidechain {
                 return entry
             }
+            end = start > data.startIndex ? start - 1 : data.startIndex
         }
         return nil
     }

--- a/Sources/TeebeCore/AppStateStore.swift
+++ b/Sources/TeebeCore/AppStateStore.swift
@@ -45,6 +45,10 @@ public struct AppState: Codable, Equatable, Sendable {
     /// The app version we last showed the "What's New" window for. Optional so older
     /// state files decode; `nil` means "never shown" (treated as a fresh install).
     public var lastSeenVersion: String?
+    /// The user's answer to the one-time Claude Code hook offer: "accepted" (keep
+    /// the hook repaired silently), "declined" (never ask again, never touch the
+    /// settings), nil (not asked yet). Optional so older state files decode.
+    public var hookOfferResponse: String?
 
     public init(
         repositories: [PersistedRepository] = [],
@@ -54,7 +58,8 @@ public struct AppState: Codable, Equatable, Sendable {
         lastSelectedRepoPath: String? = nil,
         lastSelectedWorktreePath: String? = nil,
         layoutByRepo: [String: SectionLayout]? = nil,
-        lastSeenVersion: String? = nil
+        lastSeenVersion: String? = nil,
+        hookOfferResponse: String? = nil
     ) {
         self.repositories = repositories
         self.showChangedOnly = showChangedOnly
@@ -64,6 +69,7 @@ public struct AppState: Codable, Equatable, Sendable {
         self.lastSelectedWorktreePath = lastSelectedWorktreePath
         self.layoutByRepo = layoutByRepo
         self.lastSeenVersion = lastSeenVersion
+        self.hookOfferResponse = hookOfferResponse
     }
 }
 

--- a/Sources/TeebeCore/ClaudeHooks.swift
+++ b/Sources/TeebeCore/ClaudeHooks.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Installs teebe's ping hook into Claude Code's user settings, and names the
+/// darwin-notification channel both sides share.
+///
+/// The hook is push instead of poll: Claude Code runs `notifyutil -p` at the
+/// moments teebe cares about, so the app can idle in the background (no FSEvents
+/// stream over `~/.claude/projects`, no fast poll) and still badge/notify the
+/// instant an agent finishes. `notifyutil` is a stock macOS binary; the ping
+/// carries no payload and costs microseconds.
+public enum ClaudeHookInstaller {
+    /// The darwin-notification channel (`notifyutil -p <channel>`).
+    public static let channel = "dev.teebe.agent"
+    public static let pingCommand = "notifyutil -p \(channel)"
+    /// Hook events that mark the transitions teebe surfaces: the turn ending
+    /// (Stop), the agent asking for the user (Notification), and the user
+    /// answering (UserPromptSubmit — clears a "needs you" badge promptly).
+    public static let events = ["Stop", "Notification", "UserPromptSubmit"]
+
+    public static var defaultSettingsURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("settings.json")
+    }
+
+    public enum InstallError: Error {
+        /// The settings file exists but is not valid JSON — refuse to touch it.
+        case unreadableSettings
+    }
+
+    /// Whether every event already carries the teebe ping.
+    public static func isInstalled(in settings: [String: Any]) -> Bool {
+        let hooks = settings["hooks"] as? [String: Any] ?? [:]
+        return events.allSatisfy { event in
+            ((hooks[event] as? [[String: Any]]) ?? []).contains(where: groupHasPing)
+        }
+    }
+
+    /// A copy of `settings` with the ping hook merged into every event that lacks
+    /// it, preserving all other keys and existing hooks. nil when fully installed.
+    public static func settingsInstallingPing(into settings: [String: Any]) -> [String: Any]? {
+        guard !isInstalled(in: settings) else { return nil }
+        var result = settings
+        var hooks = settings["hooks"] as? [String: Any] ?? [:]
+        for event in events {
+            var groups = hooks[event] as? [[String: Any]] ?? []
+            guard !groups.contains(where: groupHasPing) else { continue }
+            groups.append(["hooks": [["type": "command", "command": pingCommand]]])
+            hooks[event] = groups
+        }
+        result["hooks"] = hooks
+        return result
+    }
+
+    public static func isInstalled(at url: URL = defaultSettingsURL) -> Bool {
+        guard let data = try? Data(contentsOf: url),
+              let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return false }
+        return isInstalled(in: json)
+    }
+
+    /// Merge the ping hook into the settings file, creating it when absent.
+    /// Returns false when it was already fully installed. A file that exists but
+    /// can't be parsed as a JSON object throws and is left byte-for-byte intact.
+    @discardableResult
+    public static func install(at url: URL = defaultSettingsURL) throws -> Bool {
+        var settings: [String: Any] = [:]
+        if FileManager.default.fileExists(atPath: url.path) {
+            guard let data = try? Data(contentsOf: url),
+                  let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            else { throw InstallError.unreadableSettings }
+            settings = json
+        }
+        guard let merged = settingsInstallingPing(into: settings) else { return false }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: merged, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+        return true
+    }
+
+    private static func groupHasPing(_ group: [String: Any]) -> Bool {
+        ((group["hooks"] as? [[String: Any]]) ?? [])
+            .contains { ($0["command"] as? String)?.contains(channel) == true }
+    }
+}
+
+// MARK: - Ping listener
+
+/// Listens for the darwin notification the Claude Code hook pings.
+public protocol AgentPingListening {
+    func start(_ handler: @escaping @Sendable () -> Void)
+    func stop()
+}
+
+/// Live listener on the darwin notify center — kernel-delivered, no polling, no
+/// file descriptors held open. (`notify_register_dispatch` isn't exposed to
+/// Swift; the CF darwin center receives the same `notifyutil -p` posts.)
+public final class DarwinAgentPingListener: AgentPingListening, @unchecked Sendable {
+    private let name: String
+    private var handler: (@Sendable () -> Void)?
+    private var isObserving = false
+
+    public init(name: String = ClaudeHookInstaller.channel) {
+        self.name = name
+    }
+
+    deinit { stop() }
+
+    public func start(_ handler: @escaping @Sendable () -> Void) {
+        stop()
+        self.handler = handler
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        // C callback — no captures allowed; recover self from the observer pointer.
+        CFNotificationCenterAddObserver(center, observer, { _, observer, _, _, _ in
+            guard let observer else { return }
+            let listener = Unmanaged<DarwinAgentPingListener>.fromOpaque(observer).takeUnretainedValue()
+            listener.handler?()
+        }, name as CFString, nil, .deliverImmediately)
+        isObserving = true
+    }
+
+    public func stop() {
+        guard isObserving else { return }
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterRemoveEveryObserver(center, Unmanaged.passUnretained(self).toOpaque())
+        isObserving = false
+        handler = nil
+    }
+}

--- a/Sources/TeebeCore/FSEventsWatcher.swift
+++ b/Sources/TeebeCore/FSEventsWatcher.swift
@@ -12,8 +12,15 @@ public final class FSEventsWatcher: FileSystemWatcher, @unchecked Sendable {
     // Coalescing state — accessed only on `queue`.
     var handler: (@Sendable ([String]) -> Void)?
     var debounceInterval: TimeInterval = 0.2
+    /// Upper bound on how long a flush can be pushed back by fresh events. A pure
+    /// trailing debounce starves under continuous writes (exactly the busy-agent
+    /// case): every event re-arms the timer and nothing flushes until the burst
+    /// ends. The cap forces a flush at least this often while events keep coming.
+    var maxCoalesceInterval: TimeInterval = 2.0
     private var pending = Set<String>()
     private var flushWorkItem: DispatchWorkItem?
+    /// When the oldest still-unflushed event arrived (nil when `pending` is empty).
+    private var firstPendingAt: DispatchTime?
 
     public private(set) var isWatching = false
 
@@ -78,6 +85,7 @@ public final class FSEventsWatcher: FileSystemWatcher, @unchecked Sendable {
             self?.flushWorkItem?.cancel()
             self?.flushWorkItem = nil
             self?.pending.removeAll()
+            self?.firstPendingAt = nil
         }
     }
 
@@ -86,16 +94,22 @@ public final class FSEventsWatcher: FileSystemWatcher, @unchecked Sendable {
     func ingest(_ paths: [String]) {
         queue.async { [weak self] in
             guard let self else { return }
+            let now = DispatchTime.now()
+            if self.pending.isEmpty { self.firstPendingAt = now }
             self.pending.formUnion(paths)
             self.flushWorkItem?.cancel()
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
                 let batch = Array(self.pending)
                 self.pending.removeAll()
+                self.firstPendingAt = nil
                 if !batch.isEmpty { self.handler?(batch) }
             }
             self.flushWorkItem = work
-            self.queue.asyncAfter(deadline: .now() + self.debounceInterval, execute: work)
+            // Trailing debounce, but never past the cap measured from the oldest
+            // pending event — a steady write stream still flushes periodically.
+            let cap = (self.firstPendingAt ?? now) + self.maxCoalesceInterval
+            self.queue.asyncAfter(deadline: min(now + self.debounceInterval, cap), execute: work)
         }
     }
 }

--- a/Tests/TeebeCoreTests/AgentStatusTests.swift
+++ b/Tests/TeebeCoreTests/AgentStatusTests.swift
@@ -194,7 +194,7 @@ struct AgentSessionScannerTests {
         var dir: URL
     }
 
-    func makeFixture() throws -> Fixture {
+    func makeFixture(tailBytes: Int = 256 * 1_024) throws -> Fixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("teebe-tests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -202,7 +202,8 @@ struct AgentSessionScannerTests {
             AgentSessionScanner.projectDirName(forWorktreePath: worktreePath), isDirectory: true)
         try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
         let scanner = AgentSessionScanner(
-            projectsRoot: root, thresholds: AgentStatusThresholds(stall: 600, idle: 1_800))
+            projectsRoot: root, thresholds: AgentStatusThresholds(stall: 600, idle: 1_800),
+            tailBytes: tailBytes)
         return Fixture(scanner: scanner, root: root, dir: projectDir)
     }
 
@@ -283,6 +284,26 @@ struct AgentSessionScannerTests {
             [assistantTextLine(at: now.addingTimeInterval(-7_200))],
             to: fx.dir.appendingPathComponent("s1.jsonl"), mtime: now.addingTimeInterval(-7_200))
         #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .idle)
+        try? FileManager.default.removeItem(at: fx.root)
+    }
+
+    @Test("a tail window that opens mid-multibyte-character still parses the entries after it")
+    func tailBoundaryMidCharacter() throws {
+        // First line is emoji ballast; the real entry is the final line. Pick a
+        // tail size that (a) covers the whole entry line and (b) makes the tail
+        // offset land strictly inside one 4-byte emoji — a whole-buffer UTF-8
+        // decode of such a tail fails, which must not blank the verdict.
+        let entryLine = assistantToolUseLine(at: now.addingTimeInterval(-5))
+        let ballast = String(repeating: "🦊", count: 300)
+        let content = ballast + "\n" + entryLine + "\n"
+        let size = content.utf8.count
+        var tail = entryLine.utf8.count + 16
+        while (size - tail) % 4 != 2 { tail += 1 }   // offset 2 bytes into an emoji
+
+        let fx = try makeFixture(tailBytes: tail)
+        let url = fx.dir.appendingPathComponent("s1.jsonl")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        #expect(fx.scanner.state(forWorktreePath: worktreePath, now: now) == .working)
         try? FileManager.default.removeItem(at: fx.root)
     }
 

--- a/Tests/TeebeCoreTests/ClaudeHookInstallerTests.swift
+++ b/Tests/TeebeCoreTests/ClaudeHookInstallerTests.swift
@@ -56,15 +56,15 @@ struct ClaudeHookInstallerTests {
     @Test("a partially installed settings gains only the missing events")
     func partialInstall() throws {
         var settings = try #require(ClaudeHookInstaller.settingsInstallingPing(into: [:]))
-        var hooks = settings["hooks"] as! [String: Any]
+        var hooks = try #require(settings["hooks"] as? [String: Any])
         hooks["UserPromptSubmit"] = nil   // drop one event
         settings["hooks"] = hooks
         #expect(!ClaudeHookInstaller.isInstalled(in: settings))
 
         let merged = try #require(ClaudeHookInstaller.settingsInstallingPing(into: settings))
-        let mergedHooks = merged["hooks"] as! [String: Any]
+        let mergedHooks = try #require(merged["hooks"] as? [String: Any])
         // Stop was already installed: still exactly one teebe group there.
-        let stop = mergedHooks["Stop"] as! [[String: Any]]
+        let stop = try #require(mergedHooks["Stop"] as? [[String: Any]])
         let teebeStopGroups = stop.filter {
             (($0["hooks"] as? [[String: Any]]) ?? [])
                 .contains { ($0["command"] as? String) == ClaudeHookInstaller.pingCommand }

--- a/Tests/TeebeCoreTests/ClaudeHookInstallerTests.swift
+++ b/Tests/TeebeCoreTests/ClaudeHookInstallerTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import TeebeCore
+
+@Suite("ClaudeHookInstaller")
+struct ClaudeHookInstallerTests {
+    // MARK: - Pure merge logic
+
+    @Test("empty settings gain the ping hook on every event")
+    func installsIntoEmpty() throws {
+        let merged = try #require(ClaudeHookInstaller.settingsInstallingPing(into: [:]))
+        let hooks = try #require(merged["hooks"] as? [String: Any])
+        for event in ClaudeHookInstaller.events {
+            let groups = try #require(hooks[event] as? [[String: Any]], "missing \(event)")
+            let commands = groups
+                .flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
+                .compactMap { $0["command"] as? String }
+            #expect(commands.contains(ClaudeHookInstaller.pingCommand))
+        }
+    }
+
+    @Test("existing hooks and unrelated settings survive the merge untouched")
+    func preservesExisting() throws {
+        let settings: [String: Any] = [
+            "model": "opus",
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "say done"]]]
+                ],
+                "PreToolUse": [
+                    ["matcher": "Bash", "hooks": [["type": "command", "command": "audit.sh"]]]
+                ]
+            ]
+        ]
+        let merged = try #require(ClaudeHookInstaller.settingsInstallingPing(into: settings))
+        #expect(merged["model"] as? String == "opus")
+        let hooks = try #require(merged["hooks"] as? [String: Any])
+        let stop = try #require(hooks["Stop"] as? [[String: Any]])
+        let stopCommands = stop
+            .flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
+            .compactMap { $0["command"] as? String }
+        #expect(stopCommands.contains("say done"))
+        #expect(stopCommands.contains(ClaudeHookInstaller.pingCommand))
+        // Unrelated event untouched.
+        let pre = try #require(hooks["PreToolUse"] as? [[String: Any]])
+        #expect(pre.count == 1)
+    }
+
+    @Test("already fully installed returns nil (idempotent)")
+    func idempotent() throws {
+        let first = try #require(ClaudeHookInstaller.settingsInstallingPing(into: [:]))
+        #expect(ClaudeHookInstaller.isInstalled(in: first))
+        #expect(ClaudeHookInstaller.settingsInstallingPing(into: first) == nil)
+    }
+
+    @Test("a partially installed settings gains only the missing events")
+    func partialInstall() throws {
+        var settings = try #require(ClaudeHookInstaller.settingsInstallingPing(into: [:]))
+        var hooks = settings["hooks"] as! [String: Any]
+        hooks["UserPromptSubmit"] = nil   // drop one event
+        settings["hooks"] = hooks
+        #expect(!ClaudeHookInstaller.isInstalled(in: settings))
+
+        let merged = try #require(ClaudeHookInstaller.settingsInstallingPing(into: settings))
+        let mergedHooks = merged["hooks"] as! [String: Any]
+        // Stop was already installed: still exactly one teebe group there.
+        let stop = mergedHooks["Stop"] as! [[String: Any]]
+        let teebeStopGroups = stop.filter {
+            (($0["hooks"] as? [[String: Any]]) ?? [])
+                .contains { ($0["command"] as? String) == ClaudeHookInstaller.pingCommand }
+        }
+        #expect(teebeStopGroups.count == 1)
+        #expect(ClaudeHookInstaller.isInstalled(in: merged))
+    }
+
+    // MARK: - File level
+
+    func tempSettingsURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("tb-hooks-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("settings.json")
+    }
+
+    @Test("install creates the settings file when missing and is idempotent on disk")
+    func installOnMissingFile() throws {
+        let url = tempSettingsURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let first = try ClaudeHookInstaller.install(at: url)
+        #expect(first == true)
+        #expect(ClaudeHookInstaller.isInstalled(at: url))
+        let second = try ClaudeHookInstaller.install(at: url)
+        #expect(second == false)   // second run: no-op
+    }
+
+    @Test("install preserves unrelated keys in an existing settings file")
+    func installPreservesFile() throws {
+        let url = tempSettingsURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try #"{"model":"opus","permissions":{"allow":["Bash(ls:*)"]}}"#
+            .write(to: url, atomically: true, encoding: .utf8)
+
+        let installed = try ClaudeHookInstaller.install(at: url)
+        #expect(installed == true)
+        let data = try Data(contentsOf: url)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["model"] as? String == "opus")
+        #expect((json["permissions"] as? [String: Any]) != nil)
+        #expect(ClaudeHookInstaller.isInstalled(in: json))
+    }
+
+    @Test("a malformed settings file throws and is left untouched")
+    func malformedFileUntouched() throws {
+        let url = tempSettingsURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let garbage = "{not json"
+        try garbage.write(to: url, atomically: true, encoding: .utf8)
+
+        #expect(throws: (any Error).self) { try ClaudeHookInstaller.install(at: url) }
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents == garbage)
+    }
+}

--- a/Tests/TeebeCoreTests/FileSystemWatcherTests.swift
+++ b/Tests/TeebeCoreTests/FileSystemWatcherTests.swift
@@ -45,6 +45,27 @@ struct FileSystemWatcherTests {
         #expect(collector.batches.count == 2)
     }
 
+    @Test("continuous events cannot starve the flush past the max coalesce interval")
+    func starvationCapped() async throws {
+        let watcher = FSEventsWatcher()
+        let collector = BatchCollector()
+        watcher.debounceInterval = 0.05
+        watcher.maxCoalesceInterval = 0.15
+        watcher.handler = { collector.add($0) }
+
+        // Fire events every 20ms — always inside the 50ms debounce window, so a
+        // pure trailing debounce would never flush until the burst ends.
+        for index in 0..<30 {
+            watcher.ingest(["/f\(index)"])
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        // The cap forces intermediate flushes mid-burst, and nothing is lost.
+        #expect(collector.batches.count >= 2)
+        #expect(collector.allPaths.count == 30)
+    }
+
     @Test("real FSEvents delivers a write within timeout")
     func realDelivery() async throws {
         let fm = FileManager.default

--- a/Tests/TeebeTests/AppSmokeTests.swift
+++ b/Tests/TeebeTests/AppSmokeTests.swift
@@ -12,3 +12,28 @@ struct AppSmokeTests {
         _ = RootView(app: app, preview: preview)
     }
 }
+
+@MainActor
+@Suite("Hook setup decision")
+struct HookSetupActionTests {
+    @Test("already installed does nothing regardless of the stored answer",
+          arguments: [nil, "accepted", "declined"] as [String?])
+    func installedIsNone(response: String?) {
+        #expect(AppModel.hookSetupAction(installed: true, response: response) == .none)
+    }
+
+    @Test("never asked and missing asks once")
+    func asksWhenFresh() {
+        #expect(AppModel.hookSetupAction(installed: false, response: nil) == .ask)
+    }
+
+    @Test("accepted but missing repairs silently")
+    func repairsWhenAccepted() {
+        #expect(AppModel.hookSetupAction(installed: false, response: "accepted") == .repair)
+    }
+
+    @Test("declined never touches the settings and never re-asks")
+    func declinedStaysDeclined() {
+        #expect(AppModel.hookSetupAction(installed: false, response: "declined") == .none)
+    }
+}

--- a/Tests/TeebeTests/Fakes.swift
+++ b/Tests/TeebeTests/Fakes.swift
@@ -132,6 +132,29 @@ final class WatcherBox {
     }
 }
 
+// MARK: - Fake agent ping (darwin notification channel)
+
+/// Records lifecycle and lets a test fire the ping by hand.
+final class FakeAgentPing: AgentPingListening, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _startCount = 0
+    private var _stopCount = 0
+    private var handler: (@Sendable () -> Void)?
+
+    var startCount: Int { lock.lock(); defer { lock.unlock() }; return _startCount }
+    var stopCount: Int { lock.lock(); defer { lock.unlock() }; return _stopCount }
+
+    func start(_ handler: @escaping @Sendable () -> Void) {
+        lock.lock(); _startCount += 1; self.handler = handler; lock.unlock()
+    }
+    func stop() { lock.lock(); _stopCount += 1; handler = nil; lock.unlock() }
+    /// Simulate a `notifyutil -p` ping from a Claude Code hook.
+    func fire() {
+        lock.lock(); let handler = handler; lock.unlock()
+        handler?()
+    }
+}
+
 // MARK: - Fake agent status
 
 /// Scriptable per-worktree agent states for tests; the closure form feeds
@@ -180,7 +203,8 @@ func makeTestEnvironment(
     makeWatcher: (@MainActor () -> FileSystemWatcher)? = nil,
     agentStatuses: (@Sendable ([String], Date) -> [String: AgentActivityState])? = nil,
     agentProjectsRootPath: String? = nil,
-    notify: (@MainActor (String, String) -> Void)? = nil
+    notify: (@MainActor (String, String) -> Void)? = nil,
+    agentPing: AgentPingListening? = nil
 ) -> AppEnvironment {
     let storeURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("tb-test-\(UUID().uuidString)")
@@ -194,6 +218,7 @@ func makeTestEnvironment(
         makeWatcher: makeWatcher ?? { FakeWatcher() },
         agentStatuses: agentStatuses ?? { _, _ in [:] },
         agentProjectsRootPath: agentProjectsRootPath,
-        notify: notify ?? { _, _ in }
+        notify: notify ?? { _, _ in },
+        makeAgentPingListener: { agentPing ?? FakeAgentPing() }
     )
 }

--- a/Tests/TeebeTests/LowPowerModeTests.swift
+++ b/Tests/TeebeTests/LowPowerModeTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+@testable import Teebe
+import TeebeCore
+import Testing
+
+/// Low-power mode: with the window occluded, every FSEvents watcher stops and the
+/// app relies on the Claude Code hook ping (darwin notification) plus a slow poll —
+/// so notifications still fire while background CPU drops to ~zero.
+@MainActor
+@Suite("Low-power mode")
+struct LowPowerModeTests {
+    let repo = Repository(path: "/repo")
+
+    struct Rig {
+        var selector: SelectorModel
+        var states: FakeAgentStates
+        var spy: NotificationSpy
+        var box: WatcherBox
+        var ping: FakeAgentPing
+    }
+
+    func makeRig() async -> Rig {
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-wt", branch: "feat/x")
+        ]
+        let states = FakeAgentStates()
+        let spy = NotificationSpy()
+        let box = WatcherBox()
+        let ping = FakeAgentPing()
+        let selector = SelectorModel(environment: makeTestEnvironment(
+            git: git,
+            makeWatcher: { box.make() },
+            agentStatuses: states.provider,
+            agentProjectsRootPath: "/fake/.claude/projects",
+            notify: spy.record,
+            agentPing: ping
+        ))
+        await selector.selectRepo(repo)
+        return Rig(selector: selector, states: states, spy: spy, box: box, ping: ping)
+    }
+
+    /// The three live watchers after a repo is selected: repo git dir, Claude
+    /// projects root, and the active worktree's tree.
+    func liveWatchers(_ box: WatcherBox) -> [FakeWatcher] {
+        [
+            box.watching(".git"),
+            box.watching("projects"),
+            box.watchers.last { $0.watchedPaths == ["/repo"] }
+        ].compactMap { $0 }
+    }
+
+    @Test("selecting a repo starts the hook ping listener; clearing stops it")
+    func pingLifecycle() async {
+        let rig = await makeRig()
+        #expect(rig.ping.startCount == 1)
+        rig.selector.clearSelection()
+        #expect(rig.ping.stopCount >= 1)
+    }
+
+    @Test("entering low power stops every file-system watcher")
+    func enteringStopsWatchers() async {
+        let rig = await makeRig()
+        let watchers = liveWatchers(rig.box)
+        #expect(watchers.count == 3)
+        #expect(watchers.allSatisfy { $0.isWatching })
+
+        await rig.selector.setLowPower(true)
+        #expect(rig.selector.isLowPower)
+        #expect(watchers.allSatisfy { !$0.isWatching })
+    }
+
+    @Test("a hook ping in low power still refreshes badges and notifies")
+    func pingRefreshesInLowPower() async throws {
+        let rig = await makeRig()
+        rig.states["/repo-wt"] = .working
+        await rig.selector.refreshAgentStates()
+        await rig.selector.setLowPower(true)
+
+        // The agent finishes while we're backgrounded; the hook pings.
+        rig.states["/repo-wt"] = .needsAttention
+        rig.ping.fire()
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(rig.selector.info(for: rig.selector.worktrees[1]).agentState == .needsAttention)
+        #expect(rig.spy.posted.count == 1)
+    }
+
+    @Test("exiting low power restarts watchers and re-derives state")
+    func exitingRestartsAndRefreshes() async {
+        let rig = await makeRig()
+        await rig.selector.setLowPower(true)
+
+        // State changed while backgrounded, with no ping delivered.
+        rig.states["/repo-wt"] = .working
+        await rig.selector.setLowPower(false)
+
+        #expect(!rig.selector.isLowPower)
+        #expect(liveWatchers(rig.box).filter(\.isWatching).count == 3)
+        #expect(rig.selector.info(for: rig.selector.worktrees[1]).agentState == .working)
+    }
+
+    @Test("setLowPower is idempotent")
+    func idempotent() async {
+        let rig = await makeRig()
+        let stopsBefore = liveWatchers(rig.box).map(\.stopCount)
+        await rig.selector.setLowPower(false)   // already off — must not churn watchers
+        #expect(liveWatchers(rig.box).map(\.stopCount) == stopsBefore)
+
+        await rig.selector.setLowPower(true)
+        let stopsAfter = liveWatchers(rig.box).map(\.stopCount)
+        await rig.selector.setLowPower(true)    // already on — no double stop
+        #expect(liveWatchers(rig.box).map(\.stopCount) == stopsAfter)
+    }
+}

--- a/Tests/TeebeTests/UserStoryTests.swift
+++ b/Tests/TeebeTests/UserStoryTests.swift
@@ -213,6 +213,33 @@ struct PersistStoryTests {
         #expect(app.selector.selectedWorktree?.path == "/repo-feature")
     }
 
+    @Test("I3b: restoring a linked worktree loads it directly — the primary is never loaded first")
+    func i3SingleLoad() async {
+        // Loading the primary and then immediately the saved worktree fires two
+        // full tree builds during the window's very first layout pass, which
+        // AppKit escalates into a constraint-loop crash at launch. Restore must
+        // be a single load.
+        let git = FakeGitClient()
+        git.worktreesResult = [
+            Worktree(path: "/repo", branch: "main", isPrimary: true),
+            Worktree(path: "/repo-feature", branch: "feature"),
+        ]
+        let box = WatcherBox()
+        let env = makeTestEnvironment(git: git, makeWatcher: { box.make() })
+        var seed = AppState()
+        seed.repositories = [PersistedRepository(path: "/repo")]
+        seed.lastSelectedRepoPath = "/repo"
+        seed.lastSelectedWorktreePath = "/repo-feature"
+        try? env.store.save(seed)
+
+        let app = AppModel(environment: env)
+        await app.bootstrap()
+        #expect(app.selector.selectedWorktree?.path == "/repo-feature")
+        // One worktree-tree watcher, on the restored worktree — none on the primary.
+        #expect(box.watchers.contains { $0.watchedPaths == ["/repo-feature"] })
+        #expect(!box.watchers.contains { $0.watchedPaths == ["/repo"] })
+    }
+
     @Test("I1: switching the selected worktree persists it durably (no quit hook needed)")
     func i1PersistSelection() async {
         let git = FakeGitClient()

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,51 @@ mv "${APP_PATH}" "${DEST}/"
 # Belt-and-suspenders: strip quarantine in case anything set it.
 xattr -dr com.apple.quarantine "${DEST}/${APP}" 2>/dev/null || true
 
+# Offer the Claude Code hook that powers low-power mode + instant notifications.
+# Only when we can actually ask (a TTY): a piped `curl | bash` install defers to
+# the in-app offer on first launch. Idempotent; a malformed settings.json is
+# left untouched.
+SETTINGS="${HOME}/.claude/settings.json"
+if [ -r /dev/tty ] && command -v python3 >/dev/null 2>&1; then
+  printf "Add the Claude Code hook for instant notifications + low-power mode? [Y/n] " > /dev/tty
+  read -r REPLY < /dev/tty || REPLY="n"
+  case "${REPLY}" in
+    [nN]*) echo "Skipped — teebe will offer it on first launch." ;;
+    *)
+      python3 - "${SETTINGS}" <<'PYEOF' \
+        || echo "note: couldn't update settings.json — teebe will offer the hook on launch"
+import json, os, sys
+path = sys.argv[1]
+CHANNEL = "dev.teebe.agent"
+CMD = "notifyutil -p " + CHANNEL
+EVENTS = ["Stop", "Notification", "UserPromptSubmit"]
+settings = {}
+if os.path.exists(path):
+    with open(path) as f:
+        settings = json.load(f)   # malformed -> raise -> file left untouched
+hooks = settings.setdefault("hooks", {})
+changed = False
+for event in EVENTS:
+    groups = hooks.setdefault(event, [])
+    if any(CHANNEL in (h.get("command") or "")
+           for g in groups for h in (g.get("hooks") or [])):
+        continue
+    groups.append({"hooks": [{"type": "command", "command": CMD}]})
+    changed = True
+if changed:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".teebe-tmp"
+    with open(tmp, "w") as f:
+        json.dump(settings, f, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+    print("✓ Claude Code hook installed")
+else:
+    print("✓ Claude Code hook already present")
+PYEOF
+      ;;
+  esac
+fi
+
 echo "Launching teebe…"
 open "${DEST}/${APP}"
 

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -12,7 +12,7 @@ LOGO="Sources/Teebe/Resources/teebe-logo.png"
 # uses to decide whether an update is newer, so it MUST increase per release —
 # CI passes the release tag (e.g. APP_VERSION=0.2.0). A static value would make
 # every release look identical and Sparkle would never offer an update.
-APP_VERSION="${APP_VERSION:-0.5.1}"
+APP_VERSION="${APP_VERSION:-0.6.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$APP_VERSION}"
 
 # Sparkle auto-update config. Override via env in CI; the public key pairs with


### PR DESCRIPTION
## What

- **FSEventsWatcher**: cap the trailing debounce (`maxCoalesceInterval`) — a continuous agent write stream could starve flushes indefinitely (frozen tree mid-burst, unbounded pending set).
- **AgentSessionScanner**: static ISO8601 formatters (were rebuilt per line); reverse per-line tail scan — a tail window opening mid-multibyte character no longer blanks the verdict to idle; `tailBytes` injectable for tests.
- **Low-power mode**: window occluded → all FSEvents watchers stop; badges/notifications ride a Claude Code hook ping (darwin channel `dev.teebe.agent` via `notifyutil`) plus a slow stall poll. Exiting refreshes everything missed.
- **ClaudeHookInstaller**: idempotent merge of the ping hook into `~/.claude/settings.json` (Stop / Notification / UserPromptSubmit); malformed files are never touched. In-app one-time offer (repairs silently if accepted); install.sh offers on TTY installs.
- **Launch-crash fix**: restoring a saved *linked* worktree used to double-load (primary, then saved) inside the window's first layout pass → AppKit constraint-loop crash (reproduced on 0.5.1). Restore is now a single load.

## Tests

217 passing (19 new: watcher starvation, UTF-8 tail boundary, hook merge, low-power lifecycle, single-load restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxZ47jAbG72bgKucH2b6Cq