### PR TITLE
Settings window with appearance picker; pinned window shows in App Exposé

### DIFF
--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -80,6 +80,11 @@ struct TeebeApp: App {
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
+
+        // Adds "Settings…" (⌘,) to the app menu.
+        Settings {
+            SettingsView(app: app)
+        }
     }
 }
 

--- a/Sources/Teebe/ViewModels/AppModel.swift
+++ b/Sources/Teebe/ViewModels/AppModel.swift
@@ -9,6 +9,8 @@ import TeebeCore
 final class AppModel {
     private(set) var repositories: [Repository] = []
     var floatOnTop: Bool { didSet { persist() } }
+    /// Light / dark override, or follow the system. Applied app-wide via `NSApp.appearance`.
+    var appearance: AppearanceMode { didSet { appearance.apply(); persist() } }
     private(set) var errorMessage: String?
 
     /// Which section the keyboard currently drives — arrows, Enter and Space act on
@@ -38,6 +40,7 @@ final class AppModel {
         self.state = environment.store.load()
         self.selector = SelectorModel(environment: environment)
         self.floatOnTop = false
+        self.appearance = .system
         // Persist whenever the selection changes, and clear any stale global error —
         // navigating to a different repo/worktree should dismiss the banner.
         self.selector.onSelectionChange = { [weak self] in
@@ -65,6 +68,7 @@ final class AppModel {
         // persist a half-built state back over what we just loaded.
         isHydrating = true
         floatOnTop = state.floatOnTop
+        appearance = AppearanceMode(rawValue: state.appearance ?? "") ?? .system
         repositories = state.repositories.map { Repository(path: $0.path) }
         selector.setRepositories(repositories)
         // Snapshot the restore targets before selecting anything: selection triggers
@@ -327,6 +331,7 @@ final class AppModel {
         guard !isHydrating else { return }
         state.repositories = repositories.map { PersistedRepository(path: $0.path) }
         state.floatOnTop = floatOnTop
+        state.appearance = appearance == .system ? nil : appearance.rawValue
         state.lastSelectedRepoPath = selector.selectedRepo?.path
         state.lastSelectedWorktreePath = selector.selectedWorktree?.path
         try? environment.store.save(state)

--- a/Sources/Teebe/Views/SettingsView.swift
+++ b/Sources/Teebe/Views/SettingsView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import AppKit
+
+/// The user's appearance choice. `system` follows macOS; the others force it.
+enum AppearanceMode: String, CaseIterable, Identifiable {
+    case system, light, dark
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+
+    /// Push the choice to every window (and future ones) at once. `NSApp` is nil
+    /// under `swift test` (no application object), so this is a no-op there.
+    @MainActor func apply() {
+        guard let app = NSApp else { return }
+        switch self {
+        case .system: app.appearance = nil
+        case .light: app.appearance = NSAppearance(named: .aqua)
+        case .dark: app.appearance = NSAppearance(named: .darkAqua)
+        }
+    }
+}
+
+/// The Settings window (⌘,). Small on purpose: only preferences that aren't
+/// already a one-click toggle in the main window live here.
+struct SettingsView: View {
+    @Bindable var app: AppModel
+
+    var body: some View {
+        Form {
+            Picker("Appearance", selection: $app.appearance) {
+                ForEach(AppearanceMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+        .formStyle(.grouped)
+        .frame(width: 360)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/Sources/Teebe/Views/WindowAccessor.swift
+++ b/Sources/Teebe/Views/WindowAccessor.swift
@@ -65,19 +65,31 @@ struct WindowController: NSViewRepresentable {
             onZoom = parent.onZoom
             if floatOnTop != parent.floatOnTop {
                 floatOnTop = parent.floatOnTop
-                window?.level = floatOnTop ? .floating : .normal
+                applyLevel()
             }
         }
 
         @objc private func zoomClicked() { onZoom?() }
+
+        private func applyLevel() {
+            window?.level = floatOnTop && !NSApp.isActive ? .floating : .normal
+        }
 
         /// One-time: bind to the window and install the live-resize observers.
         func attach(_ window: NSWindow?, parent: WindowController) {
             guard let window, self.window == nil else { return }
             self.window = window
             floatOnTop = parent.floatOnTop
-            window.level = floatOnTop ? .floating : .normal
+            applyLevel()
             parent.onResolve(window)
+            // Pinned windows only need to float while another app is in front. Keeping
+            // them at the normal level while teebe is active means App Exposé and
+            // Mission Control still list them (floating-level windows are skipped).
+            for name in [NSApplication.didBecomeActiveNotification, NSApplication.didResignActiveNotification] {
+                observers.append(NotificationCenter.default.addObserver(
+                    forName: name, object: nil, queue: .main
+                ) { [weak self] _ in self?.applyLevel() })
+            }
             // Take over the green zoom button so it grows to full height, not full screen.
             if let zoomButton = window.standardWindowButton(.zoomButton) {
                 zoomButton.target = self

--- a/Sources/TeebeCore/AppStateStore.swift
+++ b/Sources/TeebeCore/AppStateStore.swift
@@ -49,6 +49,9 @@ public struct AppState: Codable, Equatable, Sendable {
     /// the hook repaired silently), "declined" (never ask again, never touch the
     /// settings), nil (not asked yet). Optional so older state files decode.
     public var hookOfferResponse: String?
+    /// Appearance override: "light", "dark", or nil to follow the system. Optional so
+    /// older state files decode.
+    public var appearance: String?
 
     public init(
         repositories: [PersistedRepository] = [],
@@ -59,7 +62,8 @@ public struct AppState: Codable, Equatable, Sendable {
         lastSelectedWorktreePath: String? = nil,
         layoutByRepo: [String: SectionLayout]? = nil,
         lastSeenVersion: String? = nil,
-        hookOfferResponse: String? = nil
+        hookOfferResponse: String? = nil,
+        appearance: String? = nil
     ) {
         self.repositories = repositories
         self.showChangedOnly = showChangedOnly
@@ -70,6 +74,7 @@ public struct AppState: Codable, Equatable, Sendable {
         self.layoutByRepo = layoutByRepo
         self.lastSeenVersion = lastSeenVersion
         self.hookOfferResponse = hookOfferResponse
+        self.appearance = appearance
     }
 }
 

--- a/Tests/TeebeCoreTests/AppStateStoreTests.swift
+++ b/Tests/TeebeCoreTests/AppStateStoreTests.swift
@@ -19,10 +19,24 @@ struct AppStateStoreTests {
                            PersistedRepository(path: "/b")],
             showChangedOnly: true,
             floatOnTop: true,
-            lastSelectedRepoPath: "/a"
+            lastSelectedRepoPath: "/a",
+            appearance: "dark"
         )
         try store.save(state)
         #expect(store.load() == state)
+    }
+
+    @Test("state without an appearance key decodes as follow-system")
+    func appearanceDefaultsToNil() throws {
+        let (url, cleanup) = tempURL(); defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let legacy = try JSONEncoder().encode(AppState(floatOnTop: true))
+        var json = try #require(JSONSerialization.jsonObject(with: legacy) as? [String: Any])
+        json.removeValue(forKey: "appearance")
+        try JSONSerialization.data(withJSONObject: json).write(to: url)
+        let loaded = AppStateStore(url: url).load()
+        #expect(loaded.appearance == nil)
+        #expect(loaded.floatOnTop == true)
     }
 
     @Test("missing file loads default state")

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -723,4 +723,22 @@ struct PreviewModelTests {
         await model.toggle(for: node, worktreePath: dir.path)
         #expect(model.content == .text("hello preview"))
     }
+
+    @Test("appearance persists and hydrates; system is stored as absent")
+    func appearanceRoundTrip() async throws {
+        let env = makeTestEnvironment(git: FakeGitClient())
+        let app = AppModel(environment: env)
+        await app.bootstrap()
+        #expect(app.appearance == .system)
+
+        app.appearance = .dark
+        #expect(env.store.load().appearance == "dark")
+
+        let reopened = AppModel(environment: env)
+        await reopened.bootstrap()
+        #expect(reopened.appearance == .dark)
+
+        reopened.appearance = .system
+        #expect(env.store.load().appearance == nil)
+    }
 }


### PR DESCRIPTION
Fixes #102
Fixes #103

- New Settings window (⌘,) with an Appearance picker: System / Light / Dark. Applied app-wide immediately and persisted.
- Pinned (float on top) windows now float only while another app is in front. macOS excludes floating-level windows from App Exposé and Mission Control, so the window was invisible there; at normal level while teebe is active it's listed again. Behaviour while working in other apps is unchanged.