### PR TITLE
Add website, GitHub and X links to the About panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ skills-lock.json
 # Local screenshots / scratch captures — never committed (assets/ is tracked).
 Screenshot*.png
 Screenshot*.jpeg
+
+# Local packaging output (the release workflow builds the real one).
+*.dmg

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -33,7 +33,7 @@ Commercial licenses are available from the copyright holder, Klein Tahiraj. They
 grant the right to use the code under terms that do not require you to
 open-source your own work.
 
-To obtain one, contact: **klein.tahiraj@gmail.com**.
+To obtain one, contact: **hello@teebe.io**.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Teebe is in active development (pre-1.0). Security fixes are applied to the
 Report privately via GitHub's [private vulnerability
 reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
 (the **Security → Report a vulnerability** tab on this repository), or email
-**klein.tahiraj@gmail.com**.
+**hello@teebe.io**.
 
 Please include:
 

--- a/Sources/Teebe/AboutPanel.swift
+++ b/Sources/Teebe/AboutPanel.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import AppKit
+
+/// Where to find the project and its author. Shown as clickable links in the
+/// About panel's credits area.
+enum ProjectLinks {
+    static let website = URL(string: "https://teebe.io")!
+    static let github = URL(string: "https://github.com/klein-t/teebe")!
+    static let x = URL(string: "https://x.com/KleinTahiraj")!
+}
+
+/// Replaces the stock "About teebe" menu item so the standard About panel carries
+/// links to the website, the GitHub repo, and the author's X account. Everything
+/// else (icon, version, copyright) still comes from `Info.plist`.
+struct AboutMenuCommand: View {
+    var body: some View {
+        Button("About \(Brand.name)") { AboutPanel.show() }
+    }
+}
+
+enum AboutPanel {
+    static func show() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.orderFrontStandardAboutPanel(options: [.credits: credits()])
+    }
+
+    /// One centered line: "teebe.io · GitHub · @KleinTahiraj", each a link.
+    static func credits() -> NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        let base: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: paragraph
+        ]
+        let result = NSMutableAttributedString()
+        let items: [(String, URL)] = [
+            ("teebe.io", ProjectLinks.website),
+            ("GitHub", ProjectLinks.github),
+            ("@KleinTahiraj", ProjectLinks.x)
+        ]
+        for (index, (title, url)) in items.enumerated() {
+            if index > 0 { result.append(NSAttributedString(string: "  ·  ", attributes: base)) }
+            var attrs = base
+            attrs[.link] = url
+            result.append(NSAttributedString(string: title, attributes: attrs))
+        }
+        return result
+    }
+}

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -49,7 +49,9 @@ struct TeebeApp: App {
         .windowResizability(.contentMinSize) // freely resizable; content scrolls inside
         .defaultSize(width: 440, height: 640)
         .commands {
-            // "Check for Updates…", "What's New", and "Keyboard Shortcuts" next to About.
+            // Custom About (adds website / GitHub / X links to the standard panel),
+            // then "Check for Updates…", "What's New", and "Keyboard Shortcuts" below it.
+            CommandGroup(replacing: .appInfo) { AboutMenuCommand() }
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
                 WhatsNewMenuCommand()


### PR DESCRIPTION
Fixes #98

- About menu now opens the standard panel with clickable links: teebe.io, GitHub, @KleinTahiraj on X.
- SECURITY.md and LICENSING.md contact address is now hello@teebe.io.
- Ignore local `*.dmg` packaging output.