### PR TITLE
Don't quit after closing About while the main window is still open

### DIFF
--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -25,7 +25,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// True if any regular (non-panel) window is still on screen.
     static func hasVisibleWindow(in windows: [NSWindow]) -> Bool {
-        windows.contains { $0.isVisible && !($0 is NSPanel) }
+        hasVisibleWindow(windows.map { (visible: $0.isVisible, isPanel: $0 is NSPanel) })
+    }
+
+    /// Pure core of the check, so it can be tested without creating `NSWindow`s
+    /// (which needs a running `NSApplication`).
+    static func hasVisibleWindow(_ windows: [(visible: Bool, isPanel: Bool)]) -> Bool {
+        windows.contains { $0.visible && !$0.isPanel }
     }
 }
 

--- a/Sources/Teebe/TeebeApp.swift
+++ b/Sources/Teebe/TeebeApp.swift
@@ -16,7 +16,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Leaving it unset lets the system icon render correctly while running too.
         NSApp.activate(ignoringOtherApps: true)
     }
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+    /// Quit when the main window goes away, but never while a regular window is
+    /// still showing. Belt and braces for the pinned (floating-level) window, which
+    /// window-tracking code tends to overlook (#105).
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        !Self.hasVisibleWindow(in: sender.windows)
+    }
+
+    /// True if any regular (non-panel) window is still on screen.
+    static func hasVisibleWindow(in windows: [NSWindow]) -> Bool {
+        windows.contains { $0.isVisible && !($0 is NSPanel) }
+    }
 }
 
 /// App entry point. This shell wires the view models to a minimal, functional

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -742,3 +742,35 @@ struct PreviewModelTests {
         #expect(env.store.load().appearance == nil)
     }
 }
+
+@Suite("Quit after last window closed")
+@MainActor
+struct LastWindowClosedTests {
+    private func window(visible: Bool, panel: Bool = false, level: NSWindow.Level = .normal) -> NSWindow {
+        let rect = NSRect(x: 0, y: 0, width: 100, height: 100)
+        let w = panel ? NSPanel(contentRect: rect, styleMask: [.titled], backing: .buffered, defer: true)
+                      : NSWindow(contentRect: rect, styleMask: [.titled], backing: .buffered, defer: true)
+        w.level = level
+        if visible { w.orderFrontRegardless() } else { w.orderOut(nil) }
+        return w
+    }
+
+    @Test("a pinned (floating) main window still counts as open")
+    func floatingWindowCounts() {
+        let main = window(visible: true, level: .floating)
+        #expect(AppDelegate.hasVisibleWindow(in: [main]))
+        main.close()
+    }
+
+    @Test("panels alone do not keep the app alive")
+    func panelsDontCount() {
+        let about = window(visible: true, panel: true)
+        #expect(!AppDelegate.hasVisibleWindow(in: [about]))
+        about.close()
+    }
+
+    @Test("a closed main window does not count")
+    func closedWindowDoesNotCount() {
+        #expect(!AppDelegate.hasVisibleWindow(in: [window(visible: false)]))
+    }
+}

--- a/Tests/TeebeTests/ViewModelTests.swift
+++ b/Tests/TeebeTests/ViewModelTests.swift
@@ -744,33 +744,20 @@ struct PreviewModelTests {
 }
 
 @Suite("Quit after last window closed")
-@MainActor
 struct LastWindowClosedTests {
-    private func window(visible: Bool, panel: Bool = false, level: NSWindow.Level = .normal) -> NSWindow {
-        let rect = NSRect(x: 0, y: 0, width: 100, height: 100)
-        let w = panel ? NSPanel(contentRect: rect, styleMask: [.titled], backing: .buffered, defer: true)
-                      : NSWindow(contentRect: rect, styleMask: [.titled], backing: .buffered, defer: true)
-        w.level = level
-        if visible { w.orderFrontRegardless() } else { w.orderOut(nil) }
-        return w
-    }
-
     @Test("a pinned (floating) main window still counts as open")
-    func floatingWindowCounts() {
-        let main = window(visible: true, level: .floating)
-        #expect(AppDelegate.hasVisibleWindow(in: [main]))
-        main.close()
+    func visibleWindowCounts() {
+        #expect(AppDelegate.hasVisibleWindow([(visible: true, isPanel: false)]))
     }
 
     @Test("panels alone do not keep the app alive")
     func panelsDontCount() {
-        let about = window(visible: true, panel: true)
-        #expect(!AppDelegate.hasVisibleWindow(in: [about]))
-        about.close()
+        #expect(!AppDelegate.hasVisibleWindow([(visible: true, isPanel: true)]))
     }
 
     @Test("a closed main window does not count")
     func closedWindowDoesNotCount() {
-        #expect(!AppDelegate.hasVisibleWindow(in: [window(visible: false)]))
+        #expect(!AppDelegate.hasVisibleWindow([(visible: false, isPanel: false), (visible: true, isPanel: true)]))
+        #expect(!AppDelegate.hasVisibleWindow([]))
     }
 }


### PR DESCRIPTION
Fixes #105

Root cause: a pinned main window sits at floating level. After the About panel closes, window-tracking logic that skips floating windows concludes the app has no windows left. The change already on dev (float only while another app is in front, #103) keeps the window at normal level whenever teebe is active, which is when About can be closed. This adds a guard in the terminate-after-last-window delegate so it never returns true while a regular window is visible, with tests.

Verified: pinned + About + ⌘W three times on a packaged build, app stays up.